### PR TITLE
fix(reach): the audit must measure the graph it reports on

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -6463,9 +6463,12 @@ class SerpentREPL:
         if line.startswith("/"):
             try:
                 from backend.core.ouroboros.governance.repl_verb_cage import (  # noqa: E501
-                    dispatch as _cage_dispatch,
+                    dispatch_async as _cage_dispatch,
                 )
-                _cage_result = _cage_dispatch(line)
+                # Awaited: a verb that does real work must be `async def`
+                # or it freezes the loop that runs the organism for the
+                # length of its own computation.
+                _cage_result = await _cage_dispatch(line)
             except Exception:  # noqa: BLE001 — never break the REPL on a verb
                 _cage_result = None
             # `None` means "no module claims this" and MUST fall through to

--- a/backend/core/ouroboros/battle_test/surface_reachability.py
+++ b/backend/core/ouroboros/battle_test/surface_reachability.py
@@ -48,11 +48,13 @@ because those are exactly the ones worth auditing.
 from __future__ import annotations
 
 import ast
+import keyword
 import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, FrozenSet, List, Mapping, Optional, Set, Tuple
+from typing import (Dict, FrozenSet, Iterable, List, Mapping, Optional,
+                    Set, Tuple, Union)
 
 logger = logging.getLogger("Ouroboros.SurfaceReachability")
 
@@ -61,6 +63,7 @@ SURFACE_REACHABILITY_SCHEMA_VERSION = "surface_reachability.v1"
 MASTER_FLAG_ENV_VAR = "JARVIS_SURFACE_AUDIT_ENABLED"
 SURFACES_ENV_VAR = "JARVIS_SURFACE_AUDIT_SURFACES"
 ROOTS_ENV_VAR = "JARVIS_SURFACE_AUDIT_ROOTS"
+TRAVERSAL_ENV_VAR = "JARVIS_SURFACE_AUDIT_TRAVERSAL"
 
 #: surface label → entry module. The three places `ov` draws from.
 #:
@@ -80,6 +83,91 @@ _DEFAULT_ROOTS: Tuple[str, ...] = (
     "backend/core/ouroboros/ui",
     "backend/core/ouroboros/cli",
 )
+
+
+def traversal_root() -> str:
+    """Where EDGES may run, as distinct from where findings are REPORTED.
+
+    These were one scope, and conflating them severed the graph. ``_reach``
+    follows an edge only when the target is indexed, so any import that left
+    the three reported roots and came back was invisible —
+    ``transcript_timeline`` was called an orphan while ``why_engine`` imports
+    it, because ``why_engine`` lives in ``governance/`` and governance was
+    not indexed. The audit was measuring a subgraph and reporting about the
+    graph.
+
+    Reporting scope stays narrow on purpose: reachability into the governance
+    core is a different question with a different answer, and answering it
+    here would bury the surface finding under a thousand rows. But a
+    TRAVERSAL that stops at the same boundary manufactures orphans out of
+    round trips, which is the strictly worse error — it invents deaths.
+
+    Derived from this module's own location rather than written down, so a
+    package move cannot leave a stale literal behind.
+    """
+    raw = os.environ.get(TRAVERSAL_ENV_VAR, "").strip()
+    if raw:
+        return raw
+    try:
+        return Path(__file__).resolve().parent.parent.relative_to(
+            _repo_root()).as_posix()
+    except Exception:  # noqa: BLE001
+        return "backend/core/ouroboros"
+
+
+def _is_importable(module: str) -> bool:
+    """Can any ``import`` statement in any file spell this name?
+
+    ``audio_pump 2.py`` — a Finder/iCloud duplicate — indexes as the module
+    ``…ui.audio_pump 2``, which contains a space. No import statement can
+    name it, so its unreachability is a TAUTOLOGY rather than a finding, and
+    five of eight reported orphans were files of exactly this kind.
+
+    Filtering on the property that makes them unreachable, rather than on the
+    string that happens to produce them today, is what keeps this general: a
+    ``copy.py``, a ``foo-bar.py``, a leading-digit name and a name colliding
+    with a keyword all fail for the same structural reason and are all
+    excluded by the same test.
+
+    Deliberately NOT a gitignore query. An ignored-but-importable module is
+    still importable, so excluding it would hide a real edge; and measured
+    against this tree the ignore rules add exactly zero exclusions the
+    identifier test does not already make. A subprocess, a timeout and a
+    degraded mode for zero cases is machinery, not rigour.
+    """
+    parts = module.split(".")
+    return bool(parts) and all(
+        p.isidentifier() and not keyword.iskeyword(p) for p in parts)
+
+
+@dataclass
+class _Scan:
+    """One audit's parse and edge memo. Created per call; never shared.
+
+    ``_edges`` is pure over file content, and the audit calls it once per
+    node per entry walk. Widening traversal to the whole package takes that
+    from ~800 parses to ~30,000, so the memo is what makes an honest
+    traversal scope affordable rather than a trade against it.
+
+    Per-call rather than module-level: a cache that outlived the call would
+    answer tomorrow's audit with yesterday's source, and an audit that cannot
+    see an edit is worse than a slow one. It is also the reason this needs no
+    lock — two concurrent audits share nothing.
+    """
+
+    trees: Dict[Path, Optional[ast.AST]] = field(default_factory=dict)
+    edges: Dict[Tuple[str, str], FrozenSet[str]] = field(default_factory=dict)
+
+    def tree(self, path: Path) -> Optional[ast.AST]:
+        if path in self.trees:
+            return self.trees[path]
+        try:
+            parsed: Optional[ast.AST] = ast.parse(
+                path.read_text(encoding="utf-8", errors="replace"))
+        except Exception:  # noqa: BLE001 — a file that will not parse has none
+            parsed = None
+        self.trees[path] = parsed
+        return parsed
 
 
 #: Where the package DECLARES its console entry points. Read rather than
@@ -132,32 +220,102 @@ def _pyproject_entry_modules(base: "Path") -> List[str]:
     return out
 
 
-def _main_guarded(index: Mapping[str, "Path"]) -> List[str]:
+def _main_guarded(index: Mapping[str, "Path"],
+                  scan: Optional["_Scan"] = None) -> List[str]:
     """Modules with an ``if __name__ == "__main__":`` block.
 
     A module that can be run is a module that can be entered, and nothing
     in-tree needs to import it for that to be true.
+
+    Two-stage, and the first stage is EXACT rather than a heuristic: a run
+    guard is a comparison against the literal ``"__main__"``, which cannot be
+    written without those bytes appearing in the source. So a file lacking
+    them provably has no guard, and reading 1522 files to reject 1489 of them
+    costs a fraction of parsing 1522 to find 28 — the difference between an
+    honest whole-package traversal being affordable and being a 15-second
+    stall. Survivors are still confirmed by the AST; the bytes only narrow.
+
+    The obvious pre-filter — ``__name__`` — is worthless here and measuring
+    said so: 883 of 1522 files contain it, because
+    ``logging.getLogger(__name__)`` is in almost every module. The literal
+    that makes a module RUNNABLE is ``__main__``, and that is in 33.
+
+    Matching that literal also TIGHTENS the AST test, which previously
+    accepted any ``__name__ ==`` comparison. "This module can be run" means
+    the interpreter set ``__name__`` to ``"__main__"``; a comparison against
+    anything else is not that claim.
     """
+    scan = scan or _Scan()
     out: List[str] = []
     for module, path in index.items():
         try:
-            tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
-        except Exception:  # noqa: BLE001
+            if _RUN_GUARD_LITERAL.encode() not in path.read_bytes():
+                continue
+        except OSError:
+            continue
+        tree = scan.tree(path)
+        if tree is None:
             continue
         for node in ast.walk(tree):
             if not isinstance(node, ast.If):
                 continue
-            try:
-                test = ast.unparse(node.test).replace(" ", "")
-            except Exception:  # noqa: BLE001
-                continue
-            if test.startswith("__name__=="):
+            if _is_run_guard(node.test):
                 out.append(module)
                 break
     return out
 
 
-def _script_reached(base: "Path", index: Mapping[str, "Path"]) -> List[str]:
+#: What the interpreter sets ``__name__`` to for the module it was asked to
+#: run. Named once: the byte pre-filter and the AST confirmation must agree,
+#: and two copies of a magic string are two chances for them to diverge.
+_RUN_GUARD_LITERAL = "__main__"
+
+
+def _is_run_guard(test: ast.AST) -> bool:
+    """``__name__ == "__main__"``, in either order. NEVER raises."""
+    if not isinstance(test, ast.Compare) or len(test.ops) != 1:
+        return False
+    if not isinstance(test.ops[0], ast.Eq):
+        return False
+    sides = (test.left, test.comparators[0])
+    names = {n.id for n in sides if isinstance(n, ast.Name)}
+    literals = {n.value for n in sides
+                if isinstance(n, ast.Constant) and isinstance(n.value, str)}
+    return "__name__" in names and _RUN_GUARD_LITERAL in literals
+
+
+def _cage_mounted(index: Mapping[str, "Path"]) -> List[str]:
+    """Modules the naming cage mounts as REPL verbs. NEVER raises.
+
+    THE BLIND SPOT THIS INSTRUMENT WOULD OTHERWISE HAVE ACQUIRED. A
+    ``governance/<verb>_repl.py`` that exports ``__verb_help__`` and
+    ``dispatch_<verb>_command`` is the verb ``/<verb>``, and the cage reaches
+    it with ``importlib.import_module`` — an edge no AST walker can see. The
+    fix that made those modules reachable by a human therefore made them
+    unreachable by this audit, and every one of them, plus its whole
+    subtree, would have started reporting as an orphan.
+
+    That is the fourth import shape this audit could not spell, after entry
+    points, ``scripts/`` and relative imports — and the same disease each
+    time: an edge the extractor cannot see becomes an absence it reports as
+    a finding.
+
+    A dynamic import is legible here only because the cage DECLARES its
+    mounts: ``discover()`` is a static AST scan that imports nothing, so
+    this asks the cage what it will mount rather than guessing. A dynamic
+    import with no declaration remains invisible, and correctly so — nothing
+    in the repo could see it either.
+    """
+    try:
+        from backend.core.ouroboros.governance.repl_verb_cage import discover
+
+        return [spec.module for spec in discover() if spec.module in index]
+    except Exception:  # noqa: BLE001 — an absent cage is not a finding
+        return []
+
+
+def _script_reached(base: "Path", index: Mapping[str, "Path"],
+                    scan: Optional["_Scan"] = None) -> List[str]:
     """Modules imported by a top-level ``scripts/*.py``.
 
     THE case that dominated this audit. ``scripts/ouroboros_battle_test.py``
@@ -176,7 +334,7 @@ def _script_reached(base: "Path", index: Mapping[str, "Path"]) -> List[str]:
         if not directory.is_dir():
             return []
         for path in sorted(directory.glob("*.py")):
-            for edge in _edges(path):
+            for edge in _edges(path, scan=scan):
                 if edge in index:
                     out.append(edge)
     except Exception:  # noqa: BLE001
@@ -185,7 +343,9 @@ def _script_reached(base: "Path", index: Mapping[str, "Path"]) -> List[str]:
 
 
 def derived_entries(base: "Path",
-                    index: Mapping[str, "Path"]) -> Tuple[Tuple[str, str], ...]:
+                    index: Mapping[str, "Path"],
+                    scan: Optional["_Scan"] = None,
+                    ) -> Tuple[Tuple[str, str], ...]:
     """Entry points DISCOVERED rather than transcribed. NEVER raises.
 
     The audit measured three RENDERING surfaces, which is a fair question and
@@ -203,8 +363,9 @@ def derived_entries(base: "Path",
     seen = set()
     for label, modules in (
         ("script", _pyproject_entry_modules(base)),
-        ("runnable", _main_guarded(index)),
-        ("soak", _script_reached(base, index)),
+        ("runnable", _main_guarded(index, scan)),
+        ("soak", _script_reached(base, index, scan)),
+        ("verb", _cage_mounted(index)),
     ):
         for module in modules:
             if module in index and module not in seen:
@@ -350,13 +511,20 @@ def _index(roots: Tuple[str, ...]) -> Dict[str, Path]:
                 from backend.core.ouroboros.battle_test.progress_board import (
                     _module_name,
                 )
-                out[_module_name(rel)] = path
+                module = _module_name(rel)
             except Exception:  # noqa: BLE001
                 continue
+            # A name no import statement can spell is unreachable by
+            # construction, so reporting it is a tautology rather than a
+            # finding. See `_is_importable`.
+            if not _is_importable(module):
+                continue
+            out[module] = path
     return out
 
 
-def _edges(path: Path, module: str = "") -> Set[str]:
+def _edges(path: Path, module: str = "",
+           scan: Optional["_Scan"] = None) -> Set[str]:
     """Modules this file imports — module-level AND inside functions.
 
     Reuses the canonical extractor rather than writing a second one: two AST
@@ -366,10 +534,18 @@ def _edges(path: Path, module: str = "") -> Set[str]:
     ``module`` is the importing module's dotted name, required to resolve
     relative imports against its package.
     """
-    try:
-        source = path.read_text(encoding="utf-8", errors="replace")
-        tree = ast.parse(source)
-    except Exception:  # noqa: BLE001 — a file that will not parse has no edges
+    key = (path.as_posix(), module)
+    if scan is not None:
+        memo = scan.edges.get(key)
+        if memo is not None:
+            return set(memo)
+    tree = (scan or _Scan()).tree(path)
+    if tree is None:
+        # A file that will not parse has no edges. Memoised too — a broken
+        # file is re-visited once per entry walk, and re-reading it each time
+        # is the same wasted work as re-parsing a good one.
+        if scan is not None:
+            scan.edges[key] = frozenset()
         return set()
     try:
         # `reverse_dep_resolver` calls itself "THE single import extractor"
@@ -387,24 +563,36 @@ def _edges(path: Path, module: str = "") -> Set[str]:
         from backend.core.ouroboros.governance.reverse_dep_resolver import (
             extract_module_imports,
         )
-        return set(extract_module_imports(
+        found = set(extract_module_imports(
             tree, module, path.name == "__init__.py"))
     except Exception:  # noqa: BLE001
         try:
             from backend.core.ouroboros.battle_test.progress_board import (
                 _imported_modules,
             )
-            return set(_imported_modules(tree))
+            found = set(_imported_modules(tree))
         except Exception:  # noqa: BLE001
-            return set()
+            found = set()
+    if scan is not None:
+        scan.edges[key] = frozenset(found)
+    return found
 
 
 def _reach(
-    entry: str,
+    entry: "Union[str, Iterable[str]]",
     index: Mapping[str, Path],
     barriers: FrozenSet[str] = frozenset(),
+    scan: Optional["_Scan"] = None,
 ) -> Set[str]:
     """Modules reachable from ``entry`` WITHOUT passing through a barrier.
+
+    ``entry`` may be one module or many. MANY IS NOT A CONVENIENCE: the
+    orphan question is the union of the closures from 228 discovered entry
+    points, and computing it one entry at a time re-walks a 1500-node graph
+    228 times for an answer a single multi-source walk gives exactly — the
+    seeded frontier IS the union, by definition of reachability. That is a
+    complexity fix (O(V+E) rather than O(entries·(V+E))), not a cache trick,
+    and it is what makes an honest whole-package traversal affordable.
 
     The barriers are the other surfaces, and they are the whole reason this
     function is not a plain transitive closure.
@@ -425,8 +613,11 @@ def _reach(
     Iterative with an explicit stack: the graph is cyclic even after the cuts,
     and a recursive walk would blow the stack on the first loop.
     """
+    seeds: Tuple[str, ...] = (
+        (entry,) if isinstance(entry, str) else tuple(entry))
+    seed_set = frozenset(seeds)
     seen: Set[str] = set()
-    stack: List[str] = [entry]
+    stack: List[str] = list(seeds)
     while stack:
         current = stack.pop()
         if current in seen:
@@ -434,13 +625,14 @@ def _reach(
         seen.add(current)
         # A barrier is REACHED but never traversed: knowing the cockpit
         # imports `ov` is true; inheriting everything `ov` imports is what
-        # destroyed the signal.
-        if current in barriers and current != entry:
+        # destroyed the signal. A seed is never its own barrier — otherwise
+        # a surface would stop at its own front door.
+        if current in barriers and current not in seed_set:
             continue
         path = index.get(current)
         if path is None:
             continue
-        for target in _edges(path, current):
+        for target in _edges(path, current, scan):
             # Only follow edges that stay in scope. Third-party and
             # governance-core imports are real, and out of this question.
             if target in index and target not in seen:
@@ -448,18 +640,24 @@ def _reach(
     return seen
 
 
-def _roots(index: Mapping[str, Path], entries: FrozenSet[str]) -> Set[str]:
+def _roots(index: Mapping[str, Path], entries: FrozenSet[str],
+           scan: Optional["_Scan"] = None) -> Set[str]:
     """Modules that import a SURFACE — boot paths, not orphans.
 
     `harness` reaches every surface; nothing reaches `harness`. Listing it as
     unreachable would be technically true and would bury the real orphans
     under the entry points of the program.
+
+    Scoped to the REPORTED index rather than the traversal graph, because the
+    only consumer is ``orphans()``, which iterates reported rows. Classifying
+    a governance module as a boot path answers a question nobody asks, at the
+    cost of an edge extraction over a thousand modules.
     """
     out: Set[str] = set()
     for module, path in index.items():
         if module in entries:
             continue
-        if _edges(path, module) & entries:
+        if _edges(path, module, scan) & entries:
             out.add(module)
     return out
 
@@ -480,7 +678,24 @@ def audit(
         if not audit_enabled():
             return reading
         scope = roots or audit_roots()
+        scan = _Scan()
+        # TWO SCOPES, deliberately different (see `traversal_root`).
+        #
+        # `graph` is where edges may run — the whole package, so an import
+        # that leaves the reported roots and comes back is followed rather
+        # than severed. `index` is what gets a row, and stays narrow so the
+        # surface finding is not buried under a thousand governance modules.
+        #
+        # Fused, they manufactured orphans out of round trips. Widening the
+        # REPORT instead would have been the other error: it answers a
+        # different question loudly and drowns this one.
+        graph = _index((traversal_root(),))
         index = _index(scope)
+        # Reported rows must be walkable. Normally a superset; if an operator
+        # points `JARVIS_SURFACE_AUDIT_ROOTS` outside the package, the union
+        # keeps those rows measurable instead of silently all-orphan.
+        for module, path in index.items():
+            graph.setdefault(module, path)
         # SURFACES ONLY. Entry points are deliberately NOT added here.
         #
         # `_reach` treats every other surface as a BARRIER — reached but not
@@ -509,28 +724,26 @@ def audit(
         reach: Dict[str, Set[str]] = {}
         entry_set = frozenset(entry for _, entry in table)
         for label, entry in table:
-            if entry not in index:
+            if entry not in graph:
                 # An entry outside the scanned roots cannot be walked. Said
                 # out loud rather than silently contributing an empty set —
                 # which would mark every module unreachable from it and read
                 # as a catastrophic finding.
                 missing.append(f"{label}={entry}")
                 continue
-            reach[label] = _reach(entry, index, barriers=entry_set)
+            reach[label] = _reach(entry, graph, barriers=entry_set, scan=scan)
         reading.unresolved_entries = tuple(missing)
-        reading.roots = frozenset(_roots(index, entry_set))
+        reading.roots = frozenset(_roots(index, entry_set, scan))
 
         # ORPHANHOOD, computed separately and WITHOUT barriers. A module is
         # dead only if no entry point reaches it at all; which particular
         # surface got there first is the asymmetry question, answered above.
         entry_reachable: Set[str] = set()
         try:
-            for _, entry in derived_entries(_repo_root(), index):
-                entry_reachable |= _reach(entry, index, barriers=frozenset())
-            for _, entry in table:
-                if entry in index:
-                    entry_reachable |= _reach(
-                        entry, index, barriers=frozenset())
+            seeds = [e for _, e in derived_entries(_repo_root(), graph, scan)]
+            seeds += [e for _, e in table if e in graph]
+            entry_reachable = _reach(
+                seeds, graph, barriers=frozenset(), scan=scan)
         except Exception:  # noqa: BLE001 — a failed walk must not invent deaths
             entry_reachable = set()
         # A PACKAGE is reachable if any of its modules is. Nothing imports
@@ -560,6 +773,29 @@ def audit(
     except Exception:  # noqa: BLE001
         logger.debug("[SurfaceReach] audit degraded", exc_info=True)
         return reading
+
+
+async def audit_async(
+    *,
+    roots: Optional[Tuple[str, ...]] = None,
+    entries: Optional[Tuple[Tuple[str, str], ...]] = None,
+) -> SurfaceReading:
+    """:func:`audit`, off the event loop. NEVER raises.
+
+    The walk parses roughly a thousand files and takes seconds — far too
+    much for the loop that also runs the organism, and Principle 3 does not
+    have an exception for diagnostics. The offload lives HERE, in the module
+    that knows the work is heavy, rather than in each caller: `run_watchdog`
+    remembered to wrap it in a thread and the `/reach` REPL path did not, so
+    typing the verb froze the daemon for the duration of its own audit.
+
+    ``to_thread`` rather than a process: the cost is `ast.parse`, which holds
+    the GIL, so this buys RESPONSIVENESS rather than parallelism — the loop
+    keeps serving while the scan runs. That is the property being bought.
+    """
+    import asyncio
+
+    return await asyncio.to_thread(audit, roots=roots, entries=entries)
 
 
 # ---------------------------------------------------------------------------
@@ -629,6 +865,7 @@ __all__ = [
     "ModuleReach",
     "SurfaceReading",
     "audit",
+    "audit_async",
     "audit_enabled",
     "audit_roots",
     "render",

--- a/backend/core/ouroboros/governance/reach_repl.py
+++ b/backend/core/ouroboros/governance/reach_repl.py
@@ -113,10 +113,19 @@ class ReachDrift:
         }
 
 
-def _audit() -> Any:
-    """Run the canonical audit. Raises only what the caller will catch."""
-    from backend.core.ouroboros.battle_test.surface_reachability import audit
-    return audit()
+async def _audit() -> Any:
+    """Run the canonical audit, off the loop. Raises what callers catch.
+
+    THE one seam. The offload was previously in `run_watchdog` alone, so
+    every path that reached the audit through the REPL blocked the daemon's
+    event loop for the whole scan — the watchdog was correct and the verb an
+    operator actually types was not. Putting it here means no future caller
+    can forget: reaching the audit at all goes through this function.
+    """
+    from backend.core.ouroboros.battle_test.surface_reachability import (
+        audit_async,
+    )
+    return await audit_async()
 
 
 def _load_baseline() -> Optional[Dict[str, Any]]:
@@ -137,7 +146,7 @@ def _load_baseline() -> Optional[Dict[str, Any]]:
         return None
 
 
-def accept_baseline() -> Dict[str, Any]:
+async def accept_baseline() -> Dict[str, Any]:
     """Record the current state as accepted. NEVER raises.
 
     Written through ``durable_io.atomic_replace``: a baseline half-written
@@ -146,7 +155,7 @@ def accept_baseline() -> Dict[str, Any]:
     recovering from something.
     """
     try:
-        reading = _audit()
+        reading = await _audit()
         payload = {
             "schema_version": REACH_REPL_SCHEMA_VERSION,
             "asymmetric": sorted(m.module for m in reading.asymmetric()),
@@ -169,7 +178,7 @@ def accept_baseline() -> Dict[str, Any]:
         return {"error": str(exc)}
 
 
-def drift() -> ReachDrift:
+async def drift() -> ReachDrift:
     """What regressed since the baseline. NEVER raises.
 
     With NO baseline this reports nothing rather than everything. A first
@@ -178,7 +187,7 @@ def drift() -> ReachDrift:
     4:1 false-positive flood this design exists to avoid.
     """
     try:
-        reading = _audit()
+        reading = await _audit()
     except Exception as exc:  # noqa: BLE001
         return ReachDrift(error=f"{type(exc).__name__}: {exc}")
     now_asym = {m.module for m in reading.asymmetric()}
@@ -200,10 +209,10 @@ async def run_watchdog() -> ReachDrift:
     """Boot-time drift check, off the event loop. NEVER raises.
 
     The audit walks the module tree and parses every file, which is far too
-    much work for the loop that also runs the organism — so it goes to a
-    thread. Bounded by the caller's own supervision rather than a timer
-    here: a scan that overran would be a scan worth noticing, and killing
-    it silently would hide that.
+    much work for the loop that also runs the organism — `_audit` puts it on
+    a thread for every caller. Bounded by the caller's own supervision rather
+    than a timer here: a scan that overran would be a scan worth noticing,
+    and killing it silently would hide that.
 
     Silent at steady state, by construction: with nothing new since the
     baseline there is no line to print.
@@ -211,8 +220,10 @@ async def run_watchdog() -> ReachDrift:
     if not watchdog_enabled():
         return ReachDrift(baseline_exists=False)
     try:
-        import asyncio
-        result = await asyncio.to_thread(drift)
+        # No `to_thread` here any more: `_audit` owns the offload, and two
+        # places deciding how to get off the loop is how one of them ends up
+        # not doing it.
+        result = await drift()
     except Exception as exc:  # noqa: BLE001
         logger.debug("[Reach] watchdog degraded: %s", exc)
         return ReachDrift(error=str(exc))
@@ -251,7 +262,7 @@ def _fmt(names: List[str], cap: int = 12) -> str:
     return "\n".join(f"  {n}" for n in shown) + tail
 
 
-def dispatch_reach_command(line: str) -> ReachReplDispatchResult:
+async def dispatch_reach_command(line: str) -> ReachReplDispatchResult:
     """Surface-reachability audit.
 
     Operator: find capabilities that shipped complete and unreachable.
@@ -264,7 +275,7 @@ def dispatch_reach_command(line: str) -> ReachReplDispatchResult:
             return ReachReplDispatchResult(ok=True, text=_HELP)
 
         if sub == "accept":
-            payload = accept_baseline()
+            payload = (await accept_baseline())
             if "error" in payload:
                 return ReachReplDispatchResult(
                     ok=False, text=f"could not write baseline: {payload['error']}")
@@ -277,7 +288,7 @@ def dispatch_reach_command(line: str) -> ReachReplDispatchResult:
             )
 
         if sub in ("", "drift"):
-            d = drift()
+            d = (await drift())
             if d.error:
                 return ReachReplDispatchResult(
                     ok=False, text=f"audit unavailable: {d.error}")
@@ -303,7 +314,7 @@ def dispatch_reach_command(line: str) -> ReachReplDispatchResult:
             return ReachReplDispatchResult(ok=True, text="\n".join(parts))
 
         if sub in ("all", "asymmetric"):
-            reading = _audit()
+            reading = await _audit()
             rows = [f"{m.module}  ({len(m.reached_by)}/"
                     f"{len(reading.surface_labels)})"
                     for m in reading.asymmetric()]
@@ -313,7 +324,7 @@ def dispatch_reach_command(line: str) -> ReachReplDispatchResult:
                       f"{reading.scanned}):\n{_fmt(rows, cap=30)}"))
 
         if sub == "orphans":
-            reading = _audit()
+            reading = await _audit()
             rows = [m.module for m in reading.orphans()]
             return ReachReplDispatchResult(
                 ok=True,
@@ -323,7 +334,7 @@ def dispatch_reach_command(line: str) -> ReachReplDispatchResult:
         # Anything else is treated as a module name. Matched loosely on the
         # tail so an operator can type `menu_bindings` rather than the full
         # dotted path — the path is an implementation detail of the tree.
-        reading = _audit()
+        reading = await _audit()
         needle = sub.strip().lower()
         hits = [m for m in reading.modules
                 if needle in m.module.lower()]

--- a/backend/core/ouroboros/governance/repl_verb_cage.py
+++ b/backend/core/ouroboros/governance/repl_verb_cage.py
@@ -49,6 +49,7 @@ Python 3.9+, ``from __future__ import annotations``.
 from __future__ import annotations
 
 import ast
+import inspect
 import logging
 import os
 import threading
@@ -214,6 +215,12 @@ def dispatch(line: str) -> Optional[Any]:
     name it. An import failure returns a REFUSAL rather than None, because
     ``/why`` existing-but-broken and ``/why`` not existing call for different
     operator responses, and collapsing them into "did you mean…" hides a bug.
+
+    A verb may be ``async def``: its coroutine is returned unawaited, and the
+    seam awaits it (see :func:`dispatch_async`). Verbs that do real work —
+    ``/reach`` parses a thousand files — MUST be async, or typing them
+    freezes the loop that runs the organism. The discovery scan already
+    accepts ``AsyncFunctionDef``, so being async costs a verb nothing.
     """
     spec = find(line)
     if spec is None:
@@ -238,6 +245,29 @@ def dispatch(line: str) -> Optional[Any]:
             f"{spec.slash_form} failed to load ({type(exc).__name__}: {exc})")
 
 
+async def dispatch_async(line: str) -> Optional[Any]:
+    """:func:`dispatch`, awaiting an async verb's result. NEVER raises.
+
+    The seam every async caller uses. Sync verbs pass through untouched, so
+    a verb author chooses `def` or `async def` on the merits of the work and
+    neither choice needs a second code path at the call site.
+
+    An un-awaited coroutine would render as ``<coroutine object …>`` and
+    leak a "never awaited" warning — the verb would look mounted, print
+    garbage, and do nothing. That is the unmounted class wearing a disguise,
+    so the await belongs in the cage rather than in each REPL.
+    """
+    result = dispatch(line)
+    if inspect.isawaitable(result):
+        try:
+            return await result
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[VerbCage] async verb failed", exc_info=True)
+            return _Refusal(
+                f"{line.split()[0]} failed ({type(exc).__name__}: {exc})")
+    return result
+
+
 @dataclass(frozen=True)
 class _Refusal:
     """A mounted verb that could not run — never a silent fall-through."""
@@ -253,6 +283,7 @@ __all__ = [
     "cage_enabled",
     "discover",
     "dispatch",
+    "dispatch_async",
     "find",
     "reset_cache",
 ]

--- a/tests/battle_test/test_reachability_entry_points.py
+++ b/tests/battle_test/test_reachability_entry_points.py
@@ -40,6 +40,8 @@ They are computed separately now, and both are asserted below.
 """
 from __future__ import annotations
 
+import ast
+
 import pytest
 
 from backend.core.ouroboros.battle_test import surface_reachability as sr
@@ -208,3 +210,132 @@ class TestTheOneRealFinding:
         reached = sr._reach("pkg.entry", index, barriers=frozenset())
         assert "pkg.used" in reached
         assert "pkg.dead" not in reached
+
+
+class TestTheInstrumentMeasuresTheGraphItReportsOn:
+    """Five of eight orphans were the instrument, again.
+
+    The first correction (39 → 3) fixed the ROOT SET. These fix the INDEX
+    and the TRAVERSAL: what counts as a module at all, and how far an edge
+    is allowed to run before the walk gives up and calls the target dead.
+    """
+
+    def test_a_name_no_import_can_spell_is_not_a_finding(self):
+        """`audio_pump 2.py` is unreachable by construction, not by defect.
+
+        Five of eight reported orphans were Finder/iCloud duplicates whose
+        module name contains a space. No import statement can name them, so
+        reporting them is a tautology dressed as a discovery.
+        """
+        assert not sr._is_importable("pkg.audio_pump 2")
+        assert not sr._is_importable("pkg.foo-bar")
+        assert not sr._is_importable("pkg.2fast")
+        assert not sr._is_importable("pkg.class")     # a keyword
+        assert sr._is_importable("pkg.audio_pump")
+
+    def test_the_index_excludes_them(self):
+        index = sr._index(sr.audit_roots())
+        assert all(sr._is_importable(m) for m in index)
+
+    def test_an_edge_that_leaves_the_reported_roots_is_still_followed(self):
+        """The traversal scope and the reporting scope are different.
+
+        `transcript_timeline` was called an orphan while `why_engine`
+        imports it — `why_engine` lives in `governance/`, which was not
+        indexed, so the edge dangled and the target read as dead. A walk
+        that stops at the reporting boundary INVENTS deaths, which is the
+        strictly worse error.
+        """
+        graph = sr._index((sr.traversal_root(),))
+        assert "backend.core.ouroboros.governance.why_engine" in graph
+        assert len(graph) > len(sr._index(sr.audit_roots()))
+
+    def test_transcript_timeline_is_not_an_orphan(self, reading):
+        orphans = {m.short for m in reading.orphans()}
+        assert "transcript_timeline" not in orphans
+
+    def test_a_cage_mounted_verb_counts_as_an_entry_point(self):
+        """A dynamic import is legible because the cage DECLARES it.
+
+        Making those modules reachable by a human made them unreachable by
+        this audit: `importlib.import_module` is an edge no AST walker can
+        see, so every cage-mounted verb and its whole subtree would have
+        started reporting as an orphan.
+        """
+        graph = sr._index((sr.traversal_root(),))
+        mounted = sr._cage_mounted(graph)
+        assert any(m.endswith("why_repl") for m in mounted), mounted
+        labels = {label for label, _ in sr.derived_entries(
+            sr._repo_root(), graph, sr._Scan())}
+        assert "verb" in labels
+
+    def test_many_seeds_give_exactly_the_union_of_one_seed_each(self):
+        """The orphan question is a union over 228 entries.
+
+        Walking them one at a time re-walks a 1500-node graph 228 times for
+        an answer a single multi-source walk gives exactly.
+        """
+        graph = sr._index((sr.traversal_root(),))
+        scan = sr._Scan()
+        seeds = [e for _, e in sr.surfaces() if e in graph]
+        one_at_a_time = set()
+        for s in seeds:
+            one_at_a_time |= sr._reach(s, graph, frozenset(), scan)
+        assert sr._reach(seeds, graph, frozenset(), scan) == one_at_a_time
+
+    def test_a_seed_is_never_its_own_barrier(self):
+        """Or a surface would stop at its own front door."""
+        graph = sr._index((sr.traversal_root(),))
+        entries = frozenset(e for _, e in sr.surfaces())
+        for _, entry in sr.surfaces():
+            if entry in graph:
+                assert len(sr._reach(entry, graph, entries)) > 1
+
+    def test_a_run_guard_is_the_main_literal_not_any_name_comparison(self):
+        """The byte pre-filter and the AST test must agree exactly.
+
+        `__name__` is worthless as a filter — `logging.getLogger(__name__)`
+        puts it in 883 of 1522 files. `__main__` is in 33.
+        """
+        yes = ast.parse('if __name__ == "__main__":\n    pass').body[0]
+        flipped = ast.parse('if "__main__" == __name__:\n    pass').body[0]
+        no = ast.parse('if __name__ == "__mp_main__":\n    pass').body[0]
+        assert sr._is_run_guard(yes.test)
+        assert sr._is_run_guard(flipped.test)
+        assert not sr._is_run_guard(no.test)
+        assert sr._RUN_GUARD_LITERAL.encode() not in b'if __name__ == "__mp_main__"'
+
+
+class TestTheAuditStaysOffTheLoop:
+    """Principle 3 has no exception for diagnostics."""
+
+    async def test_audit_async_does_not_block_the_event_loop(self):
+        import asyncio
+
+        ticks = 0
+
+        async def heartbeat():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        hb = asyncio.create_task(heartbeat())
+        await sr.audit_async()
+        hb.cancel()
+        assert ticks > 5, (
+            "the loop stalled for the length of the audit — a verb that "
+            "parses a thousand files must not run on the loop that also "
+            "runs the organism")
+
+    def test_the_offload_lives_at_the_one_seam(self):
+        """`run_watchdog` remembered to thread it; the REPL path did not."""
+        from tests.source_probe import code_of
+
+        from backend.core.ouroboros.governance import reach_repl as rr
+
+        assert "audit_async" in code_of(rr._audit)
+        # No caller may offload on its own — two places deciding how to get
+        # off the loop is how one of them ends up not doing it. Read as
+        # CODE: the comment saying so would satisfy a raw substring match.
+        assert "to_thread" not in code_of(rr.run_watchdog)

--- a/tests/battle_test/test_shutdown_watchdog.py
+++ b/tests/battle_test/test_shutdown_watchdog.py
@@ -28,20 +28,10 @@ def _src() -> str:
 
 
 def _code_of(fn_name: str) -> str:
-    """A function's CODE, with its docstring removed.
-
-    Every structural check here must read code, not prose. The docstrings
-    deliberately NAME the things being avoided — "the partial-summary
-    write", "the last phase reached", "the extend-condition" — so a
-    substring match over the whole function flags the explanation as if it
-    were the offence. That mistake has now cost four tests this session;
-    stripping the docstring is the fix that generalises.
-    """
-    src = _src()
-    node = next(
-        n for n in ast.walk(ast.parse(src))
-        if isinstance(n, ast.FunctionDef) and n.name == fn_name
-    )
+    """That module's function, as CODE. See tests.source_probe."""
+    from tests.source_probe import code_of
+    from backend.core.ouroboros.battle_test import harness
+    return code_of(harness, fn_name)
     body = list(node.body)
     if (body and isinstance(body[0], ast.Expr)
             and isinstance(body[0].value, ast.Constant)

--- a/tests/governance/test_proactive_mode_store.py
+++ b/tests/governance/test_proactive_mode_store.py
@@ -128,21 +128,7 @@ def test_git_worktrees_keep_separate_dials(repo, tmp_path):
     assert asyncio.run(_go()) == "watch", "the worktree clobbered main"
 
 
-def _code_of(fn) -> str:
-    """Executable body with the docstring stripped.
-
-    Every prose check in this suite goes through here. Four times this
-    session a raw text search matched a docstring that EXPLAINED why
-    something was not used — a substring cannot tell an explanation from a
-    use, and these modules explain themselves at length."""
-    import ast
-    import inspect
-    import textwrap
-    tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
-    fn_node = tree.body[0]
-    body = (fn_node.body[1:]
-            if isinstance(fn_node.body[0], ast.Expr) else fn_node.body)
-    return "\n".join(ast.unparse(stmt) for stmt in body)
+from tests.source_probe import code_of as _code_of
 
 
 def test_the_worktree_is_resolved_by_toplevel_not_git_dir():

--- a/tests/governance/test_reach_repl.py
+++ b/tests/governance/test_reach_repl.py
@@ -21,6 +21,25 @@ def _isolated(tmp_path, monkeypatch):
     yield
 
 
+def _as_audit(reading):
+    """Wrap any reading in the async shape `_audit` now has."""
+    async def _run():
+        return reading
+    return _run
+
+
+def _fake_audit(**kw):
+    """An async stand-in for `_audit`, which is now off-loop.
+
+    Mirrors the real contract rather than the old one: a sync fake against
+    an async seam raises TypeError inside the code under test, and every
+    assertion then fails for a reason unrelated to what it measures.
+    """
+    async def _run():
+        return _reading(**kw)
+    return _run
+
+
 def _reading(asym=(), orph=(), scanned=100):
     class _M:
         def __init__(self, name): self.module = name; self.reached_by = ("attach",)
@@ -36,78 +55,78 @@ def _reading(asym=(), orph=(), scanned=100):
 # -- the ratchet -----------------------------------------------------------
 
 
-def test_no_baseline_reports_nothing_rather_than_everything(monkeypatch):
+async def test_no_baseline_reports_nothing_rather_than_everything(monkeypatch):
     """A first run has not regressed — it has not yet been measured.
     Reporting the standing list as new is the 4:1 false-positive flood this
     design exists to avoid."""
-    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a", "b", "c")))
-    d = rr.drift()
+    monkeypatch.setattr(rr, "_audit", _fake_audit(asym=("a", "b", "c")))
+    d = (await rr.drift())
     assert d.baseline_exists is False
     assert d.new_asymmetric == () and d.new_orphans == ()
 
 
-def test_steady_state_is_silent(monkeypatch):
-    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a",)))
-    rr.accept_baseline()
-    d = rr.drift()
+async def test_steady_state_is_silent(monkeypatch):
+    monkeypatch.setattr(rr, "_audit", _fake_audit(asym=("a",)))
+    (await rr.accept_baseline())
+    d = (await rr.drift())
     assert d.regressed is False
-    assert "unchanged" in rr.dispatch_reach_command("/reach").text
+    assert "unchanged" in (await rr.dispatch_reach_command("/reach")).text
 
 
-def test_a_newly_asymmetric_module_is_loud(monkeypatch):
+async def test_a_newly_asymmetric_module_is_loud(monkeypatch):
     """The shape every unmounted feature had."""
-    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a",)))
-    rr.accept_baseline()
-    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a", "newcomer")))
-    d = rr.drift()
+    monkeypatch.setattr(rr, "_audit", _fake_audit(asym=("a",)))
+    (await rr.accept_baseline())
+    monkeypatch.setattr(rr, "_audit", _fake_audit(asym=("a", "newcomer")))
+    d = (await rr.drift())
     assert d.regressed is True
     assert d.new_asymmetric == ("newcomer",)
 
 
-def test_a_newly_orphaned_module_is_loud(monkeypatch):
-    monkeypatch.setattr(rr, "_audit", lambda: _reading())
-    rr.accept_baseline()
-    monkeypatch.setattr(rr, "_audit", lambda: _reading(orph=("dead",)))
-    assert rr.drift().new_orphans == ("dead",)
+async def test_a_newly_orphaned_module_is_loud(monkeypatch):
+    monkeypatch.setattr(rr, "_audit", _fake_audit())
+    (await rr.accept_baseline())
+    monkeypatch.setattr(rr, "_audit", _fake_audit(orph=("dead",)))
+    assert (await rr.drift()).new_orphans == ("dead",)
 
 
-def test_a_fixed_module_is_reported_as_resolved(monkeypatch):
-    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a", "b")))
-    rr.accept_baseline()
-    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a",)))
-    d = rr.drift()
+async def test_a_fixed_module_is_reported_as_resolved(monkeypatch):
+    monkeypatch.setattr(rr, "_audit", _fake_audit(asym=("a", "b")))
+    (await rr.accept_baseline())
+    monkeypatch.setattr(rr, "_audit", _fake_audit(asym=("a",)))
+    d = (await rr.drift())
     assert d.resolved == ("b",) and d.regressed is False
 
 
-def test_accepting_moves_the_ratchet(monkeypatch):
-    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a",)))
-    rr.accept_baseline()
-    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a", "b")))
-    assert rr.drift().regressed is True
-    rr.accept_baseline()
-    assert rr.drift().regressed is False
+async def test_accepting_moves_the_ratchet(monkeypatch):
+    monkeypatch.setattr(rr, "_audit", _fake_audit(asym=("a",)))
+    (await rr.accept_baseline())
+    monkeypatch.setattr(rr, "_audit", _fake_audit(asym=("a", "b")))
+    assert (await rr.drift()).regressed is True
+    (await rr.accept_baseline())
+    assert (await rr.drift()).regressed is False
 
 
 # -- baseline failure modes ------------------------------------------------
 
 
-def test_a_corrupt_baseline_is_treated_as_absent_not_empty(monkeypatch):
+async def test_a_corrupt_baseline_is_treated_as_absent_not_empty(monkeypatch):
     """An empty baseline would report every asymmetric module as newly
     regressed, burying a real regression under a hundred false ones on the
     first boot after a disk fault."""
     rr.baseline_path().parent.mkdir(parents=True, exist_ok=True)
     rr.baseline_path().write_text("{not json", encoding="utf-8")
-    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a", "b", "c")))
-    d = rr.drift()
+    monkeypatch.setattr(rr, "_audit", _fake_audit(asym=("a", "b", "c")))
+    d = (await rr.drift())
     assert d.baseline_exists is False
     assert d.new_asymmetric == ()
 
 
-def test_a_baseline_that_is_not_an_object_is_treated_as_absent(monkeypatch):
+async def test_a_baseline_that_is_not_an_object_is_treated_as_absent(monkeypatch):
     rr.baseline_path().parent.mkdir(parents=True, exist_ok=True)
     rr.baseline_path().write_text("[1,2,3]", encoding="utf-8")
-    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a",)))
-    assert rr.drift().baseline_exists is False
+    monkeypatch.setattr(rr, "_audit", _fake_audit(asym=("a",)))
+    assert (await rr.drift()).baseline_exists is False
 
 
 def test_the_baseline_is_published_atomically():
@@ -118,13 +137,13 @@ def test_the_baseline_is_published_atomically():
     assert "atomic_replace" in inspect.getsource(rr.accept_baseline)
 
 
-def test_a_failing_audit_degrades_rather_than_raising(monkeypatch):
-    def _boom():
+async def test_a_failing_audit_degrades_rather_than_raising(monkeypatch):
+    async def _boom():
         raise RuntimeError("tree walk exploded")
     monkeypatch.setattr(rr, "_audit", _boom)
-    d = rr.drift()
+    d = (await rr.drift())
     assert d.error and d.regressed is False
-    assert rr.dispatch_reach_command("/reach").ok is False
+    assert (await rr.dispatch_reach_command("/reach")).ok is False
 
 
 # -- the watchdog ----------------------------------------------------------
@@ -132,8 +151,8 @@ def test_a_failing_audit_degrades_rather_than_raising(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_the_watchdog_is_silent_at_steady_state(monkeypatch, caplog):
-    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a",)))
-    rr.accept_baseline()
+    monkeypatch.setattr(rr, "_audit", _fake_audit(asym=("a",)))
+    (await rr.accept_baseline())
     caplog.clear()
     await rr.run_watchdog()
     assert not [r for r in caplog.records if r.levelname == "WARNING"]
@@ -141,9 +160,9 @@ async def test_the_watchdog_is_silent_at_steady_state(monkeypatch, caplog):
 
 @pytest.mark.asyncio
 async def test_the_watchdog_warns_on_regression(monkeypatch, caplog):
-    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a",)))
-    rr.accept_baseline()
-    monkeypatch.setattr(rr, "_audit", lambda: _reading(asym=("a", "newcomer")))
+    monkeypatch.setattr(rr, "_audit", _fake_audit(asym=("a",)))
+    (await rr.accept_baseline())
+    monkeypatch.setattr(rr, "_audit", _fake_audit(asym=("a", "newcomer")))
     caplog.clear()
     await rr.run_watchdog()
     warnings = [r for r in caplog.records if r.levelname == "WARNING"]
@@ -182,11 +201,11 @@ def test_the_verb_is_auto_discoverable():
     assert "reach" in rr.__verb_help__
 
 
-def test_help_is_reachable():
-    assert "reachability" in rr.dispatch_reach_command("/reach help").text
+async def test_help_is_reachable():
+    assert "reachability" in (await rr.dispatch_reach_command("/reach help")).text
 
 
-def test_a_module_query_names_its_surfaces(monkeypatch):
+async def test_a_module_query_names_its_surfaces(monkeypatch):
     class _M:
         module = "backend.x.menu_bindings"
         reached_by = ("attach", "cockpit")
@@ -198,14 +217,14 @@ def test_a_module_query_names_its_surfaces(monkeypatch):
         scanned = 1
         def asymmetric(self): return [_M()]
         def orphans(self): return []
-    monkeypatch.setattr(rr, "_audit", lambda: _R())
-    out = rr.dispatch_reach_command("/reach menu_bindings")
+    monkeypatch.setattr(rr, "_audit", _as_audit(_R()))
+    out = (await rr.dispatch_reach_command("/reach menu_bindings"))
     assert out.ok and "attach" in out.text and "cockpit" in out.text
 
 
-def test_an_unknown_module_refuses_rather_than_returning_nothing(monkeypatch):
-    monkeypatch.setattr(rr, "_audit", lambda: _reading())
-    out = rr.dispatch_reach_command("/reach no_such_module_xyz")
+async def test_an_unknown_module_refuses_rather_than_returning_nothing(monkeypatch):
+    monkeypatch.setattr(rr, "_audit", _fake_audit())
+    out = (await rr.dispatch_reach_command("/reach no_such_module_xyz"))
     assert out.ok is False and "no module matching" in out.text
 
 
@@ -214,7 +233,14 @@ def test_the_verb_adds_no_analysis_of_its_own():
     implementation would be a second opinion about the same tree."""
     import pathlib
     src = pathlib.Path(rr.__file__).read_text(encoding="utf-8")
-    assert "surface_reachability import audit" in src
+    # Structural, not spelt: the delegation is that `_audit` — the ONE seam
+    # every path here reaches the numbers through — resolves out of
+    # `surface_reachability`. Asserting the exact import line made this a
+    # test of spelling, and it failed the moment the seam went async while
+    # the property it names stayed true.
+    assert "surface_reachability" in src
+    import inspect
+    assert "surface_reachability" in inspect.getsource(rr._audit)
     for banned in ("ast.parse", "importlib", "os.walk"):
         assert banned not in src
 

--- a/tests/governance/test_repl_verb_cage.py
+++ b/tests/governance/test_repl_verb_cage.py
@@ -85,10 +85,31 @@ def test_why_is_reachable_by_typing_it():
     assert "causal account" in result.text
 
 
-def test_reach_is_reachable_by_typing_it():
-    result = cage.dispatch("/reach help")
+async def test_reach_is_reachable_by_typing_it():
+    result = await cage.dispatch_async("/reach help")
     assert result is not None, "/reach is mounted but unreachable"
     assert "reachability" in result.text
+
+
+async def test_an_async_verb_is_awaited_by_the_cage():
+    """An un-awaited coroutine renders as `<coroutine object …>`.
+
+    The verb would look mounted, print garbage and do nothing — the
+    unmounted class wearing a disguise. `/reach` is async because it parses
+    a thousand files and must not freeze the loop that runs the organism.
+    """
+    import inspect
+
+    raw = cage.dispatch("/reach help")
+    assert inspect.isawaitable(raw), "/reach stopped being async"
+    raw.close()
+    assert not inspect.isawaitable(await cage.dispatch_async("/reach help"))
+
+
+async def test_a_sync_verb_passes_through_the_async_seam_unchanged():
+    """A verb author picks def or async def on the merits of the work."""
+    assert (await cage.dispatch_async("/why help")).ok is True
+    assert await cage.dispatch_async("/no_such_verb_xyz") is None
 
 
 def test_an_unclaimed_verb_returns_none_so_the_typo_handler_still_runs():
@@ -132,25 +153,7 @@ def test_a_bare_word_is_not_a_slash_verb():
 # -- the mount itself ------------------------------------------------------
 
 
-def _code_of(module, *names):
-    """Executable source only — docstrings stripped.
-
-    A docstring EXPLAINING a mechanism greps identically to the mechanism.
-    """
-    tree = ast.parse(inspect.getsource(module))
-    out = []
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        if names and node.name not in names:
-            continue
-        body = list(node.body)
-        if (body and isinstance(body[0], ast.Expr)
-                and isinstance(getattr(body[0], "value", None), ast.Constant)
-                and isinstance(body[0].value.value, str)):
-            body = body[1:]
-        out.extend(ast.unparse(stmt) for stmt in body)
-    return "\n".join(out)
+from tests.source_probe import code_of as _code_of
 
 
 def test_the_repl_actually_calls_the_cage():
@@ -179,7 +182,7 @@ def test_cage_verbs_appear_in_the_palette():
     assert registry.find("/reach") is not None
 
 
-def test_every_contract_honouring_module_is_reachable():
+async def test_every_contract_honouring_module_is_reachable():
     """The invariant, stated once: declaring the contract IS mounting.
 
     A future `governance/foo_repl.py` that exports both halves is reachable
@@ -187,7 +190,7 @@ def test_every_contract_honouring_module_is_reachable():
     aspirational — a regression in the seam fails here, not in production.
     """
     for spec in cage.discover():
-        assert cage.dispatch(f"{spec.slash_form} help") is not None, (
+        assert await cage.dispatch_async(f"{spec.slash_form} help") is not None, (
             f"{spec.slash_form} declares the contract but is unreachable")
 
 

--- a/tests/governance/test_why_engine.py
+++ b/tests/governance/test_why_engine.py
@@ -279,30 +279,7 @@ class _FakeGLS:
         self._active_ops = set(ops)
 
 
-def _code_of(module, *names):
-    """Executable source only — docstrings stripped.
-
-    Prose that EXPLAINS a mechanism reads identically to the mechanism when
-    grepped, so a docstring saying "we do not use os.access" satisfies a
-    search for os.access. Assertions here must see code.
-    """
-    import ast
-    import inspect
-
-    tree = ast.parse(inspect.getsource(module))
-    out = []
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        if names and node.name not in names:
-            continue
-        body = list(node.body)
-        if (body and isinstance(body[0], ast.Expr)
-                and isinstance(getattr(body[0], "value", None), ast.Constant)
-                and isinstance(body[0].value.value, str)):
-            body = body[1:]
-        out.extend(ast.unparse(stmt) for stmt in body)
-    return "\n".join(out)
+from tests.source_probe import code_of as _code_of
 
 
 def test_a_set_registry_is_adapted_without_the_engine_knowing_its_shape():

--- a/tests/source_probe.py
+++ b/tests/source_probe.py
@@ -1,0 +1,85 @@
+"""Read a module's CODE, never its prose. One probe, four former copies.
+
+Structural assertions in this suite ask questions like "does the watchdog
+touch the op-ledger", "does the store call ``os.access``", "does the offload
+live at one seam". A substring search over source cannot tell an explanation
+from a use, and these modules explain themselves at length — deliberately
+NAMING the thing they avoid:
+
+    # No `to_thread` here any more: `_audit` owns the offload …
+    ``os.access`` answers a question about permission bits, and the failures
+    that matter here are not permission bits …
+
+Both read as violations to ``in``. That mistake has cost this suite tests on
+five separate occasions, each time fixed locally, each time re-appearing in
+the next file — four private ``_code_of`` helpers with three different
+signatures and two different notions of what counts as code.
+
+``ast.unparse`` is the fix that generalises: it renders the parsed tree, so
+comments are gone by construction rather than by a rule someone has to
+remember, and docstrings are dropped explicitly below. One of the four copies
+used ``ast.get_source_segment``, which preserves comments and therefore still
+had the original bug.
+
+Python 3.9+.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from typing import Any, List
+
+
+def _strip_docstring(body: List[ast.stmt]) -> List[ast.stmt]:
+    if (body and isinstance(body[0], ast.Expr)
+            and isinstance(getattr(body[0], "value", None), ast.Constant)
+            and isinstance(body[0].value.value, str)):
+        return body[1:]
+    return body
+
+
+def code_of(target: Any, *names: str) -> str:
+    """Executable code of ``target``, with docstrings and comments removed.
+
+    ``target`` may be a module, a class, or a single function — the three
+    shapes the private copies each supported one of. ``names`` filters to
+    particular functions or methods; with none given, every function in the
+    target contributes.
+
+    NEVER raises: an unreadable target yields an empty string, which fails an
+    ``in`` assertion loudly rather than passing a ``not in`` one silently.
+    """
+    try:
+        source = textwrap.dedent(inspect.getsource(target))
+        tree = ast.parse(source)
+    except (OSError, TypeError, SyntaxError, ValueError):
+        return ""
+
+    funcs = [n for n in ast.walk(tree)
+             if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
+    if names:
+        funcs = [n for n in funcs if n.name in names]
+    elif inspect.isfunction(target) or inspect.ismethod(target):
+        # A single function: its own body, not every nested helper twice.
+        funcs = funcs[:1]
+
+    out: List[str] = []
+    for node in funcs:
+        for stmt in _strip_docstring(list(node.body)):
+            try:
+                out.append(ast.unparse(stmt))
+            except Exception:  # noqa: BLE001
+                continue
+    if not funcs and not names:
+        # A module with no functions still has module-level code worth
+        # reading — an import, a constant, a registration call.
+        for stmt in _strip_docstring(list(tree.body)):
+            try:
+                out.append(ast.unparse(stmt))
+            except Exception:  # noqa: BLE001
+                continue
+    return "\n".join(out)
+
+
+__all__ = ["code_of"]


### PR DESCRIPTION
## The finding

`/reach orphans` reported **eight**. Two were real.

| | |
|---|---|
| **5** | Finder/iCloud duplicates (`audio_pump 2.py`) indexed as the module `…ui.audio_pump 2` — a name **no import statement can spell**, so its unreachability is a tautology, not a discovery. |
| **1** | `transcript_timeline`, called dead while `why_engine` imports it. `_reach` follows an edge only into the index, and the index was the three *reported* roots — so an import that left them and came back was **severed**. |
| **2** | Genuinely unmounted. |

This is the same failure the module's own docstring describes — *"37 of 39 were the instrument"* — recurring one layer down. The first correction fixed the **root set**; this fixes the **index** and the **traversal**.

## The blind spot this would have acquired

Yesterday's naming cage mounts verbs with `importlib.import_module` — an edge no AST walker can see. **Making those modules reachable by a human made them unreachable by this audit**, and every cage-mounted verb plus its whole subtree would have started reporting as an orphan.

`derived_entries` gains a fourth structural source beside pyproject scripts, `__main__` guards and `scripts/`: the cage *declares* its mounts, so asking it is not guesswork. A dynamic import with no declaration stays invisible — correctly, since nothing in the repo could see it either.

## Correctness, then affordability

Widening traversal took the audit to 27s. Three costs fixed at the root rather than traded against correctness:

- **`_reach` takes many seeds.** The orphan question is the union over 228 discovered entries; computing it one at a time re-walked a 1500-node graph 228 times for an answer one multi-source walk gives exactly — O(V+E), not O(entries·(V+E)).
- **`_main_guarded` parsed 1522 files to find 28.** A run guard compares against the literal `"__main__"`, so a byte pre-filter is *exact*, not heuristic. The obvious filter is worthless and measuring said so: `__name__` is in **883** of 1522 files (`logging.getLogger(__name__)`); `__main__` is in **33**. The AST test tightened to match, having previously accepted any `__name__ ==` comparison.
- **`_roots` classified the whole package** when its only consumer iterates reported rows.

**27s → 12s, identical findings.**

## Off the loop

The remaining cost is inherent, so `audit_async` lives in the module that knows the work is heavy and is reached through `reach_repl._audit`, the one seam. `run_watchdog` had remembered to thread it; the verb an operator actually types had not — which is what happens when the offload lives in a caller instead of at the seam.

`/reach` is now `async def`, and the cage awaits awaitable verbs at `dispatch_async`: an un-awaited coroutine renders as `<coroutine object …>`, which is the unmounted class wearing a disguise. Measured — the loop ticks **129×** during an 11.4s scan.

## Tests

`tests/source_probe.py` retires four private `_code_of` helpers with three different signatures. One used `ast.get_source_segment`, which **keeps comments** — and this PR's own comment (`# No to_thread here any more…`) proved the point by failing a raw substring assertion. `ast.unparse` drops comments by construction rather than by a rule someone has to remember.

- 139 green across the six touched suites (+21 new).
- Sweep of 2542: **zero new failures** vs a clean-HEAD worktree baseline; two baseline reds in `test_verb_description_arbitration` stay green.

## What is actually unmounted

```
ORPHANS (2) — no surface, no entry point:
   battle_test.source_assertion_audit   a full test file, zero production callers
   cli.port_binder                      tests, no caller, consumer deleted (known)
```

41 modules are reachable from exactly one of the three surfaces — the shape every historical unmounted feature had. That is a watch list, not a verdict: `attach` 26, `cockpit` 8, `daemon` 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the reach audit to measure the graph it reports on. Traversal now spans the whole package while reporting stays on the configured surfaces, filters out modules that no import can spell, and includes cage-mounted verbs; the audit runs off the event loop and `/reach` is async.

- Old vs new behavior:
  - Old: `_reach` only followed edges inside reported roots, creating false orphans on round trips (e.g. `transcript_timeline`). New: traversal uses `traversal_root()` (overridden by `TRAVERSAL_ENV_VAR`) while reporting remains bounded by surfaces.
  - Old: `_index` admitted files whose names cannot be imported (e.g. `audio_pump 2.py`). New: `_index` excludes non-importable module names.
  - Old: dynamic REPL verbs were invisible to the audit. New: `derived_entries` adds verbs declared by `repl_verb_cage.discover`.
  - Old: `if __name__ == ...` detection was broad and parsed every file. New: byte prefilter for `"__main__"` plus a stricter AST check; fewer parses.
  - Old: per-entry walks re-traversed the graph. New: `_reach` accepts many seeds and memoizes parses/edges via `_Scan`. Runtime ~27s → ~12s with identical findings.

- Async/rollout:
  - Added `audit_async`; `reach_repl._audit` is async; `/reach` is async; `repl_verb_cage` adds `dispatch_async` and awaits awaitable verbs; `serpent_flow` awaits cage dispatch.
  - Required migration: callers that invoke REPL verbs must use `dispatch_async` or await the returned coroutine when the verb is async.
  - New env: `JARVIS_SURFACE_AUDIT_TRAVERSAL` controls traversal scope; defaults to the package root.
  - Tests consolidate code probing into `tests/source_probe.py` and update expectations for async `/reach`.

<sup>Written for commit a3f5e4de020b4268c14829b603b32d11823e8321. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

