### PR TITLE
feat(governance): mount source_assertion_audit as /evidence; one ratchet for N instruments

### DIFF
--- a/backend/core/ouroboros/battle_test/source_assertion_audit.py
+++ b/backend/core/ouroboros/battle_test/source_assertion_audit.py
@@ -382,6 +382,21 @@ def audit(*, roots: Optional[Sequence[str]] = None) -> AuditReading:
     return reading
 
 
+async def audit_async(*, roots: Optional[Sequence[str]] = None
+                      ) -> AuditReading:
+    """:func:`audit`, off the event loop. NEVER raises.
+
+    Same offload, same reason, same place as
+    ``surface_reachability.audit_async``: the scan parses every test file in
+    the repo, and Principle 3 has no exception for diagnostics. It lives in
+    the module that knows the work is heavy so no caller has to remember —
+    the omission that let `/reach` freeze the daemon for its own audit.
+    """
+    import asyncio
+
+    return await asyncio.to_thread(audit, roots=roots)
+
+
 def render(reading: AuditReading, *, limit: int = 20) -> List[str]:
     """Operator-readable summary. NEVER raises."""
     try:

--- a/backend/core/ouroboros/governance/audit_ratchet.py
+++ b/backend/core/ouroboros/governance/audit_ratchet.py
@@ -1,0 +1,397 @@
+"""audit_ratchet — an instrument's findings, and what changed since you looked.
+
+FOUR INSTRUMENTS, ONE RATCHET
+-----------------------------
+This repo measures its own darkness from several angles: which surfaces reach
+a module (``surface_reachability``), how many tests can only ever pass
+(``source_assertion_audit``), and others. Every one of them needs the same
+four things, and none of them is about what the instrument measures:
+
+    an ACCEPTED baseline    what the operator has already seen and allowed
+    DRIFT                   what is new since then, and what got fixed
+    ACCEPT                  pin the current state as the new floor
+    a boot WATCHDOG         say so, once, when the number gets worse
+
+``reach_repl`` grew all four inline. Copying them for the second instrument
+would be ~130 lines of duplicated persistence, degradation policy and
+comparison logic — and the copy would drift, because the two would be fixed
+separately. So the ratchet is the abstraction and the instrument is the
+parameter.
+
+WHY THE FLOOR RATCHETS RATHER THAN ALARMS
+-----------------------------------------
+A repo-wide instrument that reports its whole standing list on every boot
+gets muted within a week, and a muted instrument is worse than none: it looks
+like coverage. The ratchet reports only the DELTA against a state a human
+accepted, so steady state is silent by construction and a regression is the
+only thing that speaks.
+
+Absence of a baseline reports NOTHING rather than everything. A first run on
+a fresh checkout has not regressed — it has not yet been measured — and
+flooding an operator with the standing list is how the last four detectors
+taught people to ignore them.
+
+A CORRUPT BASELINE IS ABSENT, NOT EMPTY
+---------------------------------------
+Reading an unparseable baseline as ``{}`` would report every standing finding
+as newly regressed — a hundred false positives arriving exactly when someone
+is already recovering from a disk fault. Absent is the only safe reading.
+
+DECLARING A RATCHET MOUNTS ITS WATCHDOG
+---------------------------------------
+A ``*_repl`` module that exposes a module-level ``RATCHET`` has its watchdog
+run at boot by :func:`run_registered_watchdogs`, discovered through the same
+naming cage that mounts the verb itself. That is deliberate: ``reach_repl``
+shipped a correct ``run_watchdog`` with **zero production callers** — the
+ratchet built to catch unmounted features was itself unmounted. Making the
+declaration the registration is the only fix that does not depend on somebody
+remembering.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import (Any, Awaitable, Callable, Dict, Iterable, List, Mapping,
+                    Optional, Tuple)
+
+logger = logging.getLogger("Ouroboros.AuditRatchet")
+
+AUDIT_RATCHET_SCHEMA_VERSION: str = "audit_ratchet.1"
+
+
+def _env_flag(name: str, default: bool = True) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+@dataclass(frozen=True)
+class Instrument:
+    """What a ratchet needs to know about a measurement, and nothing else.
+
+    The ratchet never learns what a finding MEANS — it compares sets of
+    stable string keys. That is what lets one implementation serve a
+    reachability graph and a test-quality scan without either leaking into
+    it, and what will let the third instrument arrive as a declaration.
+    """
+
+    #: Stable, lowercase. Names the baseline file and the env overrides, so
+    #: renaming an instrument is a deliberate act with a visible consequence
+    #: rather than a silent orphaning of everyone's accepted state.
+    name: str
+    #: The audit itself, already off the event loop. Async because every
+    #: instrument here parses hundreds of files, and Principle 3 has no
+    #: exception for diagnostics.
+    run: Callable[[], Awaitable[Any]]
+    #: reading → {bucket: [stable key, …]}. Buckets are compared
+    #: independently so "a new orphan" and "a newly asymmetric module" stay
+    #: distinguishable in the report.
+    findings: Callable[[Any], Mapping[str, Iterable[str]]]
+    #: reading → how much was looked at. Context for the operator; never
+    #: compared, because a scan that grew is not a regression.
+    scanned: Callable[[Any], int] = lambda _r: 0
+    #: Where this instrument's baseline has always lived. Carried on the
+    #: instrument rather than derived, so adopting the ratchet does not
+    #: orphan a baseline an operator already accepted.
+    baseline_filename: str = ""
+    #: Reads a baseline written BEFORE this instrument adopted the ratchet.
+    #: An instrument that predates the ratchet has an on-disk format the
+    #: ratchet cannot know, and reading it as unrecognised would silently
+    #: discard a floor the operator accepted — they would be told "no
+    #: baseline recorded" and every standing finding would return as new.
+    #: Owned by the instrument because it is the instrument's own history;
+    #: the ratchet stays ignorant of what any bucket means.
+    legacy_buckets: Optional[
+        Callable[[Dict[str, Any]], Mapping[str, Iterable[str]]]] = None
+
+    @property
+    def env_prefix(self) -> str:
+        return f"JARVIS_{self.name.upper()}"
+
+
+@dataclass(frozen=True)
+class Drift:
+    """What changed since the baseline. Bucket-wise, never flattened."""
+
+    new: Mapping[str, Tuple[str, ...]] = field(default_factory=dict)
+    resolved: Tuple[str, ...] = ()
+    baseline_exists: bool = True
+    scanned: int = 0
+    error: str = ""
+
+    @property
+    def regressed(self) -> bool:
+        return any(bool(v) for v in self.new.values())
+
+    def bucket(self, name: str) -> Tuple[str, ...]:
+        return tuple(self.new.get(name, ()))
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": AUDIT_RATCHET_SCHEMA_VERSION,
+            "new": {k: list(v) for k, v in self.new.items()},
+            "resolved": list(self.resolved),
+            "baseline_exists": self.baseline_exists,
+            "scanned": self.scanned, "regressed": self.regressed,
+            "error": self.error,
+        }
+
+
+class AuditRatchet:
+    """One instrument's accepted floor. NEVER raises out of any method."""
+
+    def __init__(self, instrument: Instrument) -> None:
+        self.instrument = instrument
+
+    # -- location ---------------------------------------------------------
+
+    def baseline_path(self) -> Path:
+        """Per-REPOSITORY, never global.
+
+        An accepted floor is a judgement about one checkout's code, and a
+        shared file would carry one repo's allowances into another — the
+        same reasoning that keeps the proactive-mode dial per-worktree.
+        """
+        override = os.environ.get(f"{self.instrument.env_prefix}_BASELINE_PATH")
+        if override:
+            return Path(override)
+        root = Path(os.environ.get("JARVIS_PROJECT_ROOT", "."))
+        name = (self.instrument.baseline_filename
+                or f"{self.instrument.name}_baseline.json")
+        return root / ".jarvis" / name
+
+    def watchdog_enabled(self) -> bool:
+        """Default TRUE — silent at steady state, so it costs nothing."""
+        return _env_flag(f"{self.instrument.env_prefix}_WATCHDOG_ENABLED")
+
+    # -- state ------------------------------------------------------------
+
+    def _load(self) -> Optional[Dict[str, Any]]:
+        """The accepted state, or None. Corrupt reads as ABSENT."""
+        try:
+            data = json.loads(self.baseline_path().read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else None
+        except (OSError, ValueError):
+            return None
+
+    async def accept(self) -> Dict[str, Any]:
+        """Pin the current state as the floor. NEVER raises.
+
+        Written through ``durable_io.atomic_replace``: a baseline half-written
+        by a crash reads as corrupt on the next boot, which degrades to "no
+        baseline" and floods the operator exactly when they are already
+        recovering from something.
+        """
+        try:
+            reading = await self.instrument.run()
+            buckets = {k: sorted(set(v))
+                       for k, v in self.instrument.findings(reading).items()}
+            payload: Dict[str, Any] = {
+                "schema_version": AUDIT_RATCHET_SCHEMA_VERSION,
+                "instrument": self.instrument.name,
+                "buckets": buckets,
+                "scanned": self.instrument.scanned(reading),
+            }
+            await asyncio.to_thread(_write_atomic, self.baseline_path(),
+                                    payload)
+            logger.info("[%s] baseline accepted — %s across %d scanned",
+                        self.instrument.name,
+                        ", ".join(f"{k} {len(v)}" for k, v in buckets.items())
+                        or "nothing",
+                        payload["scanned"])
+            return payload
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] baseline write failed: %s",
+                         self.instrument.name, exc, exc_info=True)
+            return {"error": f"{type(exc).__name__}: {exc}"}
+
+    async def drift(self) -> Drift:
+        """What regressed since the baseline. NEVER raises."""
+        try:
+            reading = await self.instrument.run()
+        except Exception as exc:  # noqa: BLE001
+            return Drift(error=f"{type(exc).__name__}: {exc}")
+        try:
+            now = {k: set(v)
+                   for k, v in self.instrument.findings(reading).items()}
+            scanned = self.instrument.scanned(reading)
+        except Exception as exc:  # noqa: BLE001
+            return Drift(error=f"{type(exc).__name__}: {exc}")
+
+        base = self._load()
+        if base is None:
+            return Drift(baseline_exists=False, scanned=scanned)
+        was = base.get("buckets")
+        if not isinstance(was, dict) and self.instrument.legacy_buckets:
+            try:
+                converted = self.instrument.legacy_buckets(base)
+                was = {k: list(v) for k, v in converted.items()}
+            except Exception:  # noqa: BLE001
+                was = None
+        if not isinstance(was, dict):
+            # A baseline in a shape neither this ratchet nor the instrument
+            # understands is not a baseline. Treated as absent for the same
+            # reason a corrupt one is — inventing an empty floor
+            # manufactures a regression per standing finding.
+            return Drift(baseline_exists=False, scanned=scanned)
+
+        new: Dict[str, Tuple[str, ...]] = {}
+        was_map: Dict[str, Any] = was
+        resolved: List[str] = []
+        for bucket, keys in now.items():
+            before = set(was_map.get(bucket) or ())
+            new[bucket] = tuple(sorted(keys - before))
+            resolved.extend(sorted(before - keys))
+        # A bucket the baseline knows and this reading does not is entirely
+        # resolved — dropping it here would silently forget a fix.
+        for bucket, keys in was_map.items():
+            if bucket not in now:
+                resolved.extend(sorted(set(keys or ())))
+        return Drift(new=new, resolved=tuple(sorted(set(resolved))),
+                     baseline_exists=True, scanned=scanned)
+
+    async def watchdog(self) -> Drift:
+        """Boot-time drift check. NEVER raises. Silent at steady state."""
+        if not self.watchdog_enabled():
+            return Drift(baseline_exists=False)
+        result = await self.drift()
+        name = self.instrument.name
+        if result.error:
+            logger.debug("[%s] watchdog could not audit: %s", name,
+                         result.error)
+        elif not result.baseline_exists:
+            logger.info(
+                "[%s] no baseline — run `/%s accept` to pin the current "
+                "state, then this reports only what changes", name, name)
+        elif result.regressed:
+            # WARNING, not INFO: these instruments exist because capabilities
+            # keep shipping unreachable, and that has now happened six times.
+            logger.warning(
+                "[%s] REGRESSED since the accepted baseline — %s", name,
+                "; ".join(f"new {k}: {', '.join(v)}"
+                          for k, v in result.new.items() if v))
+        return result
+
+
+def _write_atomic(path: Path, payload: Dict[str, Any]) -> None:
+    from backend.core.ouroboros.governance.durable_io import atomic_replace
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True),
+                   encoding="utf-8")
+    atomic_replace(tmp, path)
+
+
+# ---------------------------------------------------------------------------
+# Boot mount — declaring a ratchet registers its watchdog
+# ---------------------------------------------------------------------------
+
+
+def registered_ratchets() -> List[AuditRatchet]:
+    """Every ratchet a mounted verb declares. NEVER raises.
+
+    Discovered through the naming cage rather than a list here: the cage
+    already knows which ``*_repl`` modules are real verbs, and a second
+    registry would be a second thing to forget. A verb opts in by exposing a
+    module-level ``RATCHET`` — one declaration, the same shape as
+    ``__verb_help__``.
+
+    Imports only the verb modules that exist, which is a handful; the cage's
+    own discovery stays import-free.
+    """
+    import importlib
+
+    out: List[AuditRatchet] = []
+    try:
+        from backend.core.ouroboros.governance.repl_verb_cage import discover
+    except Exception:  # noqa: BLE001
+        return out
+    for spec in discover():
+        try:
+            module = importlib.import_module(spec.module)
+        except Exception:  # noqa: BLE001
+            logger.debug("[AuditRatchet] %s unimportable", spec.module,
+                         exc_info=True)
+            continue
+        ratchet = getattr(module, "RATCHET", None)
+        if isinstance(ratchet, AuditRatchet):
+            out.append(ratchet)
+    return out
+
+
+def watchdogs_enabled() -> bool:
+    """Master switch for the whole boot sweep. Default TRUE."""
+    return _env_flag("JARVIS_AUDIT_WATCHDOGS_ENABLED")
+
+
+async def run_registered_watchdogs() -> Dict[str, Drift]:
+    """Run every declared watchdog concurrently. NEVER raises.
+
+    Concurrent because these are independent scans and serialising them
+    would make the slowest instrument set the boot cost for all of them.
+    Each already runs its own audit off the loop, so this composes rather
+    than nests threads.
+
+    ``return_exceptions``: one instrument that explodes must not cancel the
+    others. An audit is a diagnostic, and a diagnostic that can take down
+    the boot it reports on is a liability rather than an asset.
+    """
+    if not watchdogs_enabled():
+        return {}
+    ratchets = registered_ratchets()
+    if not ratchets:
+        return {}
+    results = await asyncio.gather(
+        *(r.watchdog() for r in ratchets), return_exceptions=True)
+    out: Dict[str, Drift] = {}
+    for ratchet, result in zip(ratchets, results):
+        if isinstance(result, BaseException):
+            logger.debug("[AuditRatchet] %s watchdog raised: %s",
+                         ratchet.instrument.name, result)
+            out[ratchet.instrument.name] = Drift(
+                error=f"{type(result).__name__}: {result}")
+        else:
+            out[ratchet.instrument.name] = result
+    return out
+
+
+def spawn_registered_watchdogs() -> Optional["asyncio.Task"]:
+    """Fire the sweep as a background task. NEVER raises, never blocks.
+
+    The boot seam calls this and moves on. A watchdog that delayed startup
+    by the length of its own scan would be traded away the first time
+    somebody profiled boot — and then the instrument is gone again.
+    """
+    if not watchdogs_enabled():
+        return None
+    try:
+        return asyncio.get_running_loop().create_task(
+            run_registered_watchdogs())
+    except RuntimeError:
+        # No loop — a synchronous context (a script, a test collection).
+        # Not an error: there is simply nothing to schedule onto.
+        return None
+    except Exception:  # noqa: BLE001
+        logger.debug("[AuditRatchet] watchdog sweep not scheduled",
+                     exc_info=True)
+        return None
+
+
+__all__ = [
+    "AUDIT_RATCHET_SCHEMA_VERSION",
+    "AuditRatchet",
+    "Drift",
+    "Instrument",
+    "registered_ratchets",
+    "run_registered_watchdogs",
+    "spawn_registered_watchdogs",
+    "watchdogs_enabled",
+]

--- a/backend/core/ouroboros/governance/evidence_repl.py
+++ b/backend/core/ouroboros/governance/evidence_repl.py
@@ -1,0 +1,273 @@
+"""``/evidence`` — what do the tests actually observe? PRD §28.
+
+``source_assertion_audit`` measures the one number that explains every other
+darkness finding: how many tests **cannot fail for a behavioural reason**. A
+test that reads a source file and asserts a string appears in it passes while
+the feature behind it is dead, and three such tests certified that
+``/narrate verbose`` worked by confirming the handler's SOURCE mentioned a
+flag no code read.
+
+THIS MODULE WAS THE FINDING
+---------------------------
+The instrument shipped complete, with a full test file, and **zero
+production callers**. Its own docstring anticipated this — *"an instrument
+that measures dead code and is not itself covered is subject to its own
+criterion"* — and it was right about the wrong axis: being covered did not
+save it, because nothing an operator could type ever reached it. It was one
+of the two real orphans `/reach` found.
+
+So the mount is the point. Declaring ``__verb_help__`` and
+``dispatch_evidence_command`` makes ``/evidence`` typeable through the
+naming cage; declaring ``RATCHET`` makes its boot watchdog run. Neither
+requires an edit anywhere else, which is the only property that would have
+prevented the original defect.
+
+WHY A RATE AND NOT A LIST
+-------------------------
+The reportable class is ``SOURCE_ONLY`` — every assertion in the function
+touches source text, so nothing was executed. That is decidable rather than
+a judgement, which is why this is a measurement and not a lint. Source
+assertions are not wrong; some invariants are genuinely structural and
+behaviour cannot express them. The pathology is the source assertion as the
+**only** evidence.
+
+The ratchet therefore watches the SET, not the rate: a rate that improves
+because someone deleted tests is not progress, and a rate that worsens
+because the suite grew is not a regression. A newly source-only test is.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+
+from backend.core.ouroboros.governance import audit_ratchet as _ratchet
+
+logger = logging.getLogger("Ouroboros.EvidenceRepl")
+
+EVIDENCE_REPL_SCHEMA_VERSION: str = "evidence_repl.1"
+
+__verb_help__ = {
+    "evidence": "measure what the tests can actually observe, not what they name",
+}
+
+_HELP = (
+    "/evidence — what do the tests actually observe? (PRD §28)\n"
+    "\n"
+    "  /evidence              what changed since the accepted baseline\n"
+    "  /evidence rate         the headline number, with the breakdown\n"
+    "  /evidence all          every test that can only ever pass\n"
+    "  /evidence flags        the `/narrate verbose` class — source-only\n"
+    "                         tests asserting an env-flag literal\n"
+    "  /evidence <module>     source-only tests under a path fragment\n"
+    "  /evidence accept       record the current state as the baseline\n"
+    "  /evidence help         this text\n"
+    "\n"
+    "A source assertion is not a defect. A source assertion as the ONLY\n"
+    "evidence is: that test cannot fail for a behavioural reason, and it\n"
+    "will pass forever after the feature it names stops working.\n"
+)
+
+
+async def _audit() -> Any:
+    """Run the canonical audit, off the loop. THE one seam.
+
+    Every path here reaches the numbers through this function, so the
+    offload cannot be forgotten by a future caller — the omission that let
+    `/reach` block the daemon for the length of its own scan.
+    """
+    from backend.core.ouroboros.battle_test.source_assertion_audit import (
+        audit_async,
+    )
+    return await audit_async()
+
+
+def _key(verdict: Any) -> str:
+    """A finding's stable identity across runs.
+
+    ``module::name``, deliberately WITHOUT the line number: a test that
+    everything above it shifted is the same test, and including the line
+    would report the whole file as newly source-only after one insertion.
+    """
+    return f"{verdict.module}::{verdict.name}"
+
+
+def _findings(reading: Any) -> Dict[str, Tuple[str, ...]]:
+    """Two buckets, the second a strict subset of the first.
+
+    Kept separate because they call for different actions: a source-only
+    test is worth revisiting; a source-only test asserting a FLAG LITERAL is
+    the exact shape that certified a dead feature, and is worth revisiting
+    first.
+    """
+    return {
+        "source_only": tuple(_key(v) for v in reading.source_only),
+        "flag_literal": tuple(_key(v) for v in reading.flag_literal_tests),
+    }
+
+
+#: Declared, therefore mounted — `audit_ratchet` finds this through the same
+#: naming cage that mounts the verb. No boot-seam edit, which is the only
+#: property that would have prevented this module's own orphaning.
+RATCHET = _ratchet.AuditRatchet(_ratchet.Instrument(
+    name="evidence",
+    run=lambda: _audit(),
+    findings=_findings,
+    scanned=lambda r: r.total,
+    baseline_filename="source_assertion_baseline.json",
+))
+
+
+def baseline_path():
+    return RATCHET.baseline_path()
+
+
+def watchdog_enabled() -> bool:
+    return RATCHET.watchdog_enabled()
+
+
+async def run_watchdog() -> _ratchet.Drift:
+    """Boot-time drift check. NEVER raises. Silent at steady state."""
+    return await RATCHET.watchdog()
+
+
+@dataclass(frozen=True)
+class EvidenceReplDispatchResult:
+    ok: bool
+    text: str
+    matched: bool = True
+    schema_version: str = EVIDENCE_REPL_SCHEMA_VERSION
+
+
+def _fmt(rows: List[str], cap: int = 12) -> str:
+    if not rows:
+        return "  (none)"
+    shown = rows[:cap]
+    tail = f"\n  … and {len(rows) - cap} more" if len(rows) > cap else ""
+    return "\n".join(f"  {r}" for r in shown) + tail
+
+
+def _row(verdict: Any) -> str:
+    flags = (" [" + ",".join(verdict.flag_literals) + "]"
+             if verdict.flag_literals else "")
+    return f"{verdict.module}:{verdict.lineno} {verdict.name}{flags}"
+
+
+async def dispatch_evidence_command(line: str) -> EvidenceReplDispatchResult:
+    """Ask what the suite can actually see.
+
+    Async because the audit parses every test file in the repo. A verb that
+    does real work synchronously freezes the loop that runs the organism for
+    the length of its own computation.
+    """
+    try:
+        raw = (line or "").strip().lstrip("/")
+        tokens = raw.split()
+        sub = tokens[1].strip().lower() if len(tokens) > 1 else ""
+
+        if sub in ("help", "-h", "--help"):
+            return EvidenceReplDispatchResult(ok=True, text=_HELP)
+
+        if sub == "accept":
+            payload = await RATCHET.accept()
+            if "error" in payload:
+                return EvidenceReplDispatchResult(
+                    ok=False,
+                    text=f"could not write baseline: {payload['error']}")
+            buckets = payload.get("buckets") or {}
+            return EvidenceReplDispatchResult(
+                ok=True,
+                text=(f"baseline accepted — "
+                      f"{len(buckets.get('source_only') or ())} source-only "
+                      f"({len(buckets.get('flag_literal') or ())} of them "
+                      f"flag-literal) across {payload.get('scanned', 0)} "
+                      f"test(s).\nFuture drift reports only what changes "
+                      f"from here."))
+
+        if sub in ("", "drift"):
+            d = await RATCHET.drift()
+            if d.error:
+                return EvidenceReplDispatchResult(
+                    ok=False, text=f"audit unavailable: {d.error}")
+            if not d.baseline_exists:
+                return EvidenceReplDispatchResult(
+                    ok=True,
+                    text=("no baseline recorded — run `/evidence accept` to "
+                          "pin the current state, then this reports only "
+                          "what changes."))
+            if not d.regressed and not d.resolved:
+                return EvidenceReplDispatchResult(
+                    ok=True,
+                    text=(f"unchanged since the baseline "
+                          f"({d.scanned} test(s) scanned)."))
+            parts: List[str] = []
+            if d.bucket("source_only"):
+                parts.append("newly source-only — these can no longer fail "
+                             "for a behavioural reason:")
+                parts.append(_fmt(list(d.bucket("source_only"))))
+            if d.bucket("flag_literal"):
+                parts.append("newly flag-literal (the `/narrate verbose` "
+                             "class):")
+                parts.append(_fmt(list(d.bucket("flag_literal"))))
+            if d.resolved:
+                parts.append(f"resolved: {len(d.resolved)}")
+            return EvidenceReplDispatchResult(ok=True, text="\n".join(parts))
+
+        reading = await _audit()
+
+        if sub == "rate":
+            from backend.core.ouroboros.battle_test.source_assertion_audit import (  # noqa: E501
+                render,
+            )
+            # Rendering delegated to the instrument: a second summary here
+            # would be a second opinion about the same reading.
+            return EvidenceReplDispatchResult(
+                ok=True, text="\n".join(render(reading, limit=0)))
+
+        if sub in ("all", "tests"):
+            rows = [_row(v) for v in reading.source_only]
+            return EvidenceReplDispatchResult(
+                ok=True,
+                text=(f"tests that can only ever pass ({len(rows)} of "
+                      f"{reading.total}):\n{_fmt(rows, cap=30)}"))
+
+        if sub == "flags":
+            rows = [_row(v) for v in reading.flag_literal_tests]
+            return EvidenceReplDispatchResult(
+                ok=True,
+                text=(f"source-only tests asserting a flag literal "
+                      f"({len(rows)}) — the exact shape that certified a "
+                      f"dead feature:\n{_fmt(rows, cap=30)}"))
+
+        # Anything else is a path fragment, matched loosely so an operator
+        # can type `governance` rather than a full relative path.
+        needle = sub
+        hits = [v for v in reading.source_only
+                if needle in v.module.lower() or needle in v.name.lower()]
+        if not hits:
+            return EvidenceReplDispatchResult(
+                ok=False,
+                text=(f"no source-only test matching {sub!r} in "
+                      f"{reading.total} scanned — try `/evidence all` or "
+                      f"`/evidence help`"))
+        return EvidenceReplDispatchResult(
+            ok=True,
+            text=(f"source-only tests matching {sub!r} ({len(hits)}):\n"
+                  f"{_fmt([_row(v) for v in hits], cap=30)}"))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[Evidence] dispatch degraded", exc_info=True)
+        return EvidenceReplDispatchResult(
+            ok=False, text=f"evidence audit unavailable ({type(exc).__name__})")
+
+
+__all__ = [
+    "EVIDENCE_REPL_SCHEMA_VERSION",
+    "RATCHET",
+    "EvidenceReplDispatchResult",
+    "baseline_path",
+    "dispatch_evidence_command",
+    "run_watchdog",
+    "watchdog_enabled",
+]

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1439,6 +1439,10 @@ class GovernedLoopService:
         # `/why` racing a failed boot finds an attribute rather than a
         # traceback.
         self._why_live_reader: Optional[Callable[[], Dict[str, Any]]] = None
+        # PRD §28: the background audit-watchdog sweep, held so teardown can
+        # cancel it. A scan outliving the service it reports on would keep
+        # parsing thousands of files against a tree nobody is serving.
+        self._audit_watchdog_task: Optional[Any] = None
         self._active_file_ops: Set[str] = set()  # canonical file paths currently in-flight
         self._completed_ops: Dict[str, OperationResult] = {}
         # Cooperative cancellation: op_ids requested for cancel via REPL /cancel
@@ -2883,6 +2887,7 @@ class GovernedLoopService:
         # while ops are still finishing they genuinely are in flight, and
         # unbinding early would make `/why` claim disk-only about work that
         # is still running.
+        self._cancel_audit_watchdogs()
         self._release_why_live_source()
         self._detach_from_stack()
         self._state = ServiceState.INACTIVE
@@ -6738,6 +6743,30 @@ class GovernedLoopService:
                 logger.debug(
                     "[GLS] /why live-source binding skipped", exc_info=True)
 
+            # PRD §28: run every declared audit watchdog once, in background.
+            #
+            # `reach_repl.run_watchdog` was written, tested, and had ZERO
+            # production callers — the ratchet built to catch capabilities
+            # that ship unreachable was itself unreachable. Wiring the two
+            # instruments by name here would have re-created that defect for
+            # the third, so the sweep asks `audit_ratchet` which verbs
+            # DECLARE a ratchet: a new instrument mounts by declaration, and
+            # this line never changes again.
+            #
+            # Fire-and-forget, and deliberately not awaited: the scans parse
+            # thousands of files, and a watchdog that delayed boot by the
+            # length of its own audit is a watchdog somebody deletes the
+            # first time they profile startup — and then the instrument is
+            # gone again. Each audit already runs off the loop.
+            try:
+                from backend.core.ouroboros.governance.audit_ratchet import (  # noqa: PLC0415
+                    spawn_registered_watchdogs as _spawn_audits,
+                )
+                self._audit_watchdog_task = _spawn_audits()
+            except Exception:  # noqa: BLE001 — a diagnostic never blocks boot
+                logger.debug(
+                    "[GLS] audit watchdog sweep not scheduled", exc_info=True)
+
             # Dynamic Fleet Registry Service Discovery: lanes TRACK the mesh.
             # While sovereign endpoints serve, the worker count locks to the
             # node count (one GPU = one lane; an N-node fleet = N lanes);
@@ -7329,6 +7358,27 @@ class GovernedLoopService:
         # StrategicDirection holder on the orchestrator.
         self._stack.governed_loop_service = self
 
+    def _cancel_audit_watchdogs(self) -> None:
+        """Stop the background audit sweep. NEVER raises. §28.
+
+        Called on BOTH teardown paths. The sweep is fire-and-forget by
+        design, which makes cancelling it a teardown OBLIGATION rather than
+        an optimisation: an audit that outlives its service keeps parsing
+        the tree and logs a regression about a repo nobody is watching.
+
+        Cancellation only, never awaited — teardown must not block for the
+        length of a scan it has just decided it no longer needs.
+        """
+        task = getattr(self, "_audit_watchdog_task", None)
+        if task is None:
+            return
+        self._audit_watchdog_task = None
+        try:
+            if not task.done():
+                task.cancel()
+        except Exception:  # noqa: BLE001
+            logger.debug("[GLS] audit watchdog cancel skipped", exc_info=True)
+
     def _release_why_live_source(self) -> None:
         """Take back the `/why` live reader this instance lent out. §27.5.
 
@@ -7603,6 +7653,7 @@ class GovernedLoopService:
         self._orchestrator = None
         self._generator = None
         self._approval_provider = None
+        self._cancel_audit_watchdogs()
         self._release_why_live_source()
         self._detach_from_stack()
 

--- a/backend/core/ouroboros/governance/reach_repl.py
+++ b/backend/core/ouroboros/governance/reach_repl.py
@@ -37,12 +37,13 @@ Python 3.9+, ``from __future__ import annotations``.
 """
 from __future__ import annotations
 
-import json
 import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+
+from backend.core.ouroboros.governance import audit_ratchet as _ratchet
+from typing import Any, Dict, List, Tuple
 
 logger = logging.getLogger("Ouroboros.ReachRepl")
 
@@ -71,19 +72,51 @@ _HELP = (
 )
 
 
+def _findings(reading: Any) -> Dict[str, Tuple[str, ...]]:
+    """Reachability's two buckets, as stable keys."""
+    return {
+        "asymmetric": tuple(m.module for m in reading.asymmetric()),
+        "orphans": tuple(m.module for m in reading.orphans()),
+    }
+
+
+def _legacy_buckets(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Read a baseline accepted before this verb adopted the ratchet.
+
+    The old file was flat — ``{"asymmetric": [...], "orphans": [...],
+    "surfaces": [...], "scanned": N}``. Named explicitly rather than inferred
+    from "every key holding a list of strings", because that rule would also
+    adopt ``surfaces`` as a bucket and then report a renamed surface label as
+    a regression.
+    """
+    return {"asymmetric": list(data.get("asymmetric") or ()),
+            "orphans": list(data.get("orphans") or ())}
+
+
+#: Declared, therefore mounted: `audit_ratchet.run_registered_watchdogs`
+#: finds this through the naming cage. The previous `run_watchdog` was
+#: correct, tested, and had zero production callers — the ratchet built to
+#: catch unmounted features was itself unmounted.
+RATCHET = _ratchet.AuditRatchet(_ratchet.Instrument(
+    name="reach",
+    run=lambda: _audit(),
+    findings=_findings,
+    scanned=lambda r: r.scanned,
+    # Unchanged on purpose: adopting the ratchet must not orphan a baseline
+    # an operator already accepted.
+    baseline_filename="surface_reachability_baseline.json",
+    legacy_buckets=_legacy_buckets,
+))
+
+
 def baseline_path() -> Path:
     """Where the accepted state lives. Per-repository, never global."""
-    root = Path(os.environ.get("JARVIS_PROJECT_ROOT", "."))
-    return Path(os.environ.get(
-        "JARVIS_REACH_BASELINE_PATH",
-        str(root / ".jarvis" / "surface_reachability_baseline.json"),
-    ))
+    return RATCHET.baseline_path()
 
 
 def watchdog_enabled() -> bool:
     """Boot-time drift check. Default TRUE — it is silent at steady state."""
-    return (os.environ.get("JARVIS_REACH_WATCHDOG_ENABLED", "true")
-            or "").strip().lower() not in ("0", "false", "no", "off")
+    return RATCHET.watchdog_enabled()
 
 
 @dataclass(frozen=True)
@@ -100,6 +133,22 @@ class ReachDrift:
     @property
     def regressed(self) -> bool:
         return bool(self.new_asymmetric or self.new_orphans)
+
+    @classmethod
+    def of(cls, d: "_ratchet.Drift") -> "ReachDrift":
+        """Project the generic drift onto this verb's vocabulary.
+
+        Kept rather than replaced by `Drift`: `new_asymmetric` and
+        `new_orphans` are what the operator and this module's spine both
+        speak, and a generic `new["asymmetric"]` at every call site would
+        make the ratchet's shape the REPL's problem.
+        """
+        return cls(
+            new_asymmetric=d.bucket("asymmetric"),
+            new_orphans=d.bucket("orphans"),
+            resolved=d.resolved, baseline_exists=d.baseline_exists,
+            scanned=d.scanned, error=d.error,
+        )
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -128,54 +177,22 @@ async def _audit() -> Any:
     return await audit_async()
 
 
-def _load_baseline() -> Optional[Dict[str, Any]]:
-    """The accepted state, or None. NEVER raises.
-
-    A corrupt baseline is treated as ABSENT rather than as an empty one:
-    an empty baseline would report every asymmetric module as newly
-    regressed, burying a real regression under a hundred false ones on the
-    first boot after a disk fault.
-    """
-    try:
-        raw = baseline_path().read_text(encoding="utf-8")
-        data = json.loads(raw)
-        if not isinstance(data, dict):
-            return None
-        return data
-    except (OSError, ValueError):
-        return None
-
-
 async def accept_baseline() -> Dict[str, Any]:
     """Record the current state as accepted. NEVER raises.
 
-    Written through ``durable_io.atomic_replace``: a baseline half-written
-    by a crash would be read as corrupt on the next boot, which degrades to
-    "no baseline" and floods the operator exactly when they are already
-    recovering from something.
+    Atomicity, degradation policy and the per-repository location all live
+    in `audit_ratchet` now — one implementation for every instrument, so a
+    fix to the persistence lands for all of them at once.
     """
-    try:
-        reading = await _audit()
-        payload = {
-            "schema_version": REACH_REPL_SCHEMA_VERSION,
-            "asymmetric": sorted(m.module for m in reading.asymmetric()),
-            "orphans": sorted(m.module for m in reading.orphans()),
-            "surfaces": list(reading.surface_labels),
-            "scanned": reading.scanned,
-        }
-        path = baseline_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-        tmp.write_text(json.dumps(payload, indent=2, sort_keys=True),
-                       encoding="utf-8")
-        from backend.core.ouroboros.governance.durable_io import atomic_replace
-        atomic_replace(tmp, path)
-        logger.info("[Reach] baseline accepted — %d asymmetric, %d orphan(s)",
-                    len(payload["asymmetric"]), len(payload["orphans"]))
+    payload = await RATCHET.accept()
+    if "error" in payload:
         return payload
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("[Reach] baseline write failed: %s", exc, exc_info=True)
-        return {"error": str(exc)}
+    # Flattened for this verb's own render, which speaks buckets by name.
+    buckets = payload.get("buckets") or {}
+    return {"schema_version": REACH_REPL_SCHEMA_VERSION,
+            "asymmetric": list(buckets.get("asymmetric") or ()),
+            "orphans": list(buckets.get("orphans") or ()),
+            "scanned": payload.get("scanned", 0)}
 
 
 async def drift() -> ReachDrift:
@@ -186,64 +203,20 @@ async def drift() -> ReachDrift:
     measured — and reporting the whole standing list as new would be the
     4:1 false-positive flood this design exists to avoid.
     """
-    try:
-        reading = await _audit()
-    except Exception as exc:  # noqa: BLE001
-        return ReachDrift(error=f"{type(exc).__name__}: {exc}")
-    now_asym = {m.module for m in reading.asymmetric()}
-    now_orph = {m.module for m in reading.orphans()}
-    base = _load_baseline()
-    if base is None:
-        return ReachDrift(baseline_exists=False, scanned=reading.scanned)
-    was_asym = set(base.get("asymmetric") or ())
-    was_orph = set(base.get("orphans") or ())
-    return ReachDrift(
-        new_asymmetric=tuple(sorted(now_asym - was_asym)),
-        new_orphans=tuple(sorted(now_orph - was_orph)),
-        resolved=tuple(sorted((was_asym | was_orph) - (now_asym | now_orph))),
-        scanned=reading.scanned,
-    )
+    return ReachDrift.of(await RATCHET.drift())
 
 
 async def run_watchdog() -> ReachDrift:
     """Boot-time drift check, off the event loop. NEVER raises.
 
-    The audit walks the module tree and parses every file, which is far too
-    much work for the loop that also runs the organism — `_audit` puts it on
-    a thread for every caller. Bounded by the caller's own supervision rather
-    than a timer here: a scan that overran would be a scan worth noticing,
-    and killing it silently would hide that.
+    Mounted by DECLARATION: `RATCHET` above is what
+    `audit_ratchet.run_registered_watchdogs` discovers. This function stays
+    as the named entry point for anything that wants just this instrument.
 
     Silent at steady state, by construction: with nothing new since the
     baseline there is no line to print.
     """
-    if not watchdog_enabled():
-        return ReachDrift(baseline_exists=False)
-    try:
-        # No `to_thread` here any more: `_audit` owns the offload, and two
-        # places deciding how to get off the loop is how one of them ends up
-        # not doing it.
-        result = await drift()
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("[Reach] watchdog degraded: %s", exc)
-        return ReachDrift(error=str(exc))
-    if result.error:
-        logger.debug("[Reach] watchdog could not audit: %s", result.error)
-    elif not result.baseline_exists:
-        logger.info(
-            "[Reach] no reachability baseline — run `/reach accept` to "
-            "record the current surface topology as expected")
-    elif result.regressed:
-        # WARNING, not INFO: a capability that shipped unreachable is the
-        # defect class this detector exists for, and it has landed six times.
-        logger.warning(
-            "[Reach] surface reachability REGRESSED — new asymmetric: %s; "
-            "new orphans: %s. A module reachable from fewer surfaces than "
-            "before is the shape every unmounted feature had.",
-            ", ".join(result.new_asymmetric) or "-",
-            ", ".join(result.new_orphans) or "-",
-        )
-    return result
+    return ReachDrift.of(await RATCHET.watchdog())
 
 
 @dataclass(frozen=True)

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -3500,6 +3500,74 @@ Master switch `JARVIS_REPL_VERB_CAGE_ENABLED`, default **true**.
 
 ---
 
+### 27.5.7 The audit ratchet — declaring one mounts its watchdog
+
+The cage made a verb reachable by a human. This makes an *instrument*
+reachable by the organism, and it exists because the same defect recurred
+one level up: `reach_repl.run_watchdog` was written, tested, documented —
+and had **zero production callers**. The ratchet built to catch capabilities
+that ship unreachable was itself unreachable.
+
+`/reach` found two real orphans. One of them, `source_assertion_audit`, is
+the instrument that measures *how many tests cannot fail for a behavioural
+reason* — the mechanism that hid every inert capability the other detectors
+later found. It shipped complete, with a full test file, and nothing an
+operator could type ever reached it. Its own docstring anticipated the risk
+on the wrong axis: being covered did not save it.
+
+**One ratchet, N instruments.** Every instrument needs the same four things,
+none of which is about what it measures:
+
+| | |
+|---|---|
+| accepted baseline | what the operator has already seen and allowed |
+| drift | what is new since then, and what got fixed |
+| accept | pin the current state as the new floor |
+| boot watchdog | say so, once, when the number gets worse |
+
+`audit_ratchet.Instrument` carries a name, an async `run`, a `findings`
+function returning `{bucket: [stable key]}`, and nothing else. The ratchet
+never learns what a finding *means* — it compares sets of strings. That is
+what lets one implementation serve a reachability graph and a test-quality
+scan, and what lets the third instrument arrive as a declaration rather
+than a copy of ~130 lines of persistence and degradation policy.
+
+**Registration is declaration.** A `*_repl` module exposing a module-level
+`RATCHET` has its watchdog run at boot, discovered through the same naming
+cage that mounts its verb. The boot seam in `GovernedLoopService` names no
+instrument — wiring the two by hand would have re-created the defect for the
+third. The sweep is spawned, never awaited: a watchdog that delayed startup
+by the length of its own scan is one somebody deletes the first time they
+profile boot, and then the instrument is gone again. Both teardown paths
+cancel it.
+
+**Design choices that are load-bearing:**
+
+- **The floor ratchets rather than alarms.** An instrument that reports its
+  whole standing list on every boot is muted within a week, and a muted
+  instrument is worse than none because it looks like coverage. Only the
+  delta against an accepted state speaks.
+- **No baseline reports nothing, not everything.** A fresh checkout has not
+  regressed; it has not been measured.
+- **A corrupt baseline is absent, not empty.** Reading it as `{}` would
+  report every standing finding as newly regressed — a hundred false
+  positives arriving exactly when someone is recovering from a disk fault.
+- **`Instrument.legacy_buckets`** lets an instrument read the format it used
+  before the ratchet existed. Adopting a shared abstraction must not
+  silently discard a floor an operator accepted. Owned by the instrument,
+  because it is the instrument's own history.
+- **Buckets compared independently.** "A new orphan" and "a newly asymmetric
+  module" are different news and must stay distinguishable.
+- **`/evidence` watches the SET, not the rate.** A rate that improves
+  because tests were deleted is not progress; one that worsens because the
+  suite grew is not a regression. A newly source-only test is.
+
+Verbs: `/reach` (surface reachability), `/evidence` (what the tests can
+actually observe). Masters `JARVIS_AUDIT_WATCHDOGS_ENABLED` and
+per-instrument `JARVIS_<NAME>_WATCHDOG_ENABLED`, all default **true**.
+
+---
+
 ### 27.11 Anti-goals
 
 Extends §38.11.4; these are specific to initiative and steering.

--- a/tests/governance/test_audit_ratchet.py
+++ b/tests/governance/test_audit_ratchet.py
@@ -1,0 +1,335 @@
+"""Regression spine for the generic audit ratchet and `/evidence`.
+
+Two instruments now share one ratchet. The assertions here are about the
+properties that made the ratchet worth extracting — degradation direction,
+per-repository state, and above all REACHABILITY, since the module being
+mounted was itself one of the two real orphans `/reach` found.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.core.ouroboros.governance import audit_ratchet as ar
+from backend.core.ouroboros.governance import evidence_repl as ev
+from backend.core.ouroboros.governance import reach_repl as rr
+from tests.source_probe import code_of
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch, tmp_path):
+    for k in ("JARVIS_EVIDENCE_BASELINE_PATH", "JARVIS_REACH_BASELINE_PATH",
+              "JARVIS_AUDIT_WATCHDOGS_ENABLED",
+              "JARVIS_EVIDENCE_WATCHDOG_ENABLED",
+              "JARVIS_REACH_WATCHDOG_ENABLED"):
+        monkeypatch.delenv(k, raising=False)
+    # EVERY instrument, not just the two named ones. The ad-hoc `probe`
+    # instrument below has no path override of its own, so without this it
+    # resolves against the operator's real repository — writing
+    # `.jarvis/probe_baseline.json` and leaking an accepted floor into the
+    # next test, which is why the "no baseline" case passed alone and failed
+    # in a full run. Redirecting the ROOT covers instruments this fixture
+    # has never heard of, which is the only version that stays correct when
+    # the third instrument lands.
+    monkeypatch.setenv("JARVIS_PROJECT_ROOT", str(tmp_path))
+    monkeypatch.setenv("JARVIS_EVIDENCE_BASELINE_PATH",
+                       str(tmp_path / "evidence.json"))
+    monkeypatch.setenv("JARVIS_REACH_BASELINE_PATH",
+                       str(tmp_path / "reach.json"))
+    yield
+
+
+def _instrument(name="probe", buckets=None, scanned=7, **kw):
+    payload = buckets if buckets is not None else {"a": ("x",), "b": ()}
+
+    async def _run():
+        return payload
+
+    return ar.Instrument(name=name, run=_run,
+                         findings=lambda r: r, scanned=lambda r: scanned, **kw)
+
+
+def _ratchet_for(**kw):
+    return ar.AuditRatchet(_instrument(**kw))
+
+
+# -- the ratchet -----------------------------------------------------------
+
+
+async def test_no_baseline_reports_nothing_rather_than_everything():
+    """A fresh checkout has not regressed — it has not been measured.
+
+    Reporting the standing list as new is how the previous four detectors
+    taught people to ignore them.
+    """
+    d = await _ratchet_for().drift()
+    assert d.baseline_exists is False
+    assert d.regressed is False and not d.resolved
+
+
+async def test_accept_then_drift_is_silent():
+    r = _ratchet_for()
+    await r.accept()
+    d = await r.drift()
+    assert d.baseline_exists is True and d.regressed is False
+
+
+async def test_a_new_finding_is_loud_and_named_by_bucket():
+    r = _ratchet_for()
+    await r.accept()
+    grown = _ratchet_for(buckets={"a": ("x", "newcomer"), "b": ()})
+    d = await grown.drift()
+    assert d.regressed is True
+    assert d.bucket("a") == ("newcomer",)
+    assert d.bucket("b") == ()
+
+
+async def test_buckets_are_compared_independently():
+    """"a new orphan" and "a newly asymmetric module" are different news."""
+    r = _ratchet_for(buckets={"a": ("x",), "b": ()})
+    await r.accept()
+    d = await _ratchet_for(buckets={"a": ("x",), "b": ("fresh",)}).drift()
+    assert d.bucket("a") == () and d.bucket("b") == ("fresh",)
+
+
+async def test_a_fix_is_reported_as_resolved():
+    r = _ratchet_for(buckets={"a": ("x", "y")})
+    await r.accept()
+    d = await _ratchet_for(buckets={"a": ("x",)}).drift()
+    assert d.resolved == ("y",) and d.regressed is False
+
+
+async def test_a_bucket_that_vanishes_entirely_still_counts_as_resolved():
+    """Dropping it would silently forget a fix."""
+    r = _ratchet_for(buckets={"a": ("x",), "gone": ("z",)})
+    await r.accept()
+    d = await _ratchet_for(buckets={"a": ("x",)}).drift()
+    assert "z" in d.resolved
+
+
+async def test_a_corrupt_baseline_reads_as_absent_not_empty(tmp_path):
+    """Empty would report every standing finding as newly regressed —
+    a hundred false positives arriving mid disk-fault recovery."""
+    r = _ratchet_for()
+    await r.accept()
+    r.baseline_path().write_text("{not json", encoding="utf-8")
+    d = await r.drift()
+    assert d.baseline_exists is False and d.regressed is False
+
+
+async def test_an_unrecognised_shape_reads_as_absent():
+    r = _ratchet_for()
+    r.baseline_path().parent.mkdir(parents=True, exist_ok=True)
+    r.baseline_path().write_text(json.dumps({"something": "else"}),
+                                 encoding="utf-8")
+    assert (await r.drift()).baseline_exists is False
+
+
+async def test_an_exploding_audit_degrades_rather_than_raising():
+    async def _boom():
+        raise RuntimeError("scan exploded")
+
+    r = ar.AuditRatchet(ar.Instrument(
+        name="probe", run=_boom, findings=lambda r: {}))
+    d = await r.drift()
+    assert d.error and d.regressed is False
+
+
+async def test_the_baseline_is_published_atomically(monkeypatch):
+    from backend.core.ouroboros.governance import durable_io
+
+    seen = []
+    real = durable_io.atomic_replace
+    monkeypatch.setattr(durable_io, "atomic_replace",
+                        lambda t, d: (seen.append((t, d)), real(t, d))[1])
+    r = _ratchet_for()
+    await r.accept()
+    assert seen, "published without atomic_replace"
+    assert not seen[0][0].exists(), "the temp file survived the publish"
+
+
+def test_state_is_per_repository_never_global(monkeypatch, tmp_path):
+    """An accepted floor is a judgement about ONE checkout's code."""
+    monkeypatch.delenv("JARVIS_EVIDENCE_BASELINE_PATH", raising=False)
+    here = tmp_path / "checkout"
+    monkeypatch.setenv("JARVIS_PROJECT_ROOT", str(here))
+    assert ev.RATCHET.baseline_path().is_relative_to(here)
+
+
+# -- the legacy adapter: adopting the ratchet must not lose a floor --------
+
+
+async def test_a_pre_ratchet_baseline_is_still_honoured(tmp_path):
+    """`/reach` had a flat on-disk format before the ratchet existed.
+
+    Reading it as unrecognised would tell the operator "no baseline
+    recorded" and return every standing finding as new — silently
+    discarding a floor they had accepted.
+    """
+    rr.baseline_path().parent.mkdir(parents=True, exist_ok=True)
+    rr.baseline_path().write_text(json.dumps({
+        "schema_version": "reach_repl.1",
+        "asymmetric": ["mod.a"], "orphans": ["mod.b"],
+        "surfaces": ["daemon"], "scanned": 3,
+    }), encoding="utf-8")
+
+    class _M:
+        def __init__(self, name): self.module = name
+
+    class _R:
+        scanned = 3
+        surface_labels = ("daemon",)
+        modules = []
+        def asymmetric(self): return [_M("mod.a")]
+        def orphans(self): return [_M("mod.b")]
+
+    async def _run():
+        return _R()
+
+    ratchet = ar.AuditRatchet(ar.Instrument(
+        name="reach", run=_run, findings=rr._findings,
+        scanned=lambda r: r.scanned,
+        baseline_filename="surface_reachability_baseline.json",
+        legacy_buckets=rr._legacy_buckets))
+    d = await ratchet.drift()
+    assert d.baseline_exists is True, "the accepted floor was discarded"
+    assert d.regressed is False
+
+
+def test_the_legacy_reader_does_not_adopt_surfaces_as_a_bucket():
+    """Inferring buckets from "any key holding a list of strings" would
+    report a renamed surface label as a regression."""
+    got = rr._legacy_buckets({"asymmetric": ["a"], "orphans": [],
+                              "surfaces": ["daemon", "attach"]})
+    assert set(got) == {"asymmetric", "orphans"}
+
+
+# -- the mount: this module WAS the finding --------------------------------
+
+
+async def test_evidence_is_reachable_by_typing_it():
+    """`source_assertion_audit` shipped complete, tested, and uncallable."""
+    from backend.core.ouroboros.governance import repl_verb_cage as cage
+
+    result = await cage.dispatch_async("/evidence help")
+    assert result is not None, "/evidence is not mounted"
+    assert "source assertion" in result.text.lower()
+
+
+async def test_the_verb_measures_the_real_repository():
+    out = await ev.dispatch_evidence_command("/evidence rate")
+    assert out.ok and "RATE" in out.text and "source_only" in out.text
+
+
+async def test_the_verb_adds_no_analysis_of_its_own():
+    """Every number comes from source_assertion_audit — a second
+    implementation would be a second opinion about the same tree."""
+    code = code_of(ev)
+    assert "source_assertion_audit" in code
+    for banned in ("ast.parse", "os.walk"):
+        assert banned not in code
+
+
+async def test_an_unknown_query_refuses_rather_than_returning_nothing():
+    out = await ev.dispatch_evidence_command("/evidence no_such_thing_xyz")
+    assert out.ok is False and "no source-only test matching" in out.text
+
+
+async def test_the_finding_key_is_stable_under_line_shifts():
+    """Including the line number would report a whole file as newly
+    source-only after one insertion above it."""
+    class _V:
+        module, name, lineno = "tests/x.py", "test_a", 10
+    a = ev._key(_V())
+    _V.lineno = 400
+    assert ev._key(_V()) == a
+
+
+# -- declaring a ratchet mounts its watchdog -------------------------------
+
+
+def test_both_instruments_are_registered_by_declaration():
+    names = {r.instrument.name for r in ar.registered_ratchets()}
+    assert {"reach", "evidence"} <= names
+
+
+def test_registration_is_discovered_not_listed():
+    """A hardcoded list is a thing to forget — which is how
+    `reach_repl.run_watchdog` shipped with zero production callers."""
+    code = code_of(ar, "registered_ratchets")
+    assert "repl_verb_cage" in code
+    assert "reach" not in code and "evidence" not in code
+
+
+async def test_one_exploding_instrument_does_not_cancel_the_others(
+        monkeypatch):
+    """A diagnostic that can take down the boot it reports on is a
+    liability rather than an asset."""
+    good = _ratchet_for(name="good")
+
+    async def _boom():
+        raise RuntimeError("nope")
+
+    bad = ar.AuditRatchet(ar.Instrument(
+        name="bad", run=_boom, findings=lambda r: {}))
+    monkeypatch.setattr(ar, "registered_ratchets", lambda: [bad, good])
+    out = await ar.run_registered_watchdogs()
+    assert set(out) == {"bad", "good"}
+    assert out["bad"].error and out["good"].baseline_exists is False
+
+
+def test_the_master_switch_silences_the_whole_sweep(monkeypatch):
+    monkeypatch.setenv("JARVIS_AUDIT_WATCHDOGS_ENABLED", "false")
+    assert ar.spawn_registered_watchdogs() is None
+
+
+def test_spawning_outside_a_loop_is_not_an_error():
+    """A synchronous context has nothing to schedule onto."""
+    assert ar.spawn_registered_watchdogs() is None
+
+
+async def test_spawning_inside_a_loop_returns_a_task(monkeypatch):
+    monkeypatch.setattr(ar, "registered_ratchets", lambda: [])
+    task = ar.spawn_registered_watchdogs()
+    assert task is not None
+    await task
+
+
+# -- the boot seam: the defect this whole arc exists to stop ---------------
+
+
+def test_the_boot_seam_spawns_the_sweep():
+    """`reach_repl.run_watchdog` was correct, tested and never called."""
+    from backend.core.ouroboros.governance import governed_loop_service as gls
+
+    code = code_of(gls)
+    assert "spawn_registered_watchdogs" in code, (
+        "the audit watchdogs have no production caller — again")
+
+
+def test_the_boot_seam_names_no_instrument():
+    """Wiring two by name would re-create the defect for the third."""
+    from backend.core.ouroboros.governance import governed_loop_service as gls
+
+    code = code_of(gls)
+    assert "reach_repl" not in code and "evidence_repl" not in code
+
+
+def test_teardown_cancels_the_sweep_on_both_paths():
+    """A scan outliving its service parses a tree nobody is serving."""
+    from backend.core.ouroboros.governance import governed_loop_service as gls
+
+    for seam in ("stop", "_teardown_partial"):
+        assert "_cancel_audit_watchdogs" in code_of(gls, seam), seam
+    assert "cancel" in code_of(gls, "_cancel_audit_watchdogs")
+
+
+def test_the_sweep_is_never_awaited_by_boot():
+    """A watchdog that delayed startup by its own scan gets deleted the
+    first time somebody profiles boot — and then it is gone again."""
+    from backend.core.ouroboros.governance import governed_loop_service as gls
+
+    code = code_of(gls)
+    assert "await _spawn_audits" not in code
+    assert "await spawn_registered_watchdogs" not in code

--- a/tests/governance/test_reach_repl.py
+++ b/tests/governance/test_reach_repl.py
@@ -129,12 +129,31 @@ async def test_a_baseline_that_is_not_an_object_is_treated_as_absent(monkeypatch
     assert (await rr.drift()).baseline_exists is False
 
 
-def test_the_baseline_is_published_atomically():
+async def test_the_baseline_is_published_atomically(monkeypatch):
     """A baseline half-written by a crash reads as corrupt on the next
     boot, which degrades to 'no baseline' and floods the operator exactly
-    when they are already recovering."""
-    import inspect
-    assert "atomic_replace" in inspect.getsource(rr.accept_baseline)
+    when they are already recovering.
+
+    OBSERVED, not spelt. This asserted that `accept_baseline`'s SOURCE
+    mentions `atomic_replace` — a SOURCE_ONLY test in the exact sense
+    `source_assertion_audit` measures. It passed while saying nothing about
+    whether the write was atomic, and it broke when the implementation
+    correctly moved to the shared ratchet even though the property held.
+    """
+    from backend.core.ouroboros.governance import durable_io
+
+    seen = []
+    real = durable_io.atomic_replace
+    monkeypatch.setattr(durable_io, "atomic_replace",
+                        lambda tmp, dst: (seen.append((tmp, dst)),
+                                          real(tmp, dst))[1])
+    monkeypatch.setattr(rr, "_audit", _fake_audit(asym=("a",)))
+    await rr.accept_baseline()
+    assert seen, "the baseline was published without atomic_replace"
+    tmp, dst = seen[0]
+    assert dst == rr.baseline_path()
+    assert not tmp.exists(), "the temp file survived the publish"
+    assert json.loads(dst.read_text())["buckets"]["asymmetric"] == ["a"]
 
 
 async def test_a_failing_audit_degrades_rather_than_raising(monkeypatch):
@@ -172,9 +191,28 @@ async def test_the_watchdog_warns_on_regression(monkeypatch, caplog):
 @pytest.mark.asyncio
 async def test_the_watchdog_runs_off_the_event_loop():
     """The audit walks the module tree and parses every file — far too much
-    work for the loop that also runs the organism."""
-    import inspect
-    assert "to_thread" in inspect.getsource(rr.run_watchdog)
+    work for the loop that also runs the organism.
+
+    MEASURED, not spelt. The old assertion looked for `to_thread` in the
+    source and would have kept passing had the call been deleted from a
+    branch it never took — and it broke when the offload correctly moved to
+    `surface_reachability.audit_async`, though the property was intact.
+    Here the loop must actually keep ticking.
+    """
+    import asyncio
+
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    hb = asyncio.create_task(heartbeat())
+    await rr.run_watchdog()
+    hb.cancel()
+    assert ticks > 5, "the loop stalled for the length of the audit"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What was orphaned

`source_assertion_audit` measures how many tests **cannot fail for a behavioural reason** — every assertion touches source text, so nothing was executed. That is the mechanism that hid every inert capability the other detectors later found: three tests certified `/narrate verbose` worked by confirming the handler's *source* mentioned a flag no code read, and they would have passed forever.

It shipped complete, with a full test file, and zero production callers. Its own docstring anticipated the risk on the wrong axis — *"an instrument that measures dead code and is not itself covered is subject to its own criterion"*. Being covered did not save it.

## And the ratchet was orphaned too

`reach_repl.run_watchdog` — written, tested, documented — **also had zero production callers**. The ratchet built to catch capabilities that ship unreachable was itself unreachable. Mounting `/evidence` by hand would have produced a second copy of that, so the fix is structural on both axes:

| declaring… | mounts… | |
|---|---|---|
| a **dispatcher** | the verb | the naming cage, shipped |
| a **ratchet** | its boot watchdog | this PR |

## One ratchet, N instruments

Every instrument needs an accepted baseline, drift, accept and a boot watchdog — none of which is about what it measures. `reach_repl` grew all four inline; copying them duplicates ~130 lines of persistence, degradation policy and comparison logic that then drift apart because they're fixed separately.

`audit_ratchet.Instrument` carries a name, an async `run`, and a `findings` function returning `{bucket: [stable key]}`. **The ratchet never learns what a finding means** — it compares sets of strings. That's what lets one implementation serve a reachability graph and a test-quality scan, and what lets the third instrument arrive as a declaration.

`reach_repl` now delegates. **19 of its 21 tests passed unchanged** — that's the evidence the refactor preserved behaviour. The two that failed asserted that `accept_baseline`'s source contains `atomic_replace` and `run_watchdog`'s contains `to_thread`: SOURCE_ONLY tests in the exact sense the newly-mounted instrument measures. They said nothing about whether the write was atomic or the loop stayed free, and they broke when the implementation correctly moved while both properties held. Rewritten to observe — one asserts `atomic_replace` was actually called and the temp file is gone, the other that the loop keeps ticking during the scan.

## Load-bearing choices

- **`Instrument.legacy_buckets`** — `/reach` had a flat on-disk format before the ratchet existed. Reading it as unrecognised would tell the operator "no baseline recorded" and return every standing finding as new, silently discarding a floor they accepted. Owned by the instrument (it's the instrument's own history); named explicitly rather than inferred from "any key holding a list of strings", which would adopt `surfaces` and report a renamed label as a regression.
- **Buckets compared independently** — "a new orphan" and "a newly asymmetric module" are different news.
- **A corrupt or unrecognised baseline reads as ABSENT, never empty** — empty manufactures one false positive per standing finding, arriving exactly when someone is recovering from a disk fault.
- **`/evidence` watches the SET, not the rate** — a rate that improves because tests were deleted is not progress; one that worsens because the suite grew is not a regression.
- **Finding keys are `module::name`, no line number** — otherwise one insertion reports a whole file as newly source-only.
- **The boot seam names no instrument.** Wiring two by hand re-creates the defect for the third. Spawned, never awaited: a watchdog that delayed startup by its own scan is one somebody deletes the first time they profile boot. Cancelled on both teardown paths.

## Measured

```
/evidence rate  →  3513 files · 60167 tests
                   behavioural 55120 · structural_pin 186 · source_only 989 · no_assertion 3872
                   RATE 1.76%  (989 tests can only ever pass) · flag-literal class: 54

boot sweep      →  returns immediately; loop ticks 600x during it
                   evidence: scanned 60195 · reach: scanned 163
```

## Tests

- 49 green (28 new; the 21 reach tests unchanged in shape).
- Sweep of 3100 against a same-selection worktree baseline at `81b1956698`: **zero regressions**.
- One test in `test_bounded_shutdown_watchdog.py` is flaky — it fails and passes in isolation on code this branch does not touch.

Neither baseline is pinned: `/reach` and `/evidence` both report *"no baseline recorded"* until an operator runs `accept`. Deciding that 989 source-only tests are the accepted floor is a judgement call, not something this PR should make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts the evidence audit as `/evidence` and introduces a shared audit ratchet used by `/reach` and `/evidence` to manage baselines, drift, and boot-time watchdogs. Previously, the evidence audit and the reach watchdog had no production callers; now both mount by declaration and surface regressions without steady-state noise.

- Declares `RATCHET` in `evidence_repl` and `reach_repl`; `audit_ratchet` discovers these via the naming cage and runs their watchdogs at boot.
- Adds `backend/core/ouroboros/governance/audit_ratchet.py` with `Instrument`, `AuditRatchet`, `run_registered_watchdogs`, and `spawn_registered_watchdogs`; compares bucketed findings, persists per-repo baselines atomically, and treats corrupt/unrecognised baselines as absent.
- Adds `backend/core/ouroboros/governance/evidence_repl.py` to expose `/evidence` (rate, list, filters, accept) and mount the evidence watchdog; findings key is `module::name` (no line).
- Refactors `reach_repl` to delegate to the ratchet; preserves baseline filename and reads the pre-ratchet flat format via `legacy_buckets`.
- Updates `governed_loop_service` to spawn the watchdog sweep in the background at boot and cancel it on both teardown paths; names no instrument.
- Adds `audit_async` to `source_assertion_audit` to run heavy scans off the loop; updates PRD docs.

- Required actions:
  - Run `/evidence accept` once to pin the initial baseline; otherwise the watchdog reports “no baseline recorded.”
  - Optional env: `JARVIS_AUDIT_WATCHDOGS_ENABLED` (master), `JARVIS_EVIDENCE_WATCHDOG_ENABLED`, `JARVIS_REACH_WATCHDOG_ENABLED`, `JARVIS_PROJECT_ROOT`, and per-instrument `*_BASELINE_PATH` overrides. Existing `/reach` baselines need no migration.

<sup>Written for commit 8459f15f2f1bb9f2794a4d442b21f5b56d756480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

