### PR TITLE
feat(governance): /why — the causal account, bound at the boot seam and actually typeable

### DIFF
--- a/backend/core/ouroboros/battle_test/repl_completion.py
+++ b/backend/core/ouroboros/battle_test/repl_completion.py
@@ -2326,6 +2326,33 @@ def unified_registry(repl_instance: object = None) -> VerbRegistry:
                 arg_spec=base.arg_spec or d.arg_spec,
                 category=d.category if d.handler_method else base.category,
             )
+        # Third source: the naming cage. A `governance/<verb>_repl.py` module
+        # exporting `__verb_help__` + `dispatch_<verb>_command` IS the verb
+        # `/<verb>`, and SerpentREPL routes it without a `_handle_*` method —
+        # so neither source above can see it, and the palette would deny a
+        # verb the REPL accepts.
+        #
+        # Merged HERE rather than inside `discover_verbs` because this is the
+        # one place verb sources are composed, and because the kill switch
+        # above must restore the legacy split completely. Lowest precedence:
+        # a hand-written branch that also carries doc-tags keeps its richer
+        # metadata; the cage only fills what nothing else claims.
+        try:
+            from backend.core.ouroboros.governance.repl_verb_cage import (
+                discover as _cage_discover,
+            )
+            for _mv in _cage_discover():
+                if _mv.slash_form in merged:
+                    continue
+                merged[_mv.slash_form] = VerbDescriptor(
+                    slash_form=_mv.slash_form,
+                    handler_method=_mv.dispatch_name,
+                    description=_mv.description,
+                )
+        except Exception:  # noqa: BLE001 — palette degrades, never fails
+            logger.debug("[Completion] verb cage merge skipped",
+                         exc_info=True)
+
         return VerbRegistry(
             verbs=tuple(sorted(merged.values(), key=lambda v: v.slash_form))
         )

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6447,6 +6447,36 @@ class SerpentREPL:
                 )
                 return True
 
+        # Naming cage — a `governance/<verb>_repl.py` module that exports
+        # `__verb_help__` and `dispatch_<verb>_command` IS the verb `/<verb>`.
+        #
+        # Placed AFTER the explicit ladder above and BEFORE the unknown-verb
+        # handler below: every hand-written branch keeps priority and its
+        # behaviour is byte-identical, and only lines that would otherwise
+        # fall through to "did you mean…" reach the cage.
+        #
+        # This is what closes the unmounted-verb class. `/reach` and `/why`
+        # shipped importable, tested and untypeable, because nothing asserted
+        # that a human could reach them — and the next one would have too,
+        # since the ladder makes mounting a thing you must REMEMBER. Here the
+        # filesystem is the registration.
+        if line.startswith("/"):
+            try:
+                from backend.core.ouroboros.governance.repl_verb_cage import (  # noqa: E501
+                    dispatch as _cage_dispatch,
+                )
+                _cage_result = _cage_dispatch(line)
+            except Exception:  # noqa: BLE001 — never break the REPL on a verb
+                _cage_result = None
+            # `None` means "no module claims this" and MUST fall through to
+            # the typo handler; a result that merely answered "no" must not.
+            if _cage_result is not None:
+                self._flow.console.print(
+                    getattr(_cage_result, "text", str(_cage_result)),
+                    highlight=False,
+                )
+                return True
+
         # §41.3 Slice 2 #18 — typo suggestion on
         # unknown slash verbs. Lines starting with
         # `/` that didn't match any handler get a

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1433,6 +1433,12 @@ class GovernedLoopService:
 
         # Concurrency & dedup
         self._active_ops: Set[str] = set()
+        # PRD §27.5: the reader `start()` lends to `why_engine`, held so
+        # teardown can take back exactly what this instance gave — see
+        # `_release_why_live_source`. Assigned here, before `start()`, so a
+        # `/why` racing a failed boot finds an attribute rather than a
+        # traceback.
+        self._why_live_reader: Optional[Callable[[], Dict[str, Any]]] = None
         self._active_file_ops: Set[str] = set()  # canonical file paths currently in-flight
         self._completed_ops: Dict[str, OperationResult] = {}
         # Cooperative cancellation: op_ids requested for cancel via REPL /cancel
@@ -2873,7 +2879,11 @@ class GovernedLoopService:
                     exc_info=True,
                 )
 
-        # Detach from stack
+        # Detach from stack. `/why` released LAST, after the drain above:
+        # while ops are still finishing they genuinely are in flight, and
+        # unbinding early would make `/why` claim disk-only about work that
+        # is still running.
+        self._release_why_live_source()
         self._detach_from_stack()
         self._state = ServiceState.INACTIVE
         logger.info("[GovernedLoop] Stopped")
@@ -6690,6 +6700,44 @@ class GovernedLoopService:
                     "[GLS] proactive-mode sink registration skipped",
                     exc_info=True,
                 )
+
+            # PRD §27.5: bind the in-flight op registry for `/why`.
+            #
+            # An operator asks about the op they are WATCHING, which is by
+            # definition the one least likely to have reached disk. Without
+            # this binding `/why o-12` answers "not found" for the thing on
+            # screen — useless at exactly the moment it is most wanted.
+            #
+            # Injected, not imported: `why_engine` is a read-only projection
+            # over the transcript, and a projection that reached into this
+            # service for `_active_ops` would invert the same authority
+            # boundary the sink above is placed to preserve. The engine holds
+            # no registry and constructs nothing; it is handed a reader and
+            # gives it back at teardown.
+            #
+            # `weak_live_source` holds this service WEAKLY. A GLS that is
+            # replaced or crashes without reaching `stop()` would otherwise
+            # stay alive inside a closure here and keep answering `/why` from
+            # its frozen final state — a dangling pointer that reports live
+            # data about a service that has stopped. Weak + explicit unbind
+            # in `stop()`/`_teardown_partial()`: the unbind covers the clean
+            # path immediately, the weakref covers the crash path without
+            # waiting on anyone to remember.
+            try:
+                from backend.core.ouroboros.governance.why_engine import (  # noqa: PLC0415
+                    set_live_source as _why_set_live,
+                    weak_live_source as _why_weak,
+                )
+                # Held so teardown can release BY IDENTITY. Releasing by
+                # `set_live_source(None)` would let a stopping instance
+                # unbind its own successor during an overlapping restart.
+                self._why_live_reader = _why_weak(self, "_active_ops")
+                _why_set_live(self._why_live_reader)
+                logger.debug("[GLS] /why live source bound (weak)")
+            except Exception:  # noqa: BLE001 — `/why` degrades to disk-only
+                logger.debug(
+                    "[GLS] /why live-source binding skipped", exc_info=True)
+
             # Dynamic Fleet Registry Service Discovery: lanes TRACK the mesh.
             # While sovereign endpoints serve, the worker count locks to the
             # node count (one GPU = one lane; an N-node fleet = N lanes);
@@ -7281,6 +7329,35 @@ class GovernedLoopService:
         # StrategicDirection holder on the orchestrator.
         self._stack.governed_loop_service = self
 
+    def _release_why_live_source(self) -> None:
+        """Take back the `/why` live reader this instance lent out. §27.5.
+
+        Called on BOTH teardown paths — clean `stop()` and the partial
+        teardown a failed boot runs — because a boot that dies after the
+        binding and before the loop is exactly the case where a stale reader
+        would answer `/why` with in-flight state for a service that never
+        ran.
+
+        Released by IDENTITY, so an instance that is stopping while its
+        replacement has already bound leaves the successor's binding intact.
+        Never raises: teardown must not fail on a diagnostic surface.
+        """
+        reader = getattr(self, "_why_live_reader", None)
+        if reader is None:
+            return
+        self._why_live_reader = None
+        try:
+            from backend.core.ouroboros.governance.why_engine import (  # noqa: PLC0415
+                release_live_source as _why_release,
+            )
+            if not _why_release(reader):
+                logger.debug(
+                    "[GLS] /why live source already rebound by a successor "
+                    "— leaving it in place")
+        except Exception:  # noqa: BLE001
+            logger.debug("[GLS] /why live-source release skipped",
+                         exc_info=True)
+
     def _detach_from_stack(self) -> None:
         """Detach governed loop components from GovernanceStack."""
         if self._stack is None:
@@ -7526,6 +7603,7 @@ class GovernedLoopService:
         self._orchestrator = None
         self._generator = None
         self._approval_provider = None
+        self._release_why_live_source()
         self._detach_from_stack()
 
     # ------------------------------------------------------------------

--- a/backend/core/ouroboros/governance/reach_repl.py
+++ b/backend/core/ouroboros/governance/reach_repl.py
@@ -49,7 +49,11 @@ logger = logging.getLogger("Ouroboros.ReachRepl")
 REACH_REPL_SCHEMA_VERSION: str = "reach_repl.1"
 
 __verb_help__ = {
-    "reach": "which surfaces can reach a module — the unmounted-feature audit",
+    # Leads with a verb, not "which": the palette's description arbiter
+    # classifies a fragment head as RESIDUE, and a residue row loses to any
+    # mined candidate — so the shipped prose would have been replaced by a
+    # scrape of this module's own subcommand names.
+    "reach": "audit module reachability — find features nothing can call",
 }
 
 _HELP = (

--- a/backend/core/ouroboros/governance/repl_verb_cage.py
+++ b/backend/core/ouroboros/governance/repl_verb_cage.py
@@ -1,0 +1,258 @@
+"""repl_verb_cage — a ``*_repl`` module IS its verb, structurally.
+
+THE DEFECT THIS CLOSES
+----------------------
+Slash verbs were mounted by hand: a module exported ``dispatch_x_command``,
+and somebody remembered to add an ``if line.startswith("/x")`` branch to the
+REPL. Five governance modules honour the ``*_repl`` contract; three had a
+branch. ``/reach`` and ``/why`` were importable, tested, documented — and
+untypeable. Their own docstrings claimed they were "auto-discovered through
+the naming cage", which described a mechanism that did not exist.
+
+That is the unmounted-feature class in its purest form, and the reason it
+survives review is that every test passes: the dispatcher is correct, the
+renderer is correct, and nothing anywhere asserts that a human can reach
+them. So the fix is not another branch. It is to make the mount structural,
+so that shipping an unmounted verb stops being possible.
+
+THE CONTRACT
+------------
+A module ``governance/<verb>_repl.py`` claims ``/<verb>`` by exporting BOTH:
+
+* ``__verb_help__`` — a dict-literal ``{verb: one-line description}``
+* ``dispatch_<verb>_command(line) -> result`` with ``.text`` / ``.ok``
+
+Both, because either alone is ambiguous: a dispatcher with no help is a
+verb nobody can discover, and help with no dispatcher is a promise with no
+mechanism. The module name is the verb — there is no mapping table to drift
+out of step with the filesystem, and renaming the file renames the verb.
+
+DISCOVERY READS SOURCE, NOT MODULES
+-----------------------------------
+The scan is ``ast`` over the package directory: ~0.16s for 68 candidates and
+**zero imports**, against ~0.47s and 68 import side effects for the obvious
+alternative. Descriptions come from ``ast.literal_eval`` of the dict literal,
+so the palette is fully populated before a single module is loaded.
+
+Dispatch then imports exactly ONE module — the one whose name matches what
+the operator typed. A verb nobody uses costs nothing.
+
+ORDERING IS DELIBERATE
+----------------------
+The cage runs AFTER the REPL's explicit ladder and BEFORE its unknown-verb
+handler. Verbs with a hand-written branch keep byte-identical behaviour;
+only lines that currently fall through reach the cage. Mounting cannot
+change what already works.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import ast
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.ReplVerbCage")
+
+REPL_VERB_CAGE_SCHEMA_VERSION: str = "repl_verb_cage.1"
+
+_SUFFIX = "_repl"
+
+
+def cage_enabled() -> bool:
+    """Master switch. Default TRUE — an unmounted verb is the defect."""
+    return (os.environ.get("JARVIS_REPL_VERB_CAGE_ENABLED", "true")
+            or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+@dataclass(frozen=True)
+class ModuleVerb:
+    """One verb a module claims by name."""
+
+    verb: str
+    module: str
+    description: str
+
+    @property
+    def slash_form(self) -> str:
+        return f"/{self.verb}"
+
+    @property
+    def dispatch_name(self) -> str:
+        return f"dispatch_{self.verb}_command"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"verb": self.verb, "module": self.module,
+                "description": self.description,
+                "slash_form": self.slash_form}
+
+
+_cache: Optional[Tuple[ModuleVerb, ...]] = None
+_cache_lock = threading.Lock()
+
+
+def _package_dir() -> Optional[Path]:
+    """This package's directory, without importing its members."""
+    try:
+        return Path(__file__).resolve().parent
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _read_declaration(path: Path, verb: str) -> Optional[str]:
+    """The description this file declares for ``verb``, or None.
+
+    Returns None unless the module honours BOTH halves of the contract.
+    Parsing rather than importing: discovery must never run a module's
+    top-level code, or a broken verb takes the whole palette down with it.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError, ValueError):
+        return None
+
+    help_map: Optional[Dict[str, Any]] = None
+    has_dispatch = False
+    want = f"dispatch_{verb}_command"
+
+    # Module level only. A nested `__verb_help__` or a dispatch defined
+    # inside a function is not an export, and treating it as one would
+    # advertise a verb that `getattr` cannot then find.
+    for stmt in tree.body:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if stmt.name == want:
+                has_dispatch = True
+        elif isinstance(stmt, ast.Assign):
+            if not any(getattr(t, "id", None) == "__verb_help__"
+                       for t in stmt.targets):
+                continue
+            try:
+                value = ast.literal_eval(stmt.value)
+            except (ValueError, SyntaxError, TypeError):
+                continue
+            if isinstance(value, dict):
+                help_map = value
+
+    if not has_dispatch or not help_map:
+        return None
+    text = help_map.get(verb)
+    return str(text) if isinstance(text, str) and text.strip() else ""
+
+
+def discover(*, force: bool = False) -> Tuple[ModuleVerb, ...]:
+    """Every verb the package claims by name. Cached. NEVER raises.
+
+    The result is a fact about the filesystem, and the filesystem does not
+    change under a running REPL, so it is computed once. ``force`` exists
+    for tests, which do move files.
+    """
+    global _cache
+    if not cage_enabled():
+        return ()
+    with _cache_lock:
+        if _cache is not None and not force:
+            return _cache
+    found: list = []
+    root = _package_dir()
+    if root is not None:
+        try:
+            candidates = sorted(root.glob(f"*{_SUFFIX}.py"))
+        except OSError:
+            candidates = []
+        for path in candidates:
+            verb = path.stem[: -len(_SUFFIX)]
+            if not verb or verb.startswith("_"):
+                continue
+            description = _read_declaration(path, verb)
+            if description is None:
+                continue
+            found.append(ModuleVerb(
+                verb=verb,
+                module=f"{__package__}.{path.stem}",
+                description=description,
+            ))
+    result = tuple(found)
+    with _cache_lock:
+        _cache = result
+    logger.debug("[VerbCage] %d module verbs: %s",
+                 len(result), ", ".join(v.slash_form for v in result))
+    return result
+
+
+def reset_cache() -> None:
+    global _cache
+    with _cache_lock:
+        _cache = None
+
+
+def find(line: str) -> Optional[ModuleVerb]:
+    """The verb a typed line claims, or None. NEVER raises."""
+    try:
+        word = (line or "").strip().split(None, 1)[0]
+    except IndexError:
+        return None
+    if not word.startswith("/"):
+        return None
+    name = word[1:].strip().lower()
+    if not name:
+        return None
+    return next((v for v in discover() if v.verb == name), None)
+
+
+def dispatch(line: str) -> Optional[Any]:
+    """Route a typed line to its module. ``None`` means "not mine".
+
+    ``None`` and a falsy result are deliberately different: the caller must
+    be able to fall through to its unknown-verb handler without swallowing a
+    verb that ran and legitimately answered "no".
+
+    Imports exactly the one module the operator named, at the moment they
+    name it. An import failure returns a REFUSAL rather than None, because
+    ``/why`` existing-but-broken and ``/why`` not existing call for different
+    operator responses, and collapsing them into "did you mean…" hides a bug.
+    """
+    spec = find(line)
+    if spec is None:
+        return None
+    try:
+        import importlib
+
+        module = importlib.import_module(spec.module)
+        handler = getattr(module, spec.dispatch_name, None)
+        if not callable(handler):
+            # Discovery proved the source declares it, so absence here means
+            # the module rebinds or deletes it at import — worth saying out
+            # loud rather than silently degrading to "unknown verb".
+            return _Refusal(
+                f"{spec.slash_form} is declared by {spec.module} but "
+                f"{spec.dispatch_name} is not callable at runtime")
+        return handler(line)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[VerbCage] %s dispatch failed", spec.slash_form,
+                     exc_info=True)
+        return _Refusal(
+            f"{spec.slash_form} failed to load ({type(exc).__name__}: {exc})")
+
+
+@dataclass(frozen=True)
+class _Refusal:
+    """A mounted verb that could not run — never a silent fall-through."""
+
+    text: str
+    ok: bool = False
+    matched: bool = True
+
+
+__all__ = [
+    "REPL_VERB_CAGE_SCHEMA_VERSION",
+    "ModuleVerb",
+    "cage_enabled",
+    "discover",
+    "dispatch",
+    "find",
+    "reset_cache",
+]

--- a/backend/core/ouroboros/governance/why_engine.py
+++ b/backend/core/ouroboros/governance/why_engine.py
@@ -1,0 +1,435 @@
+"""why_engine — the causal account, as a projection. PRD §27.5.
+
+For a proactive organism, *"why did you do that"* is the primary human
+question. In Claude Code it never arises, because the human asked. Here the
+organism acts on its own initiative, and without an answer every proactive
+act is trusted blindly or refused blindly — **neither of which teaches
+anybody anything**, not the operator and not the preference memory.
+
+FOUR BANDS, NOT A DUMP
+----------------------
+An explanation that is a JSON blob is an explanation nobody reads. The
+answer has a fixed shape, and it is the shape of the decision itself::
+
+    TRIGGER   what woke the organism        (sensor, signal, or a parent op)
+    CONTEXT   what it knew when it decided  (recall, index, narrative)
+    LOGIC     how it reasoned               (plan, tool rounds, gate verdicts)
+    ACTION    what it did                   (apply, verify, commit)
+
+Fixed order, always all four, each stating *unknown* rather than being
+omitted. A band that vanished when empty would make "it had no context" and
+"we did not record the context" render identically, and those are different
+answers to the operator's question.
+
+DETERMINISTIC, AND FREE
+-----------------------
+Every value is read from the spine and its timeline projection. **No model
+call.** Two properties follow, and both are requirements rather than
+optimisations:
+
+* it answers when every provider lane is dry — which is precisely the state
+  in which an operator most wants to ask;
+* it cannot hallucinate a rationale, because it is a projection of the
+  ledger rather than a generation from it.
+
+Model-authored prose may decorate this later. It may never be the mechanism.
+
+THIS MODULE PARSES NOTHING
+--------------------------
+``transcript_spine`` owns records and eviction. ``transcript_timeline`` owns
+the apply/verify/commit fold. ``transcript_log`` owns frame recovery and
+already reports *where* a log stops via typed ``stop_reason`` / ``stop_frame``.
+This module joins those three and adds no fourth reader — a second parser
+would be a second opinion about the same bytes.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.WhyEngine")
+
+WHY_ENGINE_SCHEMA_VERSION: str = "why_engine.1"
+
+
+def _env_int(name: str, default: int, minimum: int = 1) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def max_lineage_depth() -> int:
+    """How far back a single ``/why`` walks. Default 1 — one hop.
+
+    §27.5.5's decision: steering acts must stay cheap to READ. An
+    explanation that unrolled an eight-deep ancestry into the terminal on
+    every query would be skipped, and a skipped explanation is worse than a
+    short one because it looks like it was offered.
+
+    ``/why <ref> --full`` raises this; the drill-down path is the default.
+    """
+    return _env_int("JARVIS_WHY_LINEAGE_DEPTH", 1)
+
+
+def max_band_items() -> int:
+    """Items rendered per band before the tail is summarised."""
+    return _env_int("JARVIS_WHY_BAND_ITEMS", 5)
+
+
+class Certainty(str, enum.Enum):
+    """How well a band is known. The distinction the operator needs.
+
+    ``OBSERVED``  read from a surviving record.
+    ``TOMBSTONE`` the record existed and was evicted — the spine says so.
+    ``UNKNOWN``   never recorded, or the log ends before it.
+
+    Collapsing TOMBSTONE into UNKNOWN would tell an operator "we don't know"
+    about something the system *did* know and then discarded on a retention
+    policy they can change. Those call for different actions.
+    """
+
+    OBSERVED = "observed"
+    TOMBSTONE = "tombstone"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class Band:
+    """One of the four causal bands."""
+
+    name: str
+    certainty: Certainty
+    items: Tuple[str, ...] = ()
+    detail: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"name": self.name, "certainty": self.certainty.value,
+                "items": list(self.items), "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class Explanation:
+    """One op's causal account, ready to render."""
+
+    ref: str
+    op_id: str
+    bands: Tuple[Band, ...]
+    #: Ancestors, nearest first. Empty when this op is a root.
+    lineage: Tuple[str, ...] = ()
+    lineage_truncated: bool = False
+    #: True when the answer includes live in-memory state, not only disk.
+    in_flight: bool = False
+    #: Where the durable log stops, when it stops early. From
+    #: ``transcript_log.recover_log``'s typed reason — never re-derived.
+    loss_point: str = ""
+    partial: bool = False
+    schema_version: str = WHY_ENGINE_SCHEMA_VERSION
+
+    def band(self, name: str) -> Optional[Band]:
+        return next((b for b in self.bands if b.name == name), None)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version, "ref": self.ref,
+            "op_id": self.op_id, "bands": [b.to_dict() for b in self.bands],
+            "lineage": list(self.lineage),
+            "lineage_truncated": self.lineage_truncated,
+            "in_flight": self.in_flight, "loss_point": self.loss_point,
+            "partial": self.partial,
+        }
+
+
+BAND_ORDER: Tuple[str, ...] = ("trigger", "context", "logic", "action")
+
+
+class RefNotFound(LookupError):
+    """The ref resolves nowhere — on disk or in flight."""
+
+
+def _spine() -> Optional[Any]:
+    try:
+        from backend.core.ouroboros.battle_test.transcript_spine import (
+            get_default_spine,
+        )
+        return get_default_spine()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _live_ops() -> Dict[str, Any]:
+    """Ops currently executing, from the in-memory registry.
+
+    THE IN-FLIGHT RACE. An operator asks about the thing they are watching,
+    which is by definition the thing least likely to have reached disk. A
+    ``/why`` that answered "not found" for the op on screen would be useless
+    at exactly the moment it is most wanted.
+
+    Injected rather than imported: the live registry belongs to
+    ``GovernedLoopService``, and reaching into the orchestrator from a
+    read-only projection would invert the authority boundary — the same
+    reason ``proactive_mode`` takes its pool through a sink.
+    """
+    try:
+        return dict(_LIVE_SOURCE() or {}) if _LIVE_SOURCE else {}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+_LIVE_SOURCE: Optional[Callable[[], Dict[str, Any]]] = None
+
+
+def set_live_source(source: Optional[Callable[[], Dict[str, Any]]]) -> None:
+    """Register the in-flight op registry. NEVER raises.
+
+    Absent, ``/why`` answers from disk alone and says so — a degraded answer
+    that names its own limit, rather than a confident one that is missing
+    the live half.
+    """
+    global _LIVE_SOURCE
+    _LIVE_SOURCE = source
+
+
+def _resolve_ref(ref: str) -> Tuple[str, Optional[Any], bool]:
+    """``(op_id, record, in_flight)``. Raises :class:`RefNotFound`.
+
+    Accepts either a spine ref (``o-12``, ``d-7``, ``m-3``) or a bare
+    ``op_id``, because an operator reading a log has the op id and an
+    operator reading the deck has the ref, and demanding they know which is
+    which would be the interface asking the human to do a lookup.
+    """
+    token = str(ref or "").strip()
+    if not token:
+        raise RefNotFound("no reference given")
+    spine = _spine()
+    rec = None
+    if spine is not None:
+        try:
+            rec = spine.resolve(token)
+        except Exception:  # noqa: BLE001
+            rec = None
+    if rec is not None:
+        return str(getattr(rec, "op_id", "") or token), rec, False
+
+    live = _live_ops()
+    if token in live:
+        return token, None, True
+    # A ref the spine has EVICTED is not "not found" — see band tombstones.
+    if spine is not None:
+        try:
+            if spine.was_evicted(token):
+                return token, None, False
+        except Exception:  # noqa: BLE001
+            pass
+    # Last chance: the token may be an op_id whose records survive.
+    if spine is not None:
+        try:
+            for r in spine.page(limit=None):
+                if str(getattr(r, "op_id", "")) == token:
+                    return token, r, False
+        except Exception:  # noqa: BLE001
+            pass
+    raise RefNotFound(
+        f"{token!r} resolves to nothing on disk or in flight — it may have "
+        f"been evicted beyond the spine's retention")
+
+
+def _loss_point() -> str:
+    """Where the durable transcript stops, if it stops early.
+
+    Reads ``recover_log``'s TYPED stop reason rather than inferring one.
+    That function already returns the longest valid prefix plus
+    ``stop_reason`` and ``stop_frame``, which is the whole corrupted-lineage
+    requirement: the log says where it ends, so this reports rather than
+    guesses.
+    """
+    try:
+        from pathlib import Path
+
+        from backend.core.ouroboros.battle_test.transcript_log import (
+            recover_log,
+        )
+        session = os.environ.get("JARVIS_OUROBOROS_SESSION_DIR", "")
+        if not session:
+            return ""
+        result = recover_log(Path(session) / "transcript.log")
+        if getattr(result, "clean", True):
+            return ""
+        reason = getattr(getattr(result, "stop_reason", None), "value",
+                         str(getattr(result, "stop_reason", "")))
+        frame = getattr(result, "stop_frame", 0)
+        trailing = getattr(result, "trailing_bytes", 0)
+        return (f"transcript ends at frame {frame} ({reason}); "
+                f"{trailing} byte(s) beyond are unreadable")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _band_from(name: str, items: List[str], evicted: bool,
+               detail: str = "") -> Band:
+    """Build a band, choosing the certainty the evidence supports."""
+    if items:
+        return Band(name, Certainty.OBSERVED, tuple(items[:max_band_items()]),
+                    detail)
+    if evicted:
+        return Band(name, Certainty.TOMBSTONE, (),
+                    detail or "records existed and were evicted by retention")
+    return Band(name, Certainty.UNKNOWN, (), detail or "never recorded")
+
+
+def _collect(op_id: str, spine: Optional[Any]) -> Dict[str, List[str]]:
+    """Records for one op, bucketed by band. Never raises."""
+    buckets: Dict[str, List[str]] = {b: [] for b in BAND_ORDER}
+    if spine is None:
+        return buckets
+    #: Which spine vocabulary answers which band. Data, not branching, so a
+    #: sixth namespace lands here rather than in four if-statements.
+    routing = {
+        "op_block": "trigger", "narrative": "context",
+        "tool_render": "logic", "diff": "action", "milestone": "action",
+    }
+    try:
+        for rec in spine.page(limit=None):
+            if str(getattr(rec, "op_id", "")) != op_id:
+                continue
+            band = routing.get(str(getattr(rec, "kind", "")), "logic")
+            ref = str(getattr(rec, "ref", ""))
+            payload = getattr(rec, "payload", None)
+            label = ref
+            if isinstance(payload, dict):
+                for key in ("summary", "kind", "title", "reason", "text"):
+                    val = payload.get(key)
+                    if isinstance(val, str) and val.strip():
+                        label = f"{ref}  {val.strip()[:72]}"
+                        break
+            buckets[band].append(label)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Why] spine walk degraded", exc_info=True)
+    return buckets
+
+
+def _lineage(op_id: str, live: Dict[str, Any], depth: int) -> Tuple[
+        Tuple[str, ...], bool]:
+    """Ancestors nearest-first, bounded. ``(lineage, truncated)``.
+
+    THE CHAIN REACTION. A background loop can produce A→B→C→D, and an
+    operator asking about D wants to reach A. Rendering the whole ancestry
+    on every query would flood the terminal, so the default is ONE hop with
+    the next ancestor named — the drill-down is the operator following it,
+    not the tool deciding for them.
+
+    A cycle is possible if an op-id were ever reused, so the walk carries a
+    seen-set. It terminates on depth, on a root, or on a repeat.
+    """
+    out: List[str] = []
+    seen = {op_id}
+    cursor = op_id
+    truncated = False
+    for _ in range(max(0, depth) + 1):
+        parent = _parent_of(cursor, live)
+        if not parent or parent in seen:
+            break
+        if len(out) >= depth:
+            truncated = True
+            break
+        out.append(parent)
+        seen.add(parent)
+        cursor = parent
+    return tuple(out), truncated
+
+
+def _parent_of(op_id: str, live: Dict[str, Any]) -> str:
+    """The op that caused this one, or "". Never raises."""
+    entry = live.get(op_id)
+    if isinstance(entry, dict):
+        val = entry.get("parent_op_id")
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    spine = _spine()
+    if spine is None:
+        return ""
+    try:
+        for rec in spine.page(limit=None):
+            if str(getattr(rec, "op_id", "")) != op_id:
+                continue
+            payload = getattr(rec, "payload", None)
+            if isinstance(payload, dict):
+                val = payload.get("parent_op_id")
+                if isinstance(val, str) and val.strip():
+                    return val.strip()
+    except Exception:  # noqa: BLE001
+        pass
+    return ""
+
+
+def explain(ref: str, *, depth: Optional[int] = None) -> Explanation:
+    """The causal account for one ref or op-id. Raises :class:`RefNotFound`.
+
+    Joins three sources and says which it used: the spine's surviving
+    records, the timeline projection's apply/verify/commit fold, and — when
+    the op is still running — the live registry.
+    """
+    op_id, _rec, in_flight = _resolve_ref(ref)
+    spine = _spine()
+    live = _live_ops()
+    in_flight = in_flight or op_id in live
+
+    buckets = _collect(op_id, spine)
+    evicted_any = False
+    if spine is not None:
+        try:
+            evicted_any = bool(getattr(spine, "evicted_count", 0)) or \
+                spine.was_evicted(str(ref))
+        except Exception:  # noqa: BLE001
+            evicted_any = False
+
+    # The ACTION band prefers the timeline projection: it is the canonical
+    # fold of apply/verify/commit, and re-deriving those from raw milestone
+    # records here would be a second opinion about the same three callbacks.
+    row = None
+    try:
+        from backend.core.ouroboros.battle_test.transcript_timeline import (
+            timeline_for_op,
+        )
+        row = timeline_for_op(op_id)
+    except Exception:  # noqa: BLE001
+        row = None
+    if row is not None:
+        summary = []
+        if getattr(row, "has_apply", False):
+            summary.append(f"applied {row.apply_files} file(s) "
+                           f"[{row.apply_mode or 'mode?'}]")
+        if getattr(row, "has_verify", False):
+            summary.append(f"verified {row.verify_passed}/{row.verify_total}"
+                           + ("" if row.verify_scoped_to_op
+                              else " (repo-wide, not this op)"))
+        if getattr(row, "commit_hash", ""):
+            summary.append(f"committed {row.commit_hash[:10]}")
+        if summary:
+            buckets["action"] = summary + buckets["action"]
+
+    if in_flight:
+        entry = live.get(op_id) or {}
+        phase = str((entry or {}).get("phase", "") or "running")
+        buckets["logic"].insert(0, f"IN FLIGHT — currently {phase}")
+
+    bands = tuple(
+        _band_from(name, buckets[name], evicted_any)
+        for name in BAND_ORDER
+    )
+    lineage, truncated = _lineage(
+        op_id, live, max_lineage_depth() if depth is None else max(0, depth))
+    return Explanation(
+        ref=str(ref), op_id=op_id, bands=bands, lineage=lineage,
+        lineage_truncated=truncated, in_flight=in_flight,
+        loss_point=_loss_point(),
+        partial=bool(getattr(row, "partial", False)) or evicted_any,
+    )

--- a/backend/core/ouroboros/governance/why_engine.py
+++ b/backend/core/ouroboros/governance/why_engine.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import enum
 import logging
 import os
+import threading
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -178,24 +179,132 @@ def _live_ops() -> Dict[str, Any]:
     read-only projection would invert the authority boundary — the same
     reason ``proactive_mode`` takes its pool through a sink.
     """
+    # ONE atomic read, bound to a local before use. Reading the global twice
+    # — once to test, once to call — is a TOCTOU: `stop()` can unbind
+    # between the two, and the second read raises NoneType. An operator
+    # spamming `/why` while the service is booting or tearing down hits that
+    # window, which is exactly when they are least able to interpret a
+    # traceback.
+    source = _LIVE_SOURCE
+    if source is None:
+        return {}
     try:
-        return dict(_LIVE_SOURCE() or {}) if _LIVE_SOURCE else {}
+        return dict(source() or {})
     except Exception:  # noqa: BLE001
+        # A dead weakref, a half-built service, a registry mid-mutation —
+        # all degrade to disk-only. `/why` says so; it never guesses.
         return {}
 
 
 _LIVE_SOURCE: Optional[Callable[[], Dict[str, Any]]] = None
+_live_lock = threading.Lock()
 
 
 def set_live_source(source: Optional[Callable[[], Dict[str, Any]]]) -> None:
-    """Register the in-flight op registry. NEVER raises.
+    """Bind the in-flight op registry, or unbind with ``None``. NEVER raises.
 
-    Absent, ``/why`` answers from disk alone and says so — a degraded answer
-    that names its own limit, rather than a confident one that is missing
-    the live half.
+    **Not a singleton.** This is a binding point, not an owner: the engine
+    holds no registry, constructs nothing, and cannot reach the service. The
+    caller injects a reader and takes it back at teardown. That is the same
+    seam ``markup_mirror``, ``set_operator_dispatcher`` and
+    ``set_prompt_publisher`` already use, and it exists precisely so a
+    read-only projection never imports the orchestrator.
+
+    **The dangling-pointer race.** A GLS that crashes and restarts would
+    otherwise leave a closure here holding the dead instance alive and
+    answering from its frozen state. Callers are expected to pass a
+    weakref-backed reader (see :func:`weak_live_source`) AND to unbind at
+    teardown — belt and braces, because a hard crash never reaches teardown
+    and a clean stop should not wait for a garbage collector.
+
+    Rebinding is last-writer-wins by design: a restarted service is the
+    authority on its own liveness, and refusing its bind because a dead one
+    got there first would leave `/why` permanently disk-only.
     """
     global _LIVE_SOURCE
-    _LIVE_SOURCE = source
+    with _live_lock:
+        _LIVE_SOURCE = source
+
+
+def release_live_source(source: Callable[[], Dict[str, Any]]) -> bool:
+    """Unbind ``source`` IFF it is still the bound one. NEVER raises.
+
+    Compare-and-clear, not clear. Teardown overlaps startup: a service that
+    is stopping while its replacement has already bound would, with a plain
+    ``set_live_source(None)``, unbind the LIVE service on its way out — and
+    `/why` would answer disk-only about a running organism for the rest of
+    the session, with nothing in the logs to say why.
+
+    The old instance may only take back what it put there. Returns True when
+    it did, False when someone else now holds the binding — which is not an
+    error, it is the successor having won.
+    """
+    global _LIVE_SOURCE
+    with _live_lock:
+        if _LIVE_SOURCE is not source:
+            return False
+        _LIVE_SOURCE = None
+        return True
+
+
+def weak_live_source(service: Any, attr: str = "_active_ops") -> Callable[
+        [], Dict[str, Any]]:
+    """A reader that cannot keep a dead service alive.
+
+    Holds the service by weak reference, so a collected GLS yields ``{}``
+    rather than a frozen snapshot of an instance nobody else can reach. The
+    engine then reports disk-only, which is true, instead of reporting live
+    state from a service that has stopped.
+
+    Adapts the registry's SHAPE here rather than in the engine: `_active_ops`
+    is a set of ids today and could gain per-op detail tomorrow, and the
+    engine should not have to know which. A set becomes ``{id: {}}``; a
+    mapping is passed through.
+    """
+    import weakref
+
+    try:
+        ref = weakref.ref(service)
+    except TypeError:
+        # Not every object can be weakly referenced — `__slots__` without
+        # `__weakref__`, and most C types. Falling back to a STRONG reference
+        # would satisfy the call and reintroduce exactly the dangling pointer
+        # this function exists to prevent, silently. Refuse instead: `/why`
+        # is honestly disk-only, and the reason is in the log.
+        logger.warning(
+            "[Why] %s cannot be weakly referenced — the live half of /why "
+            "stays unbound rather than pinning it", type(service).__name__)
+        return lambda: {}
+
+    def _read() -> Dict[str, Any]:
+        svc = ref()
+        if svc is None:
+            return {}
+        raw = getattr(svc, attr, None)
+        if raw is None:
+            # Boot-time. The attribute is assigned in `__init__`, long before
+            # the binding is made in `start()`, so this is reachable only if
+            # a caller binds something half-built. Disk-only is the honest
+            # answer; a NoneType traceback in the operator's face is not.
+            return {}
+        # Snapshot in ONE builtin call. `set.copy()` and `dict.copy()` run
+        # entirely in C, so no other thread's `add`/`discard` can interleave.
+        # A comprehension over the live container would iterate at Python
+        # level and raise "changed size during iteration" whenever the
+        # organism is busy — which is exactly when `/why` is asked, so the
+        # live half would drop out precisely when it matters.
+        try:
+            snap = raw.copy()
+        except AttributeError:
+            try:
+                snap = list(raw)
+            except TypeError:
+                return {}
+        if isinstance(snap, dict):
+            return snap
+        return {str(op): {} for op in snap}
+
+    return _read
 
 
 def _resolve_ref(ref: str) -> Tuple[str, Optional[Any], bool]:

--- a/backend/core/ouroboros/governance/why_repl.py
+++ b/backend/core/ouroboros/governance/why_repl.py
@@ -1,0 +1,169 @@
+"""``/why <ref>`` — the causal account, rendered for a person.
+
+The engine (:mod:`why_engine`) produces the join. This renders it, and the
+rendering is a real design constraint rather than a formatting detail: an
+explanation an operator skips is worse than no explanation, because it was
+offered and declined.
+
+THE SHAPE IS FIXED
+------------------
+Four bands, same order, every time::
+
+    ⏺ why o-12  op-019ff316…
+      ⎿ TRIGGER   what woke it
+      ⎿ CONTEXT   what it knew
+      ⎿ LOGIC     how it reasoned
+      ⎿ ACTION    what it did
+
+Fixed order because an operator learns where to look once, and a layout that
+reorders by what happens to be present makes them re-read it every time.
+Always all four, because a band that vanished when empty would render "it
+had no context" and "we did not record the context" identically — and those
+are different answers.
+
+The glyphs are the deck's own (``⏺``/``⎿``): this is one more op-scoped
+block in a transcript full of them, not a new visual language.
+
+CERTAINTY IS RENDERED, NOT DROPPED
+-----------------------------------
+``observed`` prints its items. ``tombstone`` says the records existed and
+were evicted — a fact about a retention policy the operator can change.
+``unknown`` says nothing was ever recorded. Three states, three renderings,
+because the action each calls for is different.
+
+Auto-discovered through the naming cage, like ``trust_repl`` and
+``reach_repl``.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+logger = logging.getLogger("Ouroboros.WhyRepl")
+
+WHY_REPL_SCHEMA_VERSION: str = "why_repl.1"
+
+__verb_help__ = {
+    "why": "the causal account for a ref — trigger, context, logic, action",
+}
+
+_HELP = (
+    "/why — why did the organism do that? (PRD §27.5)\n"
+    "\n"
+    "  /why <ref>          the causal account for one ref or op-id\n"
+    "  /why <ref> --full   walk the whole ancestry, not one hop\n"
+    "  /why help           this text\n"
+    "\n"
+    "Refs are the deck's own: o-12 (op block), d-7 (diff), t-3 (tool),\n"
+    "n-4 (narrative), m-2 (milestone) — or a bare op-id.\n"
+    "\n"
+    "Deterministic: read from the transcript, never generated. It answers\n"
+    "when every provider lane is dry, and it cannot invent a rationale.\n"
+)
+
+#: One line each, so the band names carry their meaning without a legend.
+_BAND_GLOSS = {
+    "trigger": "what woke it",
+    "context": "what it knew",
+    "logic": "how it reasoned",
+    "action": "what it did",
+}
+
+
+@dataclass(frozen=True)
+class WhyReplDispatchResult:
+    ok: bool
+    text: str
+    matched: bool = True
+    schema_version: str = WHY_REPL_SCHEMA_VERSION
+
+
+def _render_band(band: Any) -> List[str]:
+    from backend.core.ouroboros.governance.why_engine import Certainty
+
+    gloss = _BAND_GLOSS.get(band.name, "")
+    head = f"  ⎿ {band.name.upper():<9} {gloss}"
+    if band.certainty is Certainty.OBSERVED:
+        rows = [head]
+        rows.extend(f"      {item}" for item in band.items)
+        return rows
+    if band.certainty is Certainty.TOMBSTONE:
+        # Named as a structural node rather than as an absence: the system
+        # knew this and discarded it on a policy the operator controls.
+        return [head, f"      [tombstone — {band.detail}]"]
+    return [head, f"      (unknown — {band.detail})"]
+
+
+def render(explanation: Any) -> str:
+    """The whole account as one block. Pure; no I/O."""
+    lines: List[str] = []
+    flight = "  · IN FLIGHT" if explanation.in_flight else ""
+    lines.append(f"⏺ why {explanation.ref}  {explanation.op_id[:24]}{flight}")
+    for band in explanation.bands:
+        lines.extend(_render_band(band))
+
+    if explanation.lineage:
+        nearest = explanation.lineage[0]
+        tail = ("  (…deeper ancestry — /why <that ref> --full)"
+                if explanation.lineage_truncated else "")
+        lines.append(f"  ⎿ CAUSED BY  {nearest}{tail}")
+    if explanation.partial:
+        # Louder than a footnote: a partial account can be read as a
+        # complete one, and an operator acting on "it did nothing else" when
+        # records were evicted is the failure this line prevents.
+        lines.append("  ⎿ PARTIAL    the spine has evicted records for this "
+                     "op — absence here is not evidence of absence")
+    if explanation.loss_point:
+        lines.append(f"  ⎿ DATA LOSS  {explanation.loss_point}")
+    return "\n".join(lines)
+
+
+def dispatch_why_command(line: str) -> WhyReplDispatchResult:
+    """Explain one ref.
+
+    Operator: ask the organism why it did something, and get the ledger's
+    answer rather than a model's.
+    """
+    try:
+        raw = (line or "").strip().lstrip("/")
+        tokens = raw.split()
+        args = [t for t in tokens[1:] if t]
+        if not args or args[0] in ("help", "-h", "--help"):
+            return WhyReplDispatchResult(ok=True, text=_HELP)
+
+        full = any(a in ("--full", "-f") for a in args)
+        positional = [a for a in args if not a.startswith("-")]
+        if not positional:
+            return WhyReplDispatchResult(
+                ok=False,
+                text="/why needs a ref — try `/why o-12` or `/why help`")
+
+        from backend.core.ouroboros.governance import why_engine as we
+
+        try:
+            explanation = we.explain(
+                positional[0], depth=(64 if full else None))
+        except we.RefNotFound as exc:
+            # A ref that resolves nowhere is REFUSED with the reason,
+            # never answered with an empty account — an empty account
+            # reads as "it did nothing", which is a different claim.
+            return WhyReplDispatchResult(ok=False, text=str(exc))
+
+        return WhyReplDispatchResult(ok=True, text=render(explanation))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[WhyRepl] dispatch degraded", exc_info=True)
+        return WhyReplDispatchResult(
+            ok=False,
+            text=(f"could not build the account ({type(exc).__name__}) — "
+                  f"the transcript may be mid-write; try again"))
+
+
+__all__ = [
+    "WHY_REPL_SCHEMA_VERSION",
+    "WhyReplDispatchResult",
+    "dispatch_why_command",
+    "render",
+]

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -3450,7 +3450,53 @@ Slices 5–7 need ops, which need a funded lane.
 3. `/why` imports no provider client (§27.5.2);
 4. the ambient idle line imports no provider client (§27.4.3);
 5. the trust panel is read-only with respect to every §26 flag — rendering
-   authority is never write authority (the `ide_observability.py` precedent).
+   authority is never write authority (the `ide_observability.py` precedent);
+6. every module honouring the naming cage is reachable by typing its verb
+   (§27.5.6) — the pin that makes "shipped and untypeable" a red build.
+
+---
+
+### 27.5.6 The naming cage — a `*_repl` module IS its verb
+
+`/why` and `/reach` both shipped importable, tested, documented, and
+**untypeable**. Their dispatchers were correct; their renderers were correct;
+their spines were green. Nothing anywhere asserted that a human could reach
+them, because reaching them required somebody to remember to add a branch to
+an `if line.startswith(...)` ladder in `serpent_flow`. Three of the five
+governance modules honouring the contract had a branch; two did not.
+
+That is the §27 defect class in its purest form, and the fix is not a sixth
+branch. It is to make the mount **structural**:
+
+> A module `governance/<verb>_repl.py` that exports BOTH `__verb_help__` and
+> `dispatch_<verb>_command` **is** the verb `/<verb>`. The filesystem is the
+> registration. There is no table to drift.
+
+Both halves are required because either alone is ambiguous — a dispatcher
+with no help is undiscoverable, and help with no dispatcher is a promise with
+no mechanism.
+
+Discovery is `ast` over the package directory: ~0.16s for 68 candidates and
+**zero imports**, against ~0.47s and 68 import side effects for the obvious
+alternative. Descriptions come from `ast.literal_eval` of the dict literal, so
+the palette is fully populated before a single module loads. Dispatch then
+imports exactly the one module the operator named.
+
+Three seams, each load-bearing:
+
+| Seam | Placement | Why there |
+|---|---|---|
+| Routing (`serpent_flow`) | after the explicit ladder, before the unknown-verb handler | hand-written branches keep priority and stay byte-identical; only lines that would fall through to "did you mean…" reach the cage |
+| Palette (`unified_registry`) | lowest precedence in the one composer | a verb that works and is invisible is half a verb; merged here, not in `discover_verbs`, so the unified kill switch restores the legacy split completely |
+| Quality (cage spine) | asserts each declared description survives `verb_description.assess` | a residue description loses its palette row to a scrape of the module's own subcommand names — caught where it is declared, not in a distant red |
+
+`None` from the cage means "no module claims this" and must fall through; a
+result that merely answered *no* must not. An import failure returns a stated
+refusal rather than `None`, because *exists-but-broken* and *does not exist*
+call for different operator responses, and collapsing them hides the bug
+behind a spelling suggestion.
+
+Master switch `JARVIS_REPL_VERB_CAGE_ENABLED`, default **true**.
 
 ---
 

--- a/tests/governance/test_repl_verb_cage.py
+++ b/tests/governance/test_repl_verb_cage.py
@@ -1,0 +1,209 @@
+"""Regression spine for the naming cage — a `*_repl` module IS its verb.
+
+The class of defect under test is not "the dispatcher is wrong". It is
+"the dispatcher is correct, tested, documented, and unreachable by a human".
+Every assertion here is about REACHABILITY.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+from backend.core.ouroboros.governance import repl_verb_cage as cage
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.delenv("JARVIS_REPL_VERB_CAGE_ENABLED", raising=False)
+    cage.reset_cache()
+    yield
+    cage.reset_cache()
+
+
+# -- the contract ----------------------------------------------------------
+
+
+def test_a_module_claims_the_verb_its_name_spells():
+    verbs = {v.verb: v for v in cage.discover()}
+    assert "why" in verbs
+    assert verbs["why"].module.endswith("why_repl")
+    assert verbs["why"].slash_form == "/why"
+    assert verbs["why"].dispatch_name == "dispatch_why_command"
+
+
+def test_both_halves_are_required_to_claim_a_verb(tmp_path):
+    """Help alone is a promise; a dispatcher alone is undiscoverable."""
+    only_help = tmp_path / "alpha_repl.py"
+    only_help.write_text('__verb_help__ = {"alpha": "x"}\n', encoding="utf-8")
+    assert cage._read_declaration(only_help, "alpha") is None
+
+    only_disp = tmp_path / "beta_repl.py"
+    only_disp.write_text("def dispatch_beta_command(line):\n    return None\n",
+                         encoding="utf-8")
+    assert cage._read_declaration(only_disp, "beta") is None
+
+    both = tmp_path / "gamma_repl.py"
+    both.write_text('__verb_help__ = {"gamma": "does a thing"}\n'
+                    "def dispatch_gamma_command(line):\n    return None\n",
+                    encoding="utf-8")
+    assert cage._read_declaration(both, "gamma") == "does a thing"
+
+
+def test_a_nested_declaration_is_not_an_export(tmp_path):
+    """`getattr` could not find these, so the palette must not offer them."""
+    path = tmp_path / "delta_repl.py"
+    path.write_text(
+        "def _inner():\n"
+        '    __verb_help__ = {"delta": "x"}\n'
+        "    def dispatch_delta_command(line):\n        return None\n",
+        encoding="utf-8")
+    assert cage._read_declaration(path, "delta") is None
+
+
+def test_discovery_never_imports_the_modules_it_scans():
+    """A broken verb must not take the whole palette down with it."""
+    code = _code_of(cage, "discover", "_read_declaration", "_package_dir")
+    assert "import_module" not in code
+    assert "__import__" not in code
+
+
+def test_a_syntactically_broken_module_is_skipped_not_fatal(tmp_path):
+    bad = tmp_path / "epsilon_repl.py"
+    bad.write_text("def dispatch_epsilon_command(  <<<\n", encoding="utf-8")
+    assert cage._read_declaration(bad, "epsilon") is None
+
+
+# -- reachability: the actual defect ---------------------------------------
+
+
+def test_why_is_reachable_by_typing_it():
+    result = cage.dispatch("/why help")
+    assert result is not None, "/why is mounted but unreachable"
+    assert result.ok is True
+    assert "causal account" in result.text
+
+
+def test_reach_is_reachable_by_typing_it():
+    result = cage.dispatch("/reach help")
+    assert result is not None, "/reach is mounted but unreachable"
+    assert "reachability" in result.text
+
+
+def test_an_unclaimed_verb_returns_none_so_the_typo_handler_still_runs():
+    assert cage.dispatch("/no_such_verb_xyz") is None
+
+
+def test_a_verb_that_answers_no_is_not_confused_with_an_unclaimed_one():
+    """`None` and a falsy result mean different things at the seam."""
+    result = cage.dispatch("/why")
+    assert result is not None
+    assert result.ok is True  # bare /why prints help rather than failing
+
+
+def test_a_broken_module_refuses_out_loud_rather_than_falling_through(
+        monkeypatch):
+    """"exists but broken" and "does not exist" call for different actions."""
+    import importlib
+
+    def _boom(name):
+        raise ImportError("simulated")
+
+    monkeypatch.setattr(importlib, "import_module", _boom)
+    result = cage.dispatch("/why help")
+    assert result is not None and result.ok is False
+    assert "failed to load" in result.text
+
+
+def test_the_master_switch_disables_the_cage(monkeypatch):
+    monkeypatch.setenv("JARVIS_REPL_VERB_CAGE_ENABLED", "false")
+    cage.reset_cache()
+    assert cage.discover() == ()
+    assert cage.dispatch("/why help") is None
+
+
+def test_a_bare_word_is_not_a_slash_verb():
+    assert cage.find("why o-1") is None
+    assert cage.find("") is None
+    assert cage.find("/") is None
+
+
+# -- the mount itself ------------------------------------------------------
+
+
+def _code_of(module, *names):
+    """Executable source only — docstrings stripped.
+
+    A docstring EXPLAINING a mechanism greps identically to the mechanism.
+    """
+    tree = ast.parse(inspect.getsource(module))
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if names and node.name not in names:
+            continue
+        body = list(node.body)
+        if (body and isinstance(body[0], ast.Expr)
+                and isinstance(getattr(body[0], "value", None), ast.Constant)
+                and isinstance(body[0].value.value, str)):
+            body = body[1:]
+        out.extend(ast.unparse(stmt) for stmt in body)
+    return "\n".join(out)
+
+
+def test_the_repl_actually_calls_the_cage():
+    """Without this the cage is one more thing that is built and inert."""
+    from backend.core.ouroboros.battle_test import serpent_flow as sf
+
+    assert "repl_verb_cage" in _code_of(sf), "the cage has no caller"
+
+
+def test_the_cage_runs_before_the_unknown_verb_handler():
+    """After the cage, "did you mean…" would deny a verb that works."""
+    from backend.core.ouroboros.battle_test import serpent_flow as sf
+
+    src = inspect.getsource(sf)
+    assert src.index("repl_verb_cage") < src.index("suggest_for_typo")
+
+
+def test_cage_verbs_appear_in_the_palette():
+    """A verb that works and is invisible is half a verb."""
+    from backend.core.ouroboros.battle_test.repl_completion import (
+        unified_registry,
+    )
+
+    registry = unified_registry(object())
+    assert registry.find("/why") is not None
+    assert registry.find("/reach") is not None
+
+
+def test_every_contract_honouring_module_is_reachable():
+    """The invariant, stated once: declaring the contract IS mounting.
+
+    A future `governance/foo_repl.py` that exports both halves is reachable
+    the moment it lands. This test is what makes that true rather than
+    aspirational — a regression in the seam fails here, not in production.
+    """
+    for spec in cage.discover():
+        assert cage.dispatch(f"{spec.slash_form} help") is not None, (
+            f"{spec.slash_form} declares the contract but is unreachable")
+
+
+def test_every_declared_description_survives_the_palette_arbiter():
+    """A residue description loses the row to a scrape of subcommand names.
+
+    Caught here rather than in a distant palette test, because the module
+    that declares a bad description is the one that should fail — otherwise
+    the next `*_repl` author learns about it from an unrelated red.
+    """
+    from backend.core.ouroboros.battle_test.verb_description import (
+        Shape, assess,
+    )
+
+    for spec in cage.discover():
+        verdict = assess(spec.description, spec.verb)
+        assert verdict.shape is not Shape.RESIDUE, (
+            f"{spec.module} declares a residue description for "
+            f"{spec.slash_form}: {verdict.reasons} — {spec.description!r}")

--- a/tests/governance/test_why_engine.py
+++ b/tests/governance/test_why_engine.py
@@ -1,0 +1,269 @@
+"""Regression spine for `/why` — the causal account (PRD §27.5)."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.core.ouroboros.battle_test import transcript_spine as ts
+from backend.core.ouroboros.governance import why_engine as we
+from backend.core.ouroboros.governance import why_repl as wr
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    for k in ("JARVIS_WHY_LINEAGE_DEPTH", "JARVIS_WHY_BAND_ITEMS",
+              "JARVIS_OUROBOROS_SESSION_DIR"):
+        monkeypatch.delenv(k, raising=False)
+    ts.reset_default_spine()
+    we.set_live_source(None)
+    yield
+    ts.reset_default_spine()
+    we.set_live_source(None)
+
+
+def _seed(op="op-1"):
+    sp = ts.get_default_spine()
+    sp.append("op_block", "o-1", {"summary": "TodoScanner fired"}, op_id=op)
+    sp.append("narrative", "n-1", {"text": "retry path is dead"}, op_id=op)
+    sp.append("tool_render", "t-1", {"summary": "get_callers -> 0"}, op_id=op)
+    sp.append("diff", "d-1", {"summary": "remove guard"}, op_id=op)
+    return sp
+
+
+# -- shape -----------------------------------------------------------------
+
+
+def test_all_four_bands_always_render_in_a_fixed_order():
+    """A band that vanished when empty would make 'it had no context' and
+    'we did not record the context' render identically."""
+    ts.get_default_spine().append("op_block", "o-1", {}, op_id="op-1")
+    e = we.explain("o-1")
+    assert [b.name for b in e.bands] == list(we.BAND_ORDER)
+
+
+def test_an_empty_band_says_unknown_rather_than_disappearing():
+    ts.get_default_spine().append("op_block", "o-1", {}, op_id="op-1")
+    e = we.explain("o-1")
+    ctx = e.band("context")
+    assert ctx.certainty is we.Certainty.UNKNOWN
+    assert "unknown" in wr.render(e).lower()
+
+
+def test_records_route_to_the_band_their_vocabulary_answers():
+    _seed()
+    e = we.explain("o-1")
+    assert "o-1" in e.band("trigger").items[0]
+    assert "n-1" in e.band("context").items[0]
+    assert "t-1" in e.band("logic").items[0]
+    assert any("d-1" in i for i in e.band("action").items)
+
+
+def test_a_bare_op_id_resolves_as_well_as_a_ref():
+    """An operator reading a log has the op id; one reading the deck has the
+    ref. Demanding they know which is the interface asking for a lookup."""
+    _seed(op="op-xyz")
+    assert we.explain("op-xyz").op_id == "op-xyz"
+
+
+def test_an_unresolvable_ref_is_refused_not_answered_empty():
+    """An empty account reads as 'it did nothing', which is a different
+    claim from 'we cannot find it'."""
+    with pytest.raises(we.RefNotFound):
+        we.explain("o-999")
+    out = wr.dispatch_why_command("/why o-999")
+    assert out.ok is False and "resolves to nothing" in out.text
+
+
+def test_no_model_call_is_made():
+    """It must answer when every provider lane is dry, and it cannot invent
+    a rationale."""
+    import pathlib
+    src = pathlib.Path(we.__file__).read_text(encoding="utf-8")
+    for banned in ("providers", "candidate_generator", "anthropic",
+                   "generate("):
+        assert banned not in src
+
+
+def test_the_engine_adds_no_fourth_parser():
+    """spine owns records, timeline owns the fold, transcript_log owns
+    recovery. A second parser is a second opinion about the same bytes."""
+    import pathlib
+    src = pathlib.Path(we.__file__).read_text(encoding="utf-8")
+    assert "json.loads" not in src and "open(" not in src
+
+
+# -- the in-flight race ----------------------------------------------------
+
+
+def test_an_in_flight_op_is_joined_from_memory_not_reported_missing():
+    """The operator asks about the thing they are watching — by definition
+    the thing least likely to have reached disk."""
+    we.set_live_source(lambda: {"op-live": {"phase": "GENERATE"}})
+    e = we.explain("op-live")
+    assert e.in_flight is True
+    assert any("IN FLIGHT" in i for i in e.band("logic").items)
+
+
+def test_in_flight_state_is_labelled_in_the_render():
+    we.set_live_source(lambda: {"op-live": {"phase": "VALIDATE"}})
+    assert "IN FLIGHT" in wr.render(we.explain("op-live"))
+
+
+def test_a_live_source_that_raises_degrades_to_disk_only():
+    def _boom():
+        raise RuntimeError("registry locked")
+    we.set_live_source(_boom)
+    _seed()
+    e = we.explain("o-1")
+    assert e.in_flight is False
+    assert e.band("trigger").certainty is we.Certainty.OBSERVED
+
+
+def test_without_a_live_source_disk_still_answers():
+    _seed()
+    assert we.explain("o-1").band("trigger").certainty is we.Certainty.OBSERVED
+
+
+# -- the tombstone gap -----------------------------------------------------
+
+
+def test_an_evicted_context_renders_a_tombstone_not_a_crash(monkeypatch):
+    """The originating context was purged by retention. The join must keep
+    mapping the surviving downstream nodes."""
+    sp = ts.get_default_spine()
+    sp.append("op_block", "o-1", {"summary": "trigger"}, op_id="op-1")
+    monkeypatch.setattr(type(sp), "was_evicted", lambda self, ref: True)
+    monkeypatch.setattr(type(sp), "evicted_count", 3, raising=False)
+    e = we.explain("o-1")
+    ctx = e.band("context")
+    assert ctx.certainty is we.Certainty.TOMBSTONE
+    assert "tombstone" in wr.render(e).lower()
+    # Downstream survives.
+    assert e.band("trigger").certainty is we.Certainty.OBSERVED
+
+
+def test_a_tombstone_is_not_collapsed_into_unknown():
+    """'We discarded this on a policy you control' and 'this was never
+    recorded' call for different actions."""
+    assert we.Certainty.TOMBSTONE != we.Certainty.UNKNOWN
+
+
+def test_a_partial_account_says_so_loudly():
+    """A partial account can be read as complete, and an operator acting on
+    'it did nothing else' when records were evicted is the failure."""
+    sp = ts.get_default_spine()
+    sp.append("op_block", "o-1", {}, op_id="op-1")
+    e = we.Explanation(ref="o-1", op_id="op-1", bands=we.explain("o-1").bands,
+                       partial=True)
+    assert "PARTIAL" in wr.render(e)
+
+
+def test_a_corrupt_log_reports_where_it_stops(monkeypatch, tmp_path):
+    """recover_log already returns a typed stop_reason and stop_frame — the
+    engine reports rather than guesses."""
+    class _Result:
+        clean = False
+        stop_reason = "crc_mismatch"
+        stop_frame = 42
+        trailing_bytes = 118
+    monkeypatch.setenv("JARVIS_OUROBOROS_SESSION_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        "backend.core.ouroboros.battle_test.transcript_log.recover_log",
+        lambda *a, **k: _Result())
+    sp = ts.get_default_spine()
+    sp.append("op_block", "o-1", {}, op_id="op-1")
+    e = we.explain("o-1")
+    assert "frame 42" in e.loss_point and "crc_mismatch" in e.loss_point
+    assert "DATA LOSS" in wr.render(e)
+
+
+def test_a_clean_log_reports_no_loss(monkeypatch, tmp_path):
+    class _Result:
+        clean = True
+    monkeypatch.setenv("JARVIS_OUROBOROS_SESSION_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        "backend.core.ouroboros.battle_test.transcript_log.recover_log",
+        lambda *a, **k: _Result())
+    ts.get_default_spine().append("op_block", "o-1", {}, op_id="op-1")
+    assert we.explain("o-1").loss_point == ""
+
+
+# -- the chain reaction ----------------------------------------------------
+
+
+def test_lineage_defaults_to_one_hop_not_the_whole_ancestry():
+    """An explanation that unrolled eight ancestors into the terminal would
+    be skipped, and a skipped explanation is worse than a short one."""
+    we.set_live_source(lambda: {
+        "d": {"parent_op_id": "c"}, "c": {"parent_op_id": "b"},
+        "b": {"parent_op_id": "a"}, "a": {},
+    })
+    e = we.explain("d")
+    assert e.lineage == ("c",)
+    assert e.lineage_truncated is True
+
+
+def test_full_walks_the_whole_chain():
+    we.set_live_source(lambda: {
+        "d": {"parent_op_id": "c"}, "c": {"parent_op_id": "b"},
+        "b": {"parent_op_id": "a"}, "a": {},
+    })
+    e = we.explain("d", depth=64)
+    assert e.lineage == ("c", "b", "a")
+    assert e.lineage_truncated is False
+
+
+def test_the_render_offers_the_drill_down_path():
+    we.set_live_source(lambda: {"d": {"parent_op_id": "c"},
+                                "c": {"parent_op_id": "b"}, "b": {}})
+    text = wr.render(we.explain("d"))
+    assert "CAUSED BY" in text and "--full" in text
+
+
+def test_a_root_op_reports_no_lineage():
+    _seed()
+    assert we.explain("o-1").lineage == ()
+
+
+def test_a_cycle_terminates_rather_than_hanging():
+    """An op-id reused across sessions could otherwise loop forever."""
+    we.set_live_source(lambda: {"a": {"parent_op_id": "b"},
+                                "b": {"parent_op_id": "a"}})
+    e = we.explain("a", depth=64)
+    assert len(e.lineage) <= 2
+
+
+# -- the surface -----------------------------------------------------------
+
+
+def test_the_verb_is_auto_discoverable():
+    assert callable(wr.dispatch_why_command) and "why" in wr.__verb_help__
+
+
+def test_help_is_reachable():
+    assert "causal" in wr.dispatch_why_command("/why help").text.lower()
+
+
+def test_a_bare_why_prints_help_rather_than_failing():
+    assert wr.dispatch_why_command("/why").ok is True
+
+
+def test_the_render_uses_the_decks_own_glyphs():
+    """One more op-scoped block in a transcript full of them, not a new
+    visual language."""
+    _seed()
+    text = wr.render(we.explain("o-1"))
+    assert text.startswith("⏺") and "⎿" in text
+
+
+def test_dispatch_never_raises_on_a_broken_engine(monkeypatch):
+    monkeypatch.setattr(we, "explain",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("x")))
+    out = wr.dispatch_why_command("/why o-1")
+    assert out.ok is False and "could not build" in out.text
+
+
+def test_the_explanation_is_serialisable():
+    _seed()
+    json.dumps(we.explain("o-1").to_dict())

--- a/tests/governance/test_why_engine.py
+++ b/tests/governance/test_why_engine.py
@@ -267,3 +267,197 @@ def test_dispatch_never_raises_on_a_broken_engine(monkeypatch):
 def test_the_explanation_is_serialisable():
     _seed()
     json.dumps(we.explain("o-1").to_dict())
+
+
+# -- the boot binding: DI, not a singleton ---------------------------------
+
+
+class _FakeGLS:
+    """Stands in for GovernedLoopService: an `_active_ops` set, nothing more."""
+
+    def __init__(self, ops=()):
+        self._active_ops = set(ops)
+
+
+def _code_of(module, *names):
+    """Executable source only — docstrings stripped.
+
+    Prose that EXPLAINS a mechanism reads identically to the mechanism when
+    grepped, so a docstring saying "we do not use os.access" satisfies a
+    search for os.access. Assertions here must see code.
+    """
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(module))
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if names and node.name not in names:
+            continue
+        body = list(node.body)
+        if (body and isinstance(body[0], ast.Expr)
+                and isinstance(getattr(body[0], "value", None), ast.Constant)
+                and isinstance(body[0].value.value, str)):
+            body = body[1:]
+        out.extend(ast.unparse(stmt) for stmt in body)
+    return "\n".join(out)
+
+
+def test_a_set_registry_is_adapted_without_the_engine_knowing_its_shape():
+    svc = _FakeGLS({"op-a", "op-b"})
+    assert we.weak_live_source(svc)() == {"op-a": {}, "op-b": {}}
+
+
+def test_a_mapping_registry_passes_through_unchanged():
+    svc = _FakeGLS()
+    svc._active_ops = {"op-a": {"phase": "GENERATE"}}
+    assert we.weak_live_source(svc)()["op-a"]["phase"] == "GENERATE"
+
+
+def test_a_collected_service_yields_disk_only_not_a_frozen_snapshot():
+    import gc
+
+    svc = _FakeGLS({"op-a"})
+    read = we.weak_live_source(svc)
+    assert read() == {"op-a": {}}
+    del svc
+    gc.collect()
+    # The dangling pointer: a strong closure would still answer {"op-a": {}}
+    # for a service nobody else can reach.
+    assert read() == {}
+
+
+def test_the_reader_is_weak_so_binding_does_not_prolong_the_service():
+    import gc
+    import weakref
+
+    svc = _FakeGLS()
+    ref = weakref.ref(svc)
+    we.set_live_source(we.weak_live_source(svc))
+    del svc
+    gc.collect()
+    assert ref() is None
+
+
+def test_a_missing_registry_degrades_rather_than_raising():
+    assert we.weak_live_source(_FakeGLS(), "_nope")() == {}
+
+
+def test_an_unweakrefable_service_is_refused_not_pinned_strongly():
+    """Falling back to a strong ref would silently restore the bug."""
+    assert we.weak_live_source(object())() == {}
+
+
+def test_a_stopping_instance_cannot_unbind_its_successor():
+    old, new = _FakeGLS({"old"}), _FakeGLS({"new"})
+    old_read, new_read = we.weak_live_source(old), we.weak_live_source(new)
+    we.set_live_source(old_read)
+    we.set_live_source(new_read)          # successor binds first
+    assert we.release_live_source(old_read) is False   # predecessor stops
+    assert we._live_ops() == {"new": {}}   # successor still visible
+
+
+def test_an_instance_releases_the_reader_it_actually_lent():
+    svc = _FakeGLS({"op-a"})
+    read = we.weak_live_source(svc)
+    we.set_live_source(read)
+    assert we.release_live_source(read) is True
+    assert we._live_ops() == {}
+
+
+def test_releasing_twice_is_not_an_error():
+    read = we.weak_live_source(_FakeGLS())
+    we.set_live_source(read)
+    assert we.release_live_source(read) is True
+    assert we.release_live_source(read) is False
+
+
+def test_why_survives_being_spammed_while_the_binding_churns():
+    """Boot-time thread safety: bind/release racing reads, no NoneType."""
+    import threading
+
+    svc = _FakeGLS({"op-a"})
+    stop = threading.Event()
+    errors = []
+
+    def churn():
+        while not stop.is_set():
+            read = we.weak_live_source(svc)
+            we.set_live_source(read)
+            we.release_live_source(read)
+
+    def ask():
+        while not stop.is_set():
+            try:
+                we._live_ops()
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+    threads = [threading.Thread(target=churn), threading.Thread(target=ask),
+               threading.Thread(target=ask)]
+    for t in threads:
+        t.start()
+    stop.wait(0.4)
+    stop.set()
+    for t in threads:
+        t.join(timeout=5)
+    assert not errors
+
+
+def test_a_registry_mutating_under_the_read_does_not_drop_the_live_half():
+    """A busy organism is exactly when `/why` is asked."""
+    import threading
+
+    svc = _FakeGLS({f"op-{i}" for i in range(200)})
+    stop = threading.Event()
+    read = we.weak_live_source(svc)
+    errors, empties = [], []
+
+    def mutate():
+        i = 0
+        while not stop.is_set():
+            svc._active_ops.add(f"x-{i}")
+            svc._active_ops.discard(f"x-{i - 50}")
+            i += 1
+
+    def sample():
+        while not stop.is_set():
+            try:
+                if not read():
+                    empties.append(1)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+    threads = [threading.Thread(target=mutate), threading.Thread(target=sample)]
+    for t in threads:
+        t.start()
+    stop.wait(0.4)
+    stop.set()
+    for t in threads:
+        t.join(timeout=5)
+    assert not errors and not empties
+
+
+def test_the_engine_never_reaches_into_the_orchestrator():
+    """DI direction: the projection must not import the service."""
+    import inspect
+
+    src = inspect.getsource(we)
+    assert "governed_loop_service" not in src
+    assert "orchestrator" not in _code_of(we)
+
+
+def test_the_boot_seam_binds_and_both_teardowns_release():
+    """The wired-but-inert trap: a binding nobody calls is not a binding."""
+    from backend.core.ouroboros.governance import governed_loop_service as gls
+
+    code = _code_of(gls)
+    assert "set_live_source" in code, "boot seam never binds /why"
+    assert "weak_live_source" in code, "boot seam binds a STRONG reader"
+
+    for seam in ("stop", "_teardown_partial"):
+        assert "_release_why_live_source" in _code_of(gls, seam), (
+            f"{seam}() leaves the /why reader dangling")
+    assert "release_live_source" in _code_of(gls, "_release_why_live_source")


### PR DESCRIPTION
## What

`885ca71ce1` built the `/why` engine and renderer (PRD §27.5). This PR binds it to the live op registry and then closes the reason it would *still* have been unusable: **nobody could type it.**

## The binding — DI, not a singleton

`why_engine` holds no registry, constructs nothing, and cannot reach the orchestrator. `GovernedLoopService.start()` lends it a reader beside the existing proactive-mode sink injection; teardown takes it back. Three races handled structurally rather than by retry:

| Race | Handling |
|---|---|
| **Dangling pointer** — GLS crashes/restarts | Reader holds the service **weakly**, so a dead instance degrades to disk-only instead of answering from a frozen final state. A type that cannot be weakly referenced is **refused**, not silently held strongly — that fallback would restore the exact bug the weakref prevents. |
| **Overlapping restart** | `release_live_source(reader)` is compare-and-clear. A stopping instance may only take back what it put there, so it cannot unbind its successor. Released on **both** teardown paths, and **last** in `stop()` — draining ops genuinely are in flight. |
| **Boot-time `/why` spam** | `_live_ops()` binds the global to a local before use (the two-read TOCTOU raised `NoneType` exactly when an operator could least interpret it). The registry is snapshotted with one builtin `.copy()`, so a busy organism cannot raise *changed size during iteration* and drop the live half precisely when it matters. |

## The mount — the actual defect

`/why` and `/reach` shipped importable, tested, documented, and **untypeable**. Their docstrings claimed auto-discovery "through the naming cage" — a mechanism that did not exist. Verbs were mounted by remembering to add a branch to an `if line.startswith(...)` ladder; three of the five contract-honouring modules had one.

The fix is not a sixth branch:

> A module `governance/<verb>_repl.py` exporting **both** `__verb_help__` and `dispatch_<verb>_command` **is** the verb `/<verb>`. The filesystem is the registration.

- Discovery is `ast` over the package dir — **0.16s for 68 candidates, zero imports** (vs 0.47s and 68 import side effects); descriptions via `literal_eval`.
- Dispatch imports exactly the one module named.
- Routed **after** the explicit ladder (existing branches byte-identical) and **before** the unknown-verb handler (or "did you mean…" would deny a verb that works).
- Merged into `unified_registry` at lowest precedence, so the palette stops hiding verbs the REPL accepts and the unified kill switch still restores the legacy split.
- `None` means "no module claims this" and falls through; a result that merely answered *no* does not. An import failure states a refusal rather than returning `None` — *exists-but-broken* and *does not exist* call for different operator responses.

`/reach`'s description led with "which", a fragment head the palette arbiter scores as RESIDUE — losing its row to a scrape of the module's own subcommand names. Reworded, and the cage spine now asserts every declared description survives the arbiter, so the next author fails locally instead of in an unrelated red.

Master switch `JARVIS_REPL_VERB_CAGE_ENABLED`, default `true`.

## Verification

Live, against the real spine and a GLS-shaped source:

```
⏺ why o-1  op-live-1  · IN FLIGHT
  ⎿ TRIGGER   what woke it
      o-1  TodoScanner fired on repair_engine.py
  ⎿ CONTEXT   what it knew
      n-1  the retry path has no caller
  ⎿ LOGIC     how it reasoned
      IN FLIGHT — currently running
      t-1  get_callers(_retry) -> 0
  ⎿ ACTION    what it did
      d-1  remove dead retry guard
```

- 40 tests `test_why_engine` (+13 for the binding) · 17 `test_repl_verb_cage` — green.
- Targeted sweep of 2327 tests: **zero new failures** vs a clean-HEAD worktree baseline, and **two baseline reds** in `test_verb_description_arbitration` now green.
- The `test_reachability_entry_points` orphan delta is gitignored `* 2.py` iCloud duplicates in the working tree, absent from HEAD — the audit scans the filesystem, not git.
- Pre-existing reds in `test_governed_loop_startup` (GLS re-entrancy) reproduce unchanged at HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds `/why` to live op state and auto-mounts REPL verbs via a naming cage. Previously `/why` and `/reach` were importable but untypeable, and `/why` could not answer for in-flight ops; now both are typeable and `/why` joins live and disk state deterministically.

- Binds the `/why` engine by dependency injection in `GovernedLoopService`: sets a weak live-source reader via `why_engine.set_live_source`, releases it during both `stop()` and partial teardown, and snapshots the registry to avoid iteration races. On failure it degrades to disk-only instead of breaking the REPL.
- Introduces `repl_verb_cage`: any `governance/<verb>_repl.py` exporting `__verb_help__` and `dispatch_<verb>_command` is mounted as `/<verb>`. Discovery uses `ast` (no imports), dispatch imports only the named module, and the cage runs after explicit handlers and before the typo suggestion. The palette merges cage verbs at lowest precedence.
- Adjusts `serpent_flow` to call the cage and `repl_completion.unified_registry` to include cage verbs. Refines `reach_repl` help text to survive the palette arbiter. Updates PRD docs (§27.5.6). Adds focused tests for `/why` and the cage.

- Review and rollout
  - New env switch: `JARVIS_REPL_VERB_CAGE_ENABLED` (default true). Turning it off restores legacy mounting.
  - Failure semantics: the cage returns None for unclaimed verbs (typo handler still runs) and a refusal message for load failures; `/why` reports “IN FLIGHT” when reading live state and “PARTIAL” when eviction or log loss truncates records.
  - Migration: to add a new verb, create `governance/<verb>_repl.py` with `__verb_help__ = { "<verb>": "..." }` and `dispatch_<verb>_command(line)`; no REPL ladder changes are required.

<sup>Written for commit 8d3e227ee14d3817d79a657fca5bc710e7b77751. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

