### PR TITLE
feat(governance): the dial remembers this checkout (§30.11 Q1 + Q4)

### DIFF
--- a/backend/core/ouroboros/governance/proactive_mode_store.py
+++ b/backend/core/ouroboros/governance/proactive_mode_store.py
@@ -1,0 +1,333 @@
+"""proactive_mode_store — the dial remembers this checkout. PRD §30.11 Q4.
+
+"This repository is one I let run" is a standing judgement about a
+particular working tree, and it is exactly the shape ``UserPreferenceMemory``
+already stores for other operator judgements. It does not belong in an
+environment variable, which every process inherits and no operator can see,
+and it does not belong in the branch, which would carry one person's trust
+decision to everyone who checks it out.
+
+THE WORKTREE ILLUSION
+---------------------
+``git worktree`` gives several directories one ``.git`` backend. Keying the
+dial on the git directory would make every worktree share a single position,
+so an operator running ``watch`` in a review checkout would silently loosen
+the moment a colleague set ``safe_auto`` in a feature worktree — two
+cockpits, two intentions, one clobbered file.
+
+So the key is the **working tree**, resolved by ``git rev-parse
+--show-toplevel``, which returns the worktree path rather than the common
+dir. That is worktree-correct by construction rather than by special-casing:
+there is no branch here that says "if a worktree, then…", because the
+question was asked in the coordinate system where the answer is already
+right.
+
+WHY DEGRADATION IS ALWAYS TO ``watch``
+--------------------------------------
+Every failure path here — no repository, unreadable state, read-only mount,
+a file held by a zombie — ends in ephemeral ``watch``. That is the only
+direction that is safe to be wrong in. Degrading to the *last known* dial
+would let a filesystem fault re-arm an organism the operator had stood down;
+degrading to ``safe_auto`` would let a permissions error grant autonomy.
+Failing toward "narrates, initiates nothing" costs an operator one keystroke
+and cannot cost them a mutation they did not sanction.
+
+This is the one place in the codebase that deliberately fails CLOSED rather
+than open. ``local_model_admission`` fails open because a broken probe must
+not disable Tier 2 for a session; the dial fails closed because a broken
+disk must not grant authority. The difference is which way the error points.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("Ouroboros.ProactiveModeStore")
+
+PROACTIVE_MODE_STORE_SCHEMA_VERSION: str = "proactive_mode_store.1"
+
+STATE_FILENAME = "proactive_mode.json"
+
+
+def persistence_enabled() -> bool:
+    """§30.11 Q4. Default TRUE — the dial remembers this checkout."""
+    return (os.environ.get("JARVIS_PROACTIVE_MODE_PERSIST", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def first_contact_default() -> str:
+    """§30.11 Q1. The rung with nothing persisted: ``watch``.
+
+    Deliberately NOT the same thing as :func:`proactive_mode.position`'s
+    parse fallback. "I cannot read this name" and "nobody has chosen yet"
+    are different states, and collapsing them would make an unparseable
+    string mean the operator had asked for zero-touch observation.
+
+    ``watch`` because first contact with an unfamiliar checkout is the case
+    where the organism knows least and the operator has vouched for nothing.
+    §27.4.1.1 bounds a countdown to read-only work, which makes ``explore``
+    defensible — but a repository the operator has not looked at should not
+    spend tokens before they do.
+    """
+    return (os.environ.get("JARVIS_PROACTIVE_MODE_FIRST_CONTACT", "watch")
+            or "watch").strip().lower()
+
+
+def resolve_timeout_s() -> float:
+    try:
+        raw = os.environ.get("JARVIS_PROACTIVE_MODE_RESOLVE_TIMEOUT_S", "")
+        return max(0.1, float(raw)) if raw.strip() else 3.0
+    except (TypeError, ValueError):
+        return 3.0
+
+
+@dataclass(frozen=True)
+class StoreLocation:
+    """Where this checkout's dial lives, and whether it can be written."""
+
+    worktree: Optional[Path]
+    path: Optional[Path]
+    writable: bool
+    reason: str
+
+    @property
+    def persistent(self) -> bool:
+        return self.path is not None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": PROACTIVE_MODE_STORE_SCHEMA_VERSION,
+            "worktree": str(self.worktree) if self.worktree else None,
+            "path": str(self.path) if self.path else None,
+            "writable": self.writable, "reason": self.reason,
+        }
+
+
+async def _git_toplevel(cwd: Path) -> Optional[Path]:
+    """The WORKING TREE root, or None. Async and bounded. NEVER raises.
+
+    ``--show-toplevel`` rather than ``--git-dir`` is the whole worktree fix:
+    the former is per-worktree, the latter is shared. Run as a subprocess
+    off the loop with an explicit wait bound, because a git call against a
+    dead network mount can hang for as long as the mount's own timeout.
+    """
+    proc = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git", "rev-parse", "--show-toplevel",
+            cwd=str(cwd),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        out, _ = await asyncio.wait_for(
+            proc.communicate(), timeout=resolve_timeout_s())
+    except (asyncio.TimeoutError, OSError, ValueError):
+        if proc is not None and proc.returncode is None:
+            try:
+                proc.kill()
+                await asyncio.wait_for(proc.wait(), timeout=1.0)
+            except Exception:  # noqa: BLE001
+                pass
+        return None
+    if proc.returncode != 0:
+        return None
+    text = (out or b"").decode(errors="replace").strip()
+    return Path(text) if text else None
+
+
+async def locate(cwd: Optional[Path] = None) -> StoreLocation:
+    """Where the dial should persist for the current context. NEVER raises.
+
+    Outside a tracked repository the location is non-persistent, and the
+    caller degrades to in-memory ``watch``. That is not an error state — a
+    scratch directory has no checkout to remember a judgement about.
+    """
+    if not persistence_enabled():
+        return StoreLocation(None, None, False, "persistence disabled")
+    base = Path(cwd) if cwd else Path(
+        os.environ.get("JARVIS_PROJECT_ROOT", "") or os.getcwd())
+    try:
+        # DRY: the execution root is the canonical seam for "which tree is
+        # authoritative for mutation", and the dial governs mutation. Asking
+        # a second question here would let the two disagree about which tree
+        # the operator is steering.
+        from backend.core.ouroboros.governance.autonomous_workspace import (
+            effective_execution_root,
+        )
+        base = Path(effective_execution_root(base))
+    except Exception:  # noqa: BLE001 — the seam is advisory for locating
+        pass
+    top = await _git_toplevel(base)
+    if top is None:
+        return StoreLocation(None, None, False, "not a git working tree")
+    path = top / ".jarvis" / STATE_FILENAME
+    writable, reason = await asyncio.to_thread(_probe_writable, path)
+    return StoreLocation(top, path if writable else path, writable, reason)
+
+
+def _probe_writable(path: Path) -> Any:
+    """(writable, reason). Probes by ACTING, never by inspecting.
+
+    ``os.access`` answers a question about permission bits, and the failures
+    that matter here are not permission bits: a read-only MOUNT, a full
+    disk, an immutable flag, a directory held by a zombie. The only reliable
+    test of "can I write here" is a write, so the probe creates and removes
+    a temp beside the target.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        probe = path.parent / f".{STATE_FILENAME}.{os.getpid()}.probe"
+        probe.write_text("", encoding="utf-8")
+        probe.unlink()
+        return True, "writable"
+    except PermissionError as exc:
+        return False, f"permission denied: {exc.strerror or exc}"
+    except OSError as exc:
+        return False, f"{type(exc).__name__}: {exc.strerror or exc}"
+
+
+class ProactiveModeStore:
+    """Loads and saves the dial for one working tree. Thread-safe.
+
+    Holds no dial of its own — it reads and writes a name. The controller
+    remains the only thing that decides a rung, so a store that could not
+    reach disk degrades the PERSISTENCE and never the authority.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._location: Optional[StoreLocation] = None
+        self._degraded: str = ""
+
+    async def hydrate(self, cwd: Optional[Path] = None) -> str:
+        """The rung this checkout last recorded, or the first-contact default.
+
+        Every failure path returns :func:`first_contact_default` — see the
+        module docstring for why that direction is the only safe one.
+        """
+        loc = await locate(cwd)
+        with self._lock:
+            self._location = loc
+            self._degraded = "" if loc.writable else loc.reason
+        if not loc.persistent:
+            logger.info(
+                "[ProactiveMode] no persistent dial (%s) — first-contact "
+                "default %s", loc.reason, first_contact_default())
+            return first_contact_default()
+        try:
+            data = json.loads(loc.path.read_text(encoding="utf-8"))
+            name = str((data or {}).get("position") or "").strip().lower()
+        except FileNotFoundError:
+            logger.info(
+                "[ProactiveMode] first contact with %s — starting at %s",
+                loc.worktree, first_contact_default())
+            return first_contact_default()
+        except (OSError, ValueError) as exc:
+            # Unreadable is NOT "no preference": a corrupt file means the
+            # last judgement is unknown, and an unknown judgement must not
+            # be resolved in the organism's favour.
+            logger.warning(
+                "[ProactiveMode] dial state unreadable (%s) — falling back "
+                "to %s", exc, first_contact_default())
+            return first_contact_default()
+        from backend.core.ouroboros.governance.proactive_mode import _BY_NAME
+        if name not in _BY_NAME:
+            logger.warning(
+                "[ProactiveMode] persisted rung %r is not on the ladder — "
+                "falling back to %s", name, first_contact_default())
+            return first_contact_default()
+        logger.info("[ProactiveMode] restored dial %s for %s",
+                    name, loc.worktree)
+        return name
+
+    async def remember(self, position_name: str) -> bool:
+        """Record the dial for this checkout. True when it reached disk.
+
+        A failure is logged ONCE per degradation and then held, because a
+        read-only mount does not heal between keystrokes and an operator
+        cycling the dial should not receive one warning per press.
+        """
+        with self._lock:
+            loc = self._location
+        if loc is None:
+            loc = await locate()
+            with self._lock:
+                self._location = loc
+        if not loc.persistent or not loc.writable:
+            self._note_degraded(loc.reason)
+            return False
+        payload = {
+            "schema_version": PROACTIVE_MODE_STORE_SCHEMA_VERSION,
+            "position": str(position_name),
+            "worktree": str(loc.worktree),
+        }
+        try:
+            await asyncio.to_thread(_write_atomic, loc.path, payload)
+            with self._lock:
+                self._degraded = ""
+            return True
+        except (PermissionError, OSError) as exc:
+            self._note_degraded(f"{type(exc).__name__}: {exc}")
+            return False
+
+    def _note_degraded(self, reason: str) -> None:
+        with self._lock:
+            first = self._degraded != reason
+            self._degraded = reason
+        if first:
+            logger.warning(
+                "[ProactiveMode] dial cannot persist (%s) — the position "
+                "holds for this session and will not survive a restart",
+                reason)
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            loc = self._location
+            degraded = self._degraded
+        out = loc.to_dict() if loc else {"path": None, "writable": False}
+        out["degraded"] = degraded
+        out["first_contact_default"] = first_contact_default()
+        return out
+
+
+def _write_atomic(path: Path, payload: Dict[str, Any]) -> None:
+    """Publish the dial durably. Raises for the caller to classify.
+
+    Through ``durable_io.atomic_replace`` so a crash mid-write cannot leave
+    a half-written file that the next hydrate reads as corrupt — which
+    would silently reset the operator's standing judgement to ``watch``
+    and look like the dial forgetting.
+    """
+    from backend.core.ouroboros.governance.durable_io import atomic_replace
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True),
+                   encoding="utf-8")
+    atomic_replace(tmp, path)
+
+
+_store: Optional[ProactiveModeStore] = None
+_store_lock = threading.Lock()
+
+
+def get_store() -> ProactiveModeStore:
+    global _store
+    with _store_lock:
+        if _store is None:
+            _store = ProactiveModeStore()
+        return _store
+
+
+def reset_store() -> None:
+    global _store
+    with _store_lock:
+        _store = None

--- a/tests/governance/test_proactive_mode_store.py
+++ b/tests/governance/test_proactive_mode_store.py
@@ -1,0 +1,266 @@
+"""Regression spine for dial persistence (PRD §30.11 Q1 + Q4)."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import proactive_mode_store as st
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    for k in ("JARVIS_PROACTIVE_MODE_PERSIST",
+              "JARVIS_PROACTIVE_MODE_FIRST_CONTACT", "JARVIS_PROJECT_ROOT"):
+        monkeypatch.delenv(k, raising=False)
+    st.reset_store()
+    yield
+    st.reset_store()
+
+
+def _git(*args, cwd):
+    subprocess.run(["git", *args], cwd=str(cwd), check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git("init", "-q", cwd=r)
+    _git("config", "user.email", "t@t", cwd=r)
+    _git("config", "user.name", "t", cwd=r)
+    (r / "f.txt").write_text("x", encoding="utf-8")
+    _git("add", "f.txt", cwd=r)
+    _git("commit", "-qm", "init", cwd=r)
+    return r
+
+
+# -- Q1: first contact -----------------------------------------------------
+
+
+def test_first_contact_is_watch():
+    """§30.11 Q1 — a checkout the operator has not vouched for must not
+    spend tokens before they look."""
+    assert st.first_contact_default() == "watch"
+
+
+def test_a_fresh_checkout_hydrates_to_watch(repo):
+    assert asyncio.run(st.get_store().hydrate(repo)) == "watch"
+
+
+def test_first_contact_is_not_the_parse_fallback():
+    """'I cannot read this name' and 'nobody has chosen yet' are different
+    states; collapsing them would make an unparseable string mean the
+    operator asked for zero-touch observation."""
+    from backend.core.ouroboros.governance import proactive_mode as pm
+    assert pm.position("nonsense").name == "safe_auto"
+    assert st.first_contact_default() == "watch"
+
+
+# -- Q4: per-repository persistence ---------------------------------------
+
+
+def test_the_dial_round_trips_for_a_checkout(repo):
+    async def _go():
+        s = st.get_store()
+        await s.hydrate(repo)
+        assert await s.remember("explore") is True
+        st.reset_store()
+        return await st.get_store().hydrate(repo)
+    assert asyncio.run(_go()) == "explore"
+
+
+def test_state_lives_beside_the_working_tree(repo):
+    loc = asyncio.run(st.locate(repo))
+    assert loc.worktree == repo.resolve()
+    assert loc.path == repo.resolve() / ".jarvis" / st.STATE_FILENAME
+
+
+def test_two_repositories_do_not_share_a_dial(tmp_path, repo):
+    other = tmp_path / "other"
+    other.mkdir()
+    _git("init", "-q", cwd=other)
+
+    async def _go():
+        s = st.get_store()
+        await s.hydrate(repo)
+        await s.remember("watch")
+        st.reset_store()
+        s2 = st.get_store()
+        await s2.hydrate(other)
+        await s2.remember("safe_auto")
+        st.reset_store()
+        return await st.get_store().hydrate(repo)
+    assert asyncio.run(_go()) == "watch", "a second repo clobbered the first"
+
+
+# -- the worktree illusion -------------------------------------------------
+
+
+def test_git_worktrees_keep_separate_dials(repo, tmp_path):
+    """THE worktree regression. Several directories, one .git backend —
+    keying on the git dir would make an operator running `watch` in a review
+    checkout silently loosen when a colleague set safe_auto in a feature
+    worktree."""
+    wt = tmp_path / "wt"
+    _git("worktree", "add", "-q", "-b", "feature", str(wt), cwd=repo)
+
+    main_loc = asyncio.run(st.locate(repo))
+    wt_loc = asyncio.run(st.locate(wt))
+    assert main_loc.path != wt_loc.path, "worktrees shared one dial file"
+    assert wt_loc.worktree == wt.resolve()
+
+    async def _go():
+        s = st.get_store()
+        await s.hydrate(repo)
+        await s.remember("watch")
+        st.reset_store()
+        s2 = st.get_store()
+        await s2.hydrate(wt)
+        await s2.remember("safe_auto")
+        st.reset_store()
+        return await st.get_store().hydrate(repo)
+    assert asyncio.run(_go()) == "watch", "the worktree clobbered main"
+
+
+def _code_of(fn) -> str:
+    """Executable body with the docstring stripped.
+
+    Every prose check in this suite goes through here. Four times this
+    session a raw text search matched a docstring that EXPLAINED why
+    something was not used — a substring cannot tell an explanation from a
+    use, and these modules explain themselves at length."""
+    import ast
+    import inspect
+    import textwrap
+    tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+    fn_node = tree.body[0]
+    body = (fn_node.body[1:]
+            if isinstance(fn_node.body[0], ast.Expr) else fn_node.body)
+    return "\n".join(ast.unparse(stmt) for stmt in body)
+
+
+def test_the_worktree_is_resolved_by_toplevel_not_git_dir():
+    """--show-toplevel is per-worktree; --git-dir is shared. The fix is the
+    coordinate system, not a special case."""
+    code = _code_of(st._git_toplevel)
+    assert "--show-toplevel" in code
+    assert "--git-dir" not in code
+
+
+# -- degradation always toward watch --------------------------------------
+
+
+def test_outside_a_repository_degrades_to_watch(tmp_path):
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    loc = asyncio.run(st.locate(scratch))
+    assert loc.persistent is False
+    assert asyncio.run(st.get_store().hydrate(scratch)) == "watch"
+
+
+def test_a_readonly_workspace_degrades_without_crashing(repo):
+    """A read-only mount must cost the persistence and never the loop."""
+    jarvis = repo / ".jarvis"
+    jarvis.mkdir(parents=True, exist_ok=True)
+    os.chmod(jarvis, 0o500)
+    try:
+        async def _go():
+            s = st.get_store()
+            rung = await s.hydrate(repo)
+            wrote = await s.remember("explore")
+            return rung, wrote, s.snapshot()
+        rung, wrote, snap = asyncio.run(_go())
+        assert rung == "watch"
+        assert wrote is False, "claimed a write onto a read-only tree"
+        assert snap["degraded"]
+    finally:
+        os.chmod(jarvis, 0o700)
+
+
+def test_a_corrupt_state_file_falls_back_to_watch_not_to_the_last_dial(repo):
+    """Unreadable is NOT 'no preference'. An unknown judgement must not be
+    resolved in the organism's favour."""
+    p = repo / ".jarvis" / st.STATE_FILENAME
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{not json", encoding="utf-8")
+    assert asyncio.run(st.get_store().hydrate(repo)) == "watch"
+
+
+def test_a_rung_not_on_the_ladder_falls_back_to_watch(repo):
+    p = repo / ".jarvis" / st.STATE_FILENAME
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"position": "turbo"}), encoding="utf-8")
+    assert asyncio.run(st.get_store().hydrate(repo)) == "watch"
+
+
+def test_every_failure_path_ends_at_watch():
+    """The one place in this codebase that fails CLOSED: a broken disk must
+    not grant authority."""
+    import inspect
+    src = inspect.getsource(st.ProactiveModeStore.hydrate)
+    returns = [ln for ln in src.splitlines() if "return " in ln]
+    assert returns, "hydrate has no returns"
+    for ln in returns:
+        assert "first_contact_default" in ln or "return name" in ln
+
+
+def test_repeated_failures_warn_once_not_per_keystroke(repo, caplog):
+    """An operator cycling the dial should not get one warning per press."""
+    jarvis = repo / ".jarvis"
+    jarvis.mkdir(parents=True, exist_ok=True)
+    os.chmod(jarvis, 0o500)
+    try:
+        async def _go():
+            s = st.get_store()
+            await s.hydrate(repo)
+            for _ in range(5):
+                await s.remember("explore")
+        caplog.clear()
+        asyncio.run(_go())
+        warns = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warns) <= 1
+    finally:
+        os.chmod(jarvis, 0o700)
+
+
+# -- posture ---------------------------------------------------------------
+
+
+def test_persistence_can_be_switched_off(monkeypatch, repo):
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_PERSIST", "0")
+    loc = asyncio.run(st.locate(repo))
+    assert loc.persistent is False
+
+
+def test_writability_is_probed_by_acting_not_by_inspecting():
+    """os.access answers about permission bits; the failures that matter
+    are a read-only MOUNT, a full disk, an immutable flag."""
+    code = _code_of(st._probe_writable)
+    assert "os.access" not in code
+    assert "write_text" in code and "unlink" in code
+
+
+def test_the_state_is_published_atomically():
+    import inspect
+    assert "atomic_replace" in inspect.getsource(st._write_atomic)
+
+
+def test_the_resolver_is_bounded_and_reaps_its_child():
+    """A git call against a dead network mount hangs for the mount's own
+    timeout."""
+    code = _code_of(st._git_toplevel)
+    assert "wait_for" in code and "kill()" in code
+
+
+def test_the_snapshot_is_serialisable(repo):
+    async def _go():
+        s = st.get_store()
+        await s.hydrate(repo)
+        return s.snapshot()
+    json.dumps(asyncio.run(_go()))


### PR DESCRIPTION
Closes the last two open §30 decisions.

## Q1 — first contact is `watch`

A checkout the operator has not vouched for should not spend tokens before they look. §27.4.1.1 bounds a countdown to read-only work, which makes `explore` defensible — but "defensible" is not the bar for a repository nobody has examined.

Deliberately **not** the same value as `position()`'s parse fallback, which stays `safe_auto`. *"I cannot read this name"* and *"nobody has chosen yet"* are different states, and collapsing them would make an unparseable string mean the operator had asked for zero-touch observation.

## Q4 — per-repository persistence

"This repository is one I let run" is a standing judgement about a particular working tree — the same shape `UserPreferenceMemory` already stores. It does not belong in an environment variable, which every process inherits and no operator can see, nor in the branch, which would carry one person's trust decision to everyone who checks it out.

## The worktree illusion

`git worktree` gives several directories one `.git` backend. Keying the dial on the git dir would make an operator running `watch` in a review checkout **silently loosen** the moment a colleague set `safe_auto` in a feature worktree — two cockpits, two intentions, one clobbered file.

The key is the **working tree**, resolved by `git rev-parse --show-toplevel`, which is per-worktree where `--git-dir` is shared. Correct by construction rather than by special-casing: there is no `if a worktree, then…` branch, because the question is asked in the coordinate system where the answer is already right.

Pinned by a test that creates a real worktree and proves the two dials do not collide.

## Every failure path ends at `watch`

No repository, unreadable state, a rung not on the ladder, a read-only mount, a file held by a zombie — all degrade to ephemeral `watch`.

The direction is the whole design. Degrading to the *last known* dial would let a filesystem fault re-arm an organism the operator had stood down; degrading to `safe_auto` would let a permissions error grant autonomy.

**This is the one place in the codebase that deliberately fails CLOSED.** `local_model_admission` fails open because a broken probe must not disable Tier 2 for a session; the dial fails closed because a broken disk must not grant authority. The difference is which way the error points. Pinned by a test asserting every `return` in `hydrate()` lands on the first-contact default.

## Filesystem nuances

**Writability is probed by acting, not inspecting.** `os.access` answers about permission bits, and the failures that matter are not permission bits: a read-only mount, a full disk, an immutable flag, a directory held by a zombie. The only reliable test of "can I write here" is a write.

**Degradation warns once per distinct reason**, not per keystroke — a read-only mount does not heal between presses, and an operator cycling the dial should not receive five warnings.

**Published through `durable_io.atomic_replace`** so a crash mid-write cannot leave a file the next hydrate reads as corrupt, silently resetting the operator's standing judgement and looking like the dial forgetting.

## DRY

Locating reuses `autonomous_workspace.effective_execution_root` — the canonical seam for which tree is authoritative for mutation, and the dial governs mutation, so asking a second question would let the two disagree about which tree the operator is steering. No new filesystem traversal.

**19 tests; 120 across the mode, store and reach spines.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists the proactive-mode dial per Git working tree and changes first-contact behavior to start at watch. Previously the dial wasn’t persisted and parse fallback implied safe_auto; now fresh checkouts start at watch, and invalid names still fall back to safe_auto.

- Stores the dial at <worktree>/.jarvis/proactive_mode.json, keyed by the working tree resolved via git rev-parse --show-toplevel (not the shared .git dir), so Git worktrees keep separate dials.
- On any failure (no repo, unreadable/corrupt state, unknown rung, read-only or full disk), hydrates to watch and logs a single degradation warning per distinct reason.
- Writes are atomic via `durable_io.atomic_replace`; writability is probed by attempting a write, not `os.access`.
- Location derivation reuses `autonomous_workspace.effective_execution_root`; the store is thread-safe and only persists a position name (authority remains with the controller).
- Controls: set `JARVIS_PROACTIVE_MODE_PERSIST=0` to disable persistence; set `JARVIS_PROACTIVE_MODE_FIRST_CONTACT` to change the first-contact default; optional `JARVIS_PROJECT_ROOT` for resolution.
- Tests pin worktree isolation, closed-on-failure hydration to watch, bounded Git resolution, atomic publishing, and single-warning behavior.

<sup>Written for commit 9f7c10ddbd91fa06f78a2ebb188196fab206b3ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

