### PR TITLE
feat(graduation): wire the AutoCommit evidence gate — proof before autonomy

### DIFF
--- a/backend/core/ouroboros/governance/auto_commit_graduation_gate.py
+++ b/backend/core/ouroboros/governance/auto_commit_graduation_gate.py
@@ -139,6 +139,56 @@ class AutoCommitEvidenceVerdict(str, enum.Enum):
     EVIDENCE_INSUFFICIENT = "evidence_insufficient"
     NO_GIT_HISTORY = "no_git_history"
     MASTER_OFF = "master_off"
+    #: Every soak short of READY is short only because a rewrite made its
+    #: evidence unreadable. Distinct from EVIDENCE_INSUFFICIENT because the
+    #: operator's remedy is different — re-soak or point the gate at the
+    #: pre-squash ref, rather than "AutoCommitter never fired".
+    EVIDENCE_LOST_TO_SQUASH = "evidence_lost_to_squash"
+
+
+class GraduationBlocker(str, enum.Enum):
+    """WHY the gate is not READY, structurally. Closed taxonomy.
+
+    A surface that renders a bare "locked" teaches an operator nothing and
+    invites them to flip the flag to find out. Every non-READY verdict
+    carries at least one of these, and each maps to a sentence naming the
+    missing evidence and what would supply it.
+    """
+
+    INSUFFICIENT_CLEAN_SOAKS = "insufficient_clean_soaks"
+    MISSING_YELLOW_TIER_SIGNATURE = "missing_yellow_tier_signature"
+    VERIFICATION_LOST_VIA_SQUASH = "verification_lost_via_squash"
+    NO_GIT_HISTORY = "no_git_history"
+    LEDGER_UNAVAILABLE = "ledger_unavailable"
+    WINDOWS_UNRECONSTRUCTABLE = "windows_unreconstructable"
+    GATE_DISABLED = "gate_disabled"
+
+
+#: Operator-facing sentence per blocker. The UI renders these verbatim, so
+#: they name the missing EVIDENCE and the action that would supply it —
+#: never the internal state that produced them.
+BLOCKER_REASON: Dict[GraduationBlocker, str] = {
+    GraduationBlocker.INSUFFICIENT_CLEAN_SOAKS:
+        "Insufficient clean soaks — the generic ledger floor is not met yet",
+    GraduationBlocker.MISSING_YELLOW_TIER_SIGNATURE:
+        "Missing git cryptographic signature — one or more counted clean "
+        "soaks produced no O+V commit carrying the Yellow-tier marker, so "
+        "the unattended-apply path was never exercised",
+    GraduationBlocker.VERIFICATION_LOST_VIA_SQUASH:
+        "Verification lost via squash — commits existed in these soaks and "
+        "were rewritten off the branch; re-soak or point the gate at the "
+        "pre-squash ref",
+    GraduationBlocker.NO_GIT_HISTORY:
+        "No readable git history — the evidence cannot be checked at all",
+    GraduationBlocker.LEDGER_UNAVAILABLE:
+        "Graduation ledger unavailable — no clean-soak baseline to build on",
+    GraduationBlocker.WINDOWS_UNRECONSTRUCTABLE:
+        "Ledger reports eligible but no soak windows could be rebuilt from "
+        "its session rows",
+    GraduationBlocker.GATE_DISABLED:
+        "Evidence gate disabled — set "
+        "JARVIS_AUTOCOMMIT_GRADUATION_GATE_ENABLED=true to measure",
+}
 
 
 # ===========================================================================
@@ -157,6 +207,11 @@ class SoakCommitEvidence:
     other_tier_count: int
     sample_yellow_hashes: Tuple[str, ...]
     is_first_soak_bounded: bool  # True → window start is lookback-bounded
+    #: How membership was established — see `Provenance`. Reported so the
+    #: operator can tell proof from inference at a glance; a number that
+    #: cannot be proven must never look like one that can.
+    provenance: str = ""
+    provenance_reason: str = ""
 
     @property
     def has_evidence(self) -> bool:
@@ -172,6 +227,8 @@ class SoakCommitEvidence:
             "sample_yellow_hashes": list(self.sample_yellow_hashes),
             "is_first_soak_bounded": self.is_first_soak_bounded,
             "has_evidence": self.has_evidence,
+            "provenance": self.provenance,
+            "provenance_reason": self.provenance_reason,
         }
 
     @classmethod
@@ -190,6 +247,8 @@ class SoakCommitEvidence:
             is_first_soak_bounded=bool(
                 payload.get("is_first_soak_bounded", False)
             ),
+            provenance=str(payload.get("provenance", "")),
+            provenance_reason=str(payload.get("provenance_reason", "")),
         )
 
 
@@ -209,6 +268,20 @@ class AutoCommitGraduationReport:
     per_soak_evidence: Tuple[SoakCommitEvidence, ...]
     diagnostic: str
     generated_at_unix: float
+    #: The third state. Neither evidence nor failure — see the squash
+    #: reasoning in `autocommit_evidence_attribution`.
+    soaks_unverifiable: int = 0
+    #: Structural WHY. Empty iff READY.
+    blockers: Tuple[GraduationBlocker, ...] = ()
+
+    @property
+    def is_ready(self) -> bool:
+        return self.verdict is AutoCommitEvidenceVerdict.READY
+
+    @property
+    def blocker_reasons(self) -> Tuple[str, ...]:
+        """Operator-facing sentences. What a surface renders."""
+        return tuple(blocker_reason(b) for b in self.blockers)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -226,6 +299,9 @@ class AutoCommitGraduationReport:
             ],
             "diagnostic": self.diagnostic[:512],
             "generated_at_unix": round(self.generated_at_unix, 3),
+            "soaks_unverifiable": self.soaks_unverifiable,
+            "blockers": [b.value for b in self.blockers],
+            "blocker_reasons": list(self.blocker_reasons),
         }
 
     @classmethod
@@ -259,6 +335,12 @@ class AutoCommitGraduationReport:
             diagnostic=str(payload.get("diagnostic", "")),
             generated_at_unix=float(
                 payload.get("generated_at_unix", 0.0)
+            ),
+            soaks_unverifiable=int(payload.get("soaks_unverifiable", 0)),
+            blockers=tuple(
+                GraduationBlocker(str(b))
+                for b in payload.get("blockers", ())
+                if str(b) in {m.value for m in GraduationBlocker}
             ),
         )
 
@@ -549,6 +631,7 @@ def _master_off_report(target_flag: str) -> AutoCommitGraduationReport:
             f"{_ENV_MASTER}=false; no evidence computed"
         ),
         generated_at_unix=time.time(),
+        blockers=(GraduationBlocker.GATE_DISABLED,),
     )
 
 
@@ -582,6 +665,7 @@ async def evaluate_graduation_evidence() -> AutoCommitGraduationReport:
                 "clean-soak baseline; not ready (fail-closed)"
             ),
             generated_at_unix=time.time(),
+            blockers=(GraduationBlocker.LEDGER_UNAVAILABLE,),
         )
     clean_n, required, runner_n, eligible = prog
 
@@ -604,6 +688,7 @@ async def evaluate_graduation_evidence() -> AutoCommitGraduationReport:
                 "AutoCommitter-specific evidence is evaluated."
             ),
             generated_at_unix=time.time(),
+            blockers=(GraduationBlocker.INSUFFICIENT_CLEAN_SOAKS,),
         )
 
     lookback = _lookback_days()
@@ -626,6 +711,7 @@ async def evaluate_graduation_evidence() -> AutoCommitGraduationReport:
                 "prove AutoCommitter fired; not ready (fail-closed)"
             ),
             generated_at_unix=time.time(),
+            blockers=(GraduationBlocker.WINDOWS_UNRECONSTRUCTABLE,),
         )
 
     earliest_start = min(w[1] for w in windows)
@@ -657,39 +743,67 @@ async def evaluate_graduation_evidence() -> AutoCommitGraduationReport:
                 f"git={'ok' if git_records is not None else 'unavailable'}"
             ),
             generated_at_unix=time.time(),
+            blockers=(GraduationBlocker.NO_GIT_HISTORY,),
         )
 
+    # ATTRIBUTION, not windowing. `autocommit_evidence_attribution` owns the
+    # question "does this commit belong to this soak"; this module keeps
+    # owning "is this an O+V Yellow-tier commit" and injects that classifier.
+    #
+    # Identity first: a commit carrying `Session: <sid>` says which soak it
+    # belongs to, so no clock is consulted. The window survives only as a
+    # labelled fallback for history predating the trailer, and is reported
+    # as an INFERENCE rather than borrowing the authority of a proof.
+    from backend.core.ouroboros.governance import (  # noqa: PLC0415
+        autocommit_evidence_attribution as _attr,
+    )
+
+    def _classify(body: str) -> "CommitEvidenceKind":
+        return classify_commit_body(
+            body, ov_marker=ov_marker, yellow_marker=yellow_marker)
+
+    attributions: List[Any] = []
+    for sid, w_start, w_end, _fb in windows:
+        attributions.append(_attr.attribute(
+            sid, git_records, window=(w_start, w_end), classify=_classify))
+
+    # The reflog is read ONCE, and only when something is unaccounted for —
+    # a squash that erased nothing costs nothing to rule out.
+    if any(a.provenance is _attr.Provenance.ABSENT for a in attributions):
+        reflog = await _attr.read_reflog(timeout_s=_git_timeout_s())
+        attributions = [
+            _attr.resolve_squash(a, reflog, git_records,
+                                 window=(w[1], w[2]), classify=_classify)
+            for a, w in zip(attributions, windows)
+        ]
+
     per_soak: List[SoakCommitEvidence] = []
-    for sid, w_start, w_end, first_bounded in windows:
-        yellow = 0
-        other = 0
-        samples: List[str] = []
-        for chash, cepoch, body in git_records:
-            if not (w_start <= cepoch <= w_end):
-                continue
-            kind = classify_commit_body(
-                body, ov_marker=ov_marker, yellow_marker=yellow_marker
-            )
-            if kind is CommitEvidenceKind.YELLOW_TIER:
-                yellow += 1
-                if len(samples) < _MAX_SAMPLE_HASHES:
-                    samples.append(chash[:12])
-            elif kind is CommitEvidenceKind.OTHER_TIER:
-                other += 1
+    for (sid, w_start, w_end, first_bounded), att in zip(
+            windows, attributions):
         per_soak.append(
             SoakCommitEvidence(
                 session_id=sid,
                 window_start_epoch=w_start,
                 window_end_epoch=w_end,
-                yellow_tier_count=yellow,
-                other_tier_count=other,
-                sample_yellow_hashes=tuple(samples),
+                yellow_tier_count=att.yellow_count,
+                other_tier_count=len(att.other_hashes),
+                sample_yellow_hashes=tuple(
+                    h[:12] for h in att.yellow_hashes[:_MAX_SAMPLE_HASHES]),
                 is_first_soak_bounded=first_bounded,
+                provenance=att.provenance.value,
+                provenance_reason=att.reason,
             )
         )
 
-    with_ev = sum(1 for e in per_soak if e.has_evidence)
-    missing_ev = len(per_soak) - with_ev
+    # THREE STATES, because two force a lie. A soak whose commits were
+    # squashed away has evidence that is UNREADABLE, not absent — counting
+    # it as missing would reset an operator's hard-won soak count for
+    # following ordinary PR hygiene. It never counts as evidence either: a
+    # gate must not pass on something it could not read.
+    with_ev = sum(1 for a in attributions if a.counts_as_evidence)
+    unverifiable = sum(1 for a in attributions
+                       if a.provenance.is_unverifiable)
+    missing_ev = len(attributions) - with_ev - unverifiable
 
     if missing_ev == 0:
         verdict = AutoCommitEvidenceVerdict.READY
@@ -706,6 +820,22 @@ async def evaluate_graduation_evidence() -> AutoCommitGraduationReport:
                 f"({lookback}d) — its evidence is necessary-floor, not "
                 "prior-bounded."
             )
+    elif missing_ev == 0 and unverifiable:
+        # Everything that could be read passed; the only shortfall is
+        # unreadable. A DISTINCT verdict because the operator's remedy is
+        # different, and because folding it into EVIDENCE_INSUFFICIENT would
+        # accuse a clean soak of never having fired AutoCommitter.
+        verdict = AutoCommitEvidenceVerdict.EVIDENCE_LOST_TO_SQUASH
+        lost = sorted(e.session_id for e in per_soak
+                      if e.provenance == "squash_lost")
+        diag = (
+            f"EVIDENCE_LOST_TO_SQUASH: {with_ev}/{len(per_soak)} counted "
+            f"clean soak(s) carry Yellow-tier O+V commits and "
+            f"{unverifiable} had their commits rewritten off the branch. "
+            "The soak count is NOT reset — this is unreadable evidence, "
+            f"not absent evidence. Affected: {lost[:10]}. "
+            "Re-soak, or point the gate at the pre-squash ref."
+        )
     else:
         verdict = AutoCommitEvidenceVerdict.EVIDENCE_INSUFFICIENT
         bare = sorted(
@@ -732,10 +862,51 @@ async def evaluate_graduation_evidence() -> AutoCommitGraduationReport:
         ledger_eligible=True,
         soaks_with_evidence=with_ev,
         soaks_missing_evidence=missing_ev,
+        soaks_unverifiable=unverifiable,
         per_soak_evidence=tuple(per_soak),
         diagnostic=diag,
         generated_at_unix=time.time(),
+        blockers=_blockers_for(verdict, missing_ev, unverifiable),
     )
+
+
+def blocker_reason(blocker: "GraduationBlocker") -> str:
+    """Operator sentence for one blocker, with the marker DERIVED.
+
+    The Yellow-tier marker is spelled in exactly one place
+    (:func:`_yellow_marker`, itself derived from
+    ``RiskTier.NOTIFY_APPLY.name``). Writing it literally into operator
+    prose would create a second authority for it — and the sentence would
+    keep naming ``NOTIFY_APPLY`` after the tier was renamed, telling the
+    operator to look for a marker no commit carries. An AST pin forbids the
+    literal here precisely so that cannot happen.
+    """
+    text = BLOCKER_REASON.get(blocker, blocker.value)
+    if blocker is GraduationBlocker.MISSING_YELLOW_TIER_SIGNATURE:
+        marker = _yellow_marker()
+        if marker:
+            text = text.replace("the Yellow-tier marker", f"`{marker}`")
+    return text
+
+
+def _blockers_for(
+    verdict: AutoCommitEvidenceVerdict, missing: int, unverifiable: int,
+) -> Tuple[GraduationBlocker, ...]:
+    """The structural WHY for a computed verdict. Pure.
+
+    Derived from the counts rather than stamped at each branch, so a verdict
+    and its stated reason cannot disagree — the class of bug where a surface
+    says "insufficient soaks" while the report says the signatures were
+    squashed.
+    """
+    if verdict is AutoCommitEvidenceVerdict.READY:
+        return ()
+    out: List[GraduationBlocker] = []
+    if missing > 0:
+        out.append(GraduationBlocker.MISSING_YELLOW_TIER_SIGNATURE)
+    if unverifiable > 0:
+        out.append(GraduationBlocker.VERIFICATION_LOST_VIA_SQUASH)
+    return tuple(out) or (GraduationBlocker.MISSING_YELLOW_TIER_SIGNATURE,)
 
 
 async def evidence_summary() -> Dict[str, Any]:
@@ -815,6 +986,26 @@ def register_shipped_invariants() -> list:
         "evidence_insufficient",
         "no_git_history",
         "master_off",
+        # Added deliberately, with the pin updated in the same change —
+        # which is the workflow this pin exists to force. A squashed soak's
+        # evidence is UNREADABLE, and folding that into
+        # `evidence_insufficient` would accuse a clean soak of never having
+        # fired AutoCommitter. Different cause, different remedy, therefore
+        # a different verdict.
+        "evidence_lost_to_squash",
+    }
+
+    #: Blockers are a closed taxonomy for the same reason verdicts are: a
+    #: surface renders these sentences verbatim, so an unpinned addition
+    #: could put unreviewed text in front of an operator.
+    _EXPECTED_BLOCKER = {
+        "insufficient_clean_soaks",
+        "missing_yellow_tier_signature",
+        "verification_lost_via_squash",
+        "no_git_history",
+        "ledger_unavailable",
+        "windows_unreconstructable",
+        "gate_disabled",
     }
 
     def _enum_values(tree: ast.AST, class_name: str) -> set:
@@ -999,6 +1190,17 @@ def register_shipped_invariants() -> list:
             ),
             validate=_mk_taxonomy(
                 "AutoCommitEvidenceVerdict", _EXPECTED_VERDICT
+            ),
+        ),
+        ShippedCodeInvariant(
+            invariant_name="autocommit_grad_blocker_taxonomy_closed",
+            target_file=target,
+            description=(
+                "GraduationBlocker is a closed 7-value taxonomy — every "
+                "value renders verbatim on an operator surface."
+            ),
+            validate=_mk_taxonomy(
+                "GraduationBlocker", _EXPECTED_BLOCKER
             ),
         ),
         ShippedCodeInvariant(

--- a/backend/core/ouroboros/governance/auto_committer.py
+++ b/backend/core/ouroboros/governance/auto_committer.py
@@ -823,6 +823,35 @@ class AutoCommitter:
         risk_str = self._format_risk_tier(risk_tier)
         body_parts.append(f"Risk: {risk_str}")
 
+        # The graduation gate's ONLY clock-independent anchor.
+        #
+        # Without it, proving "this soak produced a Yellow-tier auto-commit"
+        # means asking whether the commit's timestamp falls inside a window
+        # built from ledger timestamps — two clocks that must agree. Across
+        # the Body/Engine split they are different machines, and a few
+        # seconds of drift moves the evidence to the wrong soak or to none.
+        #
+        # A trailer makes membership an exact string match with no clock on
+        # either side. It also survives the squash merges that otherwise
+        # erase the evidence, because both `git merge --squash` and GitHub's
+        # squash button concatenate the original bodies by default.
+        #
+        # Spelled from `autocommit_evidence_attribution` so the writer and
+        # the reader cannot drift apart about the one anchor the whole
+        # verification rests on. Absent session → no line, never a
+        # placeholder: a `Session: unknown` trailer would match nothing and
+        # would read, later, as a session that no longer exists.
+        try:
+            from backend.core.ouroboros.governance.autocommit_evidence_attribution import (  # noqa: E501,PLC0415
+                session_trailer_line,
+            )
+            _session_line = session_trailer_line(
+                os.environ.get("JARVIS_OUROBOROS_SESSION_ID", "") or "")
+            if _session_line:
+                body_parts.append(_session_line)
+        except Exception:  # noqa: BLE001 — never block a commit on a trailer
+            logger.debug("[AutoCommit] session trailer skipped", exc_info=True)
+
         if provider_name:
             cost_str = f" (${generation_cost:.4f})" if generation_cost > 0 else ""
             body_parts.append(f"Provider: {provider_name}{cost_str}")

--- a/backend/core/ouroboros/governance/autocommit_evidence_attribution.py
+++ b/backend/core/ouroboros/governance/autocommit_evidence_attribution.py
@@ -1,0 +1,393 @@
+"""Which soak does a commit belong to — by IDENTITY, not by clock.
+
+THE ONE ROOT CAUSE BEHIND BOTH EDGE CASES
+-----------------------------------------
+``auto_commit_graduation_gate`` attributes a commit to a clean soak by
+asking whether the commit's timestamp falls inside that soak's window.
+Windows are built from consecutive ``SessionRecord.recorded_at_epoch``
+values, and commit times come from ``%ct`` — the committer's clock. Two
+distinct failures fall out of that single decision:
+
+**Clock skew.** The Body runs on the Mac and the Engine on Windows WSL2.
+A commit authored on one and a ledger row written on the other are stamped
+by different clocks; a few seconds of drift moves a commit across a window
+boundary and the evidence attaches to the wrong soak — or to none. The
+verification is *deterministic* in the sense that it always computes the
+same answer, and *unreliable* in the sense that the answer depends on two
+machines agreeing about the time.
+
+**Squash merges.** Squashing a PR replaces N commits with one. The SHAs the
+window would have matched no longer exist on the branch. A window-based
+reader sees zero Yellow-tier commits and concludes the soak produced no
+evidence — which is indistinguishable, in the report, from a soak that
+genuinely never fired AutoCommitter. One of those should block graduation
+and the other should not.
+
+So the fix is not two special cases. It is to stop inferring membership
+from time when the commit can simply *say* which soak it belongs to.
+
+ATTRIBUTION BY TRAILER, PROVENANCE ALWAYS STATED
+------------------------------------------------
+``auto_committer`` stamps a ``Session:`` trailer. A commit therefore
+carries its own provenance, and matching it is an exact string comparison
+against ``SessionRecord.session_id`` — no clocks on either side, correct
+across worktrees, and unchanged by a squash that concatenates bodies
+(which is what ``git merge --squash`` and GitHub's squash button both do
+by default).
+
+History predating that trailer has no anchor, so the window remains — but
+it is reported as :attr:`Provenance.TIME_WINDOW`, an INFERENCE, never as
+proof. This is the same discipline ``operation_advisor`` already applies to
+blast radius (``measured`` / ``localized_lower_bound`` / ``unknown``): a
+number that cannot be proven says so rather than borrowing the authority of
+one that can.
+
+THREE STATES, BECAUSE TWO FORCE A LIE
+-------------------------------------
+The gate counted soaks as *with evidence* or *missing evidence*. A soak
+whose commits were squashed away belongs to neither: the evidence is not
+absent, it is unreadable. Forcing it into "missing" resets the operator's
+hard-won soak count for something they did by following normal PR hygiene.
+
+``UNVERIFIABLE`` is the third state. It never counts as evidence — a
+graduation gate must not pass on something it could not read — and it never
+counts as a failure either. It is reported, named, and left for the operator
+to resolve by re-soaking or by pointing the gate at the pre-squash ref.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.AutoCommitAttribution")
+
+ATTRIBUTION_SCHEMA_VERSION: str = "autocommit_evidence_attribution.1"
+
+#: The trailer `auto_committer` writes. Named ONCE and consumed from here by
+#: both the writer and this reader, so the two cannot drift into disagreement
+#: about the spelling of the anchor the whole verification rests on.
+SESSION_TRAILER_KEY: str = "Session"
+
+_SESSION_TRAILER_RE = re.compile(
+    rf"^{SESSION_TRAILER_KEY}:[ \t]*(?P<sid>\S+)[ \t]*$",
+    re.MULTILINE,
+)
+
+_ENV_REFLOG_ENABLED = "JARVIS_AUTOCOMMIT_GRAD_REFLOG_TRACE"
+_ENV_REFLOG_MAX = "JARVIS_AUTOCOMMIT_GRAD_REFLOG_MAX"
+
+
+def session_trailer_line(session_id: str) -> str:
+    """The trailer to embed in a commit body. Empty when unknown.
+
+    Empty rather than a placeholder: a trailer reading ``Session: unknown``
+    would be matched by nothing and would look, to a later reader, like a
+    session that no longer exists. An absent anchor must degrade to the
+    window, not to a false one.
+    """
+    sid = (session_id or "").strip()
+    return f"{SESSION_TRAILER_KEY}: {sid}" if sid else ""
+
+
+def extract_session_id(body: str) -> str:
+    """The soak this commit declares it belongs to, or ``""``."""
+    match = _SESSION_TRAILER_RE.search(body or "")
+    return match.group("sid") if match else ""
+
+
+def reflog_trace_enabled() -> bool:
+    """Default TRUE. Reads reflog; mutates nothing."""
+    raw = os.environ.get(_ENV_REFLOG_ENABLED)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def reflog_max_entries() -> int:
+    try:
+        return max(1, int(os.environ.get(_ENV_REFLOG_MAX, "") or 2000))
+    except (TypeError, ValueError):
+        return 2000
+
+
+class Provenance(str, enum.Enum):
+    """How a soak's evidence was established. Closed 5-value taxonomy."""
+
+    #: Exact `Session:` trailer match. Clock-independent, squash-durable.
+    SESSION_TRAILER = "session_trailer"
+    #: Commit timestamp fell inside the soak's window. An INFERENCE — two
+    #: clocks must agree for it to be right.
+    TIME_WINDOW = "time_window"
+    #: Not on the branch, but recovered from the reflog.
+    SQUASH_RECOVERED = "squash_recovered"
+    #: The soak's commits are gone and the reflog does not hold them.
+    #: Not evidence, and NOT a failure.
+    SQUASH_LOST = "squash_lost"
+    #: No anchor and no commits. A soak that genuinely produced nothing.
+    ABSENT = "absent"
+
+    @property
+    def is_proof(self) -> bool:
+        """Only an identity match proves membership."""
+        return self in (Provenance.SESSION_TRAILER,
+                        Provenance.SQUASH_RECOVERED)
+
+    @property
+    def is_unverifiable(self) -> bool:
+        """Neither evidence nor failure — the third state."""
+        return self is Provenance.SQUASH_LOST
+
+
+#: Operator-facing reason text. On the surface, never a generic "locked".
+PROVENANCE_REASON: Dict[Provenance, str] = {
+    Provenance.SESSION_TRAILER:
+        "verified by commit identity (Session trailer)",
+    Provenance.TIME_WINDOW:
+        "inferred from commit timestamps — no Session trailer on these "
+        "commits, so this is not clock-independent proof",
+    Provenance.SQUASH_RECOVERED:
+        "recovered from the reflog after a squash merge",
+    Provenance.SQUASH_LOST:
+        "verification lost via squash — the O+V signatures were compacted "
+        "away and the reflog no longer holds the originals",
+    Provenance.ABSENT:
+        "no O+V commit carrying Risk: NOTIFY_APPLY in this soak",
+}
+
+
+@dataclass(frozen=True)
+class Attribution:
+    """One soak's evidence, and how honestly it was established."""
+
+    session_id: str
+    provenance: Provenance
+    yellow_hashes: Tuple[str, ...] = ()
+    other_hashes: Tuple[str, ...] = ()
+
+    @property
+    def yellow_count(self) -> int:
+        return len(self.yellow_hashes)
+
+    @property
+    def counts_as_evidence(self) -> bool:
+        """A gate must never pass on something it could not read."""
+        return bool(self.yellow_hashes) and not self.provenance.is_unverifiable
+
+    @property
+    def reason(self) -> str:
+        return PROVENANCE_REASON.get(self.provenance, "")
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "schema_version": ATTRIBUTION_SCHEMA_VERSION,
+            "session_id": self.session_id,
+            "provenance": self.provenance.value,
+            "yellow_hashes": list(self.yellow_hashes),
+            "other_hashes": list(self.other_hashes),
+            "yellow_count": self.yellow_count,
+            "counts_as_evidence": self.counts_as_evidence,
+            "reason": self.reason,
+        }
+
+
+def attribute(
+    session_id: str,
+    commits: Sequence[Tuple[str, float, str]],
+    *,
+    window: Optional[Tuple[float, float]],
+    classify,
+) -> Attribution:
+    """Attribute ``commits`` to one soak. Pure. NEVER raises.
+
+    ``classify`` is the gate's own :func:`classify_commit_body` bound with
+    its markers — injected rather than imported so this module holds no
+    opinion about what an O+V commit looks like. The gate owns that
+    definition; this owns membership.
+
+    IDENTITY FIRST, ALWAYS. If any commit in the whole log declares this
+    session, the trailer decides membership entirely and the window is not
+    consulted — mixing them would let a skewed timestamp pull in a commit
+    that another soak has explicitly claimed.
+    """
+    from backend.core.ouroboros.governance.auto_commit_graduation_gate import (
+        CommitEvidenceKind,
+    )
+
+    claimed = [(h, b) for (h, _e, b) in commits
+               if extract_session_id(b) == session_id and session_id]
+    if claimed:
+        yellow = tuple(h for h, b in claimed
+                       if classify(b) is CommitEvidenceKind.YELLOW_TIER)
+        other = tuple(h for h, b in claimed
+                      if classify(b) is CommitEvidenceKind.OTHER_TIER)
+        return Attribution(session_id, Provenance.SESSION_TRAILER,
+                           yellow, other)
+
+    if window is None:
+        return Attribution(session_id, Provenance.ABSENT)
+
+    start, end = window
+    # A commit that DECLARES an owner is never available to a window
+    # inference — not even to a soak with no claimed commits of its own.
+    # Skew moves timestamps across boundaries; a trailer is the commit's own
+    # statement about where it belongs, and an inference must never overrule
+    # a declaration. Without this, soak A could be credited with evidence
+    # that soak B had explicitly claimed, which is the theft the identity
+    # path exists to prevent.
+    inside = [(h, b) for (h, e, b) in commits
+              if start <= e < end and not extract_session_id(b)]
+    yellow = tuple(h for h, b in inside
+                   if classify(b) is CommitEvidenceKind.YELLOW_TIER)
+    other = tuple(h for h, b in inside
+                  if classify(b) is CommitEvidenceKind.OTHER_TIER)
+    if not yellow and not other:
+        return Attribution(session_id, Provenance.ABSENT)
+    return Attribution(session_id, Provenance.TIME_WINDOW, yellow, other)
+
+
+async def read_reflog(*, timeout_s: int) -> Optional[List[Tuple[str, float, str]]]:
+    """``[(hash, epoch, body), …]`` for commits only the reflog still holds.
+
+    THE SQUASH RECOVERY PATH. A squash merge rewrites history: the original
+    commits leave the branch but stay reachable through the reflog until it
+    expires. Reading it turns "the evidence is gone" into "the evidence is
+    here, one indirection away" for the window in which that is still true.
+
+    ``git log -g`` — read-only, never ``shell=True``, argv list, bounded by
+    both a timeout and an entry cap. Returns ``None`` when the reflog is
+    unavailable (a fresh clone has none), which is a degrade rather than an
+    error: a repository without a reflog has not lost anything, it simply
+    cannot corroborate.
+    """
+    if not reflog_trace_enabled():
+        return None
+    from backend.core.ouroboros.governance.auto_commit_graduation_gate import (
+        _FLD_SEP, _REC_SEP,
+    )
+
+    fmt = f"%H{_FLD_SEP}%ct{_FLD_SEP}%B{_REC_SEP}"
+    args = ["git", "log", "-g", "--all",
+            f"--max-count={reflog_max_entries()}",
+            f"--format={fmt}", "--no-color"]
+    proc = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *args, stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE)
+        out, _ = await asyncio.wait_for(proc.communicate(),
+                                        timeout=float(timeout_s))
+    except asyncio.CancelledError:
+        if proc is not None:
+            try:
+                proc.kill()
+            except Exception:  # noqa: BLE001
+                pass
+        raise
+    except Exception:  # noqa: BLE001 — git missing, timeout, exec failure
+        if proc is not None and proc.returncode is None:
+            try:
+                proc.kill()
+                await proc.wait()
+            except Exception:  # noqa: BLE001
+                pass
+        logger.debug("[AutoCommitAttribution] reflog read failed",
+                     exc_info=True)
+        return None
+    if proc.returncode != 0:
+        return None
+
+    records: List[Tuple[str, float, str]] = []
+    for raw in out.decode("utf-8", errors="replace").split(_REC_SEP):
+        raw = raw.strip("\n")
+        if not raw:
+            continue
+        parts = raw.split(_FLD_SEP)
+        if len(parts) < 3:
+            continue
+        try:
+            records.append((parts[0].strip(), float(parts[1].strip()),
+                            parts[2]))
+        except (TypeError, ValueError):
+            continue
+    return records
+
+
+def resolve_squash(
+    attribution: Attribution,
+    reflog: Optional[Sequence[Tuple[str, float, str]]],
+    branch: Sequence[Tuple[str, float, str]],
+    *,
+    window: Optional[Tuple[float, float]],
+    classify,
+) -> Attribution:
+    """Second chance for a soak the branch has lost. Pure. NEVER raises.
+
+    Only ``ABSENT`` soaks are re-examined: a soak proven by trailer needs
+    nothing, and one attributed by window has its commits on the branch.
+
+    Three outcomes, and the third is claimed only on POSITIVE evidence:
+
+    ``SQUASH_RECOVERED`` — the reflog still holds O+V commits for this soak.
+    The original objects exist and carry their own signatures, so this is
+    proof, not inference.
+
+    ``SQUASH_LOST`` — the reflog proves that commits in this soak's window
+    were rewritten off the branch, but none of the survivors carry
+    recoverable evidence. Claimed ONLY on that positive proof of a rewrite.
+
+    ``ABSENT`` (unchanged) — no rewrite is evident, so the honest reading is
+    that the soak produced nothing. Also the answer when the reflog could not
+    be read at all: "we could not look" must never be recorded as "we looked
+    and it was gone". Those are different claims and only one of them is
+    about the operator's history.
+
+    The asymmetry is deliberate. ``SQUASH_LOST`` protects the operator's soak
+    count, so inventing it from an absence would let any quiet soak launder
+    itself into an excused one. It has to be earned by a rewrite we can see.
+    """
+    if attribution.provenance is not Provenance.ABSENT:
+        return attribution
+    if reflog is None:
+        return attribution
+
+    recovered = attribute(attribution.session_id, reflog, window=window,
+                          classify=classify)
+    if recovered.yellow_hashes or recovered.other_hashes:
+        return Attribution(attribution.session_id,
+                           Provenance.SQUASH_RECOVERED,
+                           recovered.yellow_hashes, recovered.other_hashes)
+
+    if window is None:
+        return attribution
+    start, end = window
+    on_branch = {h for (h, e, _b) in branch if start <= e < end}
+    rewritten = {h for (h, e, _b) in reflog
+                 if start <= e < end and h not in on_branch}
+    if rewritten:
+        # Commits existed in this window and are no longer reachable from
+        # the branch. Something rewrote them; their evidence, if any, is
+        # unreadable rather than absent.
+        return Attribution(attribution.session_id, Provenance.SQUASH_LOST)
+    return attribution
+
+
+__all__ = [
+    "ATTRIBUTION_SCHEMA_VERSION",
+    "PROVENANCE_REASON",
+    "SESSION_TRAILER_KEY",
+    "Attribution",
+    "Provenance",
+    "attribute",
+    "extract_session_id",
+    "read_reflog",
+    "reflog_trace_enabled",
+    "resolve_squash",
+    "session_trailer_line",
+]

--- a/backend/core/ouroboros/governance/graduation_repl.py
+++ b/backend/core/ouroboros/governance/graduation_repl.py
@@ -65,7 +65,8 @@ _HELP = (
     "\n"
     "Subcommands:\n"
     "  /graduation                    alias for /graduation status\n"
-    "  /graduation status             per-verdict summary\n"
+    "  /graduation autocommit — AutoCommitter unattended-apply evidence\n"
+        "  /graduation status             per-verdict summary\n"
     "  /graduation ready              gates marked READY\n"
     "  /graduation failed             gates with EVIDENCE_FAILED\n"
     "  /graduation details [N]        full per-row table\n"
@@ -131,7 +132,7 @@ def _matches(line: str) -> bool:
     )
 
 
-def dispatch_graduation_command(
+async def dispatch_graduation_command(
     line: str,
 ) -> GraduationReplDispatchResult:
     """Show which capabilities have graduated and which are pending.
@@ -156,6 +157,9 @@ def dispatch_graduation_command(
         )
     args = tokens[1:] if tokens else []
     head = (args[0].lower() if args else "status")
+
+    if head == "autocommit":
+        return await _render_autocommit()
 
     if head in ("help", "?"):
         return GraduationReplDispatchResult(
@@ -199,6 +203,53 @@ def dispatch_graduation_command(
                 f"{type(exc).__name__}: {str(exc)[:200]}"
             ),
         )
+
+
+async def _render_autocommit(
+    gate=None,
+) -> GraduationReplDispatchResult:
+    """The AutoCommitter unattended-apply evidence gate. §41.11.4.
+
+    INJECTED, never global. ``gate`` defaults to the canonical evaluator,
+    resolved at call time; nothing is cached and no module state is touched.
+
+    Renders the structural WHY rather than a bare verdict. "Not ready" tells
+    an operator nothing and invites them to flip the flag to find out; the
+    report's closed blocker taxonomy names the missing evidence and the act
+    that would supply it.
+    """
+    try:
+        if gate is None:
+            from backend.core.ouroboros.governance.auto_commit_graduation_gate import (  # noqa: E501
+                evaluate_graduation_evidence,
+            )
+            gate = evaluate_graduation_evidence
+        report = await gate()
+    except Exception as exc:  # noqa: BLE001
+        return GraduationReplDispatchResult(
+            ok=False,
+            text=f"  autocommit evidence unavailable ({type(exc).__name__})")
+
+    lines = [
+        "  AutoCommitter — unattended apply (Yellow tier)",
+        f"    verdict     {report.verdict.value}",
+        f"    clean soaks {report.ledger_clean_count}/"
+        f"{report.ledger_required}",
+        f"    evidence    {report.soaks_with_evidence} proven · "
+        f"{report.soaks_missing_evidence} missing · "
+        f"{report.soaks_unverifiable} unverifiable",
+    ]
+    if report.is_ready:
+        lines.append("    READY — every counted clean soak carries a "
+                     "Yellow-tier O+V commit.")
+    for reason in report.blocker_reasons:
+        lines.append(f"    ⨯ {reason}")
+    # Provenance per soak: proof and inference must not look alike.
+    for ev in report.per_soak_evidence[:8]:
+        if ev.provenance_reason:
+            lines.append(f"      {ev.session_id[:24]}  {ev.provenance} — "
+                         f"{ev.provenance_reason}")
+    return GraduationReplDispatchResult(ok=True, text="\n".join(lines))
 
 
 def _parse_limit(args) -> Optional[int]:

--- a/backend/core/ouroboros/governance/unified_graduation_dashboard.py
+++ b/backend/core/ouroboros/governance/unified_graduation_dashboard.py
@@ -86,6 +86,7 @@ the contract requires explicit scope-doc + pin update.
 """
 from __future__ import annotations
 
+import asyncio
 import enum
 import json
 import logging
@@ -93,7 +94,8 @@ import os
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, FrozenSet, List, Mapping, Optional, Tuple
+from typing import (Any, Awaitable, Callable, Dict, FrozenSet, List,
+                    Mapping, Optional, Tuple)
 
 logger = logging.getLogger(__name__)
 
@@ -709,6 +711,122 @@ def aggregate_dashboard(
         aggregated_at_unix=started,
         rows=tuple(rows),
         elapsed_s=time.monotonic() - t0,
+    )
+
+
+#: AutoCommit evidence verdict → the dashboard's operator-facing taxonomy.
+#: Exhaustive and explicit: an unmapped verdict lands on
+#: EVIDENCE_INSUFFICIENT with its raw value visible, so a verdict added
+#: without updating this table is loud at runtime rather than absorbed.
+_AUTOCOMMIT_VERDICT_MAP: Dict[str, UnifiedGraduationVerdict] = {
+    "ready": UnifiedGraduationVerdict.READY,
+    "ledger_not_eligible": UnifiedGraduationVerdict.EVIDENCE_GATHERING,
+    "evidence_insufficient": UnifiedGraduationVerdict.EVIDENCE_INSUFFICIENT,
+    # Unreadable, not failed. EVIDENCE_GATHERING says "keep going" —
+    # EVIDENCE_FAILED would accuse a clean soak of having gone wrong when
+    # the operator only squashed a PR.
+    "evidence_lost_to_squash": UnifiedGraduationVerdict.EVIDENCE_GATHERING,
+    "no_git_history": UnifiedGraduationVerdict.EVIDENCE_INSUFFICIENT,
+    "master_off": UnifiedGraduationVerdict.DISABLED,
+}
+
+AUTOCOMMIT_ROW_NAME: str = "autocommit_unattended_apply"
+
+
+def autocommit_row_from_report(report: Any) -> DashboardRow:
+    """Project an AutoCommit evidence report onto a dashboard row. Pure.
+
+    THE DIAGNOSTIC IS STRUCTURAL, NEVER "LOCKED". A row that says only
+    "not ready" teaches an operator nothing and invites them to flip the
+    flag to find out what is missing. The report carries a closed blocker
+    taxonomy; this renders those sentences verbatim, so the surface names
+    the missing evidence — "Insufficient clean soaks", "Missing git
+    cryptographic signature", "Verification lost via squash" — and what
+    would supply it.
+
+    NEVER raises: a malformed report yields an INSUFFICIENT row rather than
+    taking the whole dashboard down, which is the same posture every other
+    adapter here takes.
+    """
+    try:
+        raw = str(getattr(getattr(report, "verdict", None), "value", ""))
+        verdict = _AUTOCOMMIT_VERDICT_MAP.get(
+            raw, UnifiedGraduationVerdict.EVIDENCE_INSUFFICIENT)
+        reasons = tuple(getattr(report, "blocker_reasons", ()) or ())
+        counts = (
+            f"clean={getattr(report, 'ledger_clean_count', 0)}"
+            f"/{getattr(report, 'ledger_required', 0)} "
+            f"evidence={getattr(report, 'soaks_with_evidence', 0)} "
+            f"missing={getattr(report, 'soaks_missing_evidence', 0)} "
+            f"unverifiable={getattr(report, 'soaks_unverifiable', 0)}"
+        )
+        diagnostic = counts if not reasons else f"{counts} · " + " · ".join(
+            reasons)
+        return DashboardRow(
+            name=AUTOCOMMIT_ROW_NAME,
+            source="contract",
+            verdict=verdict,
+            raw_verdict=raw,
+            diagnostic=diagnostic[:512],
+        )
+    except Exception as exc:  # noqa: BLE001 — defensive, like every adapter
+        return DashboardRow(
+            name=AUTOCOMMIT_ROW_NAME, source="contract",
+            verdict=UnifiedGraduationVerdict.EVIDENCE_INSUFFICIENT,
+            raw_verdict="", diagnostic=f"adapter_error:{type(exc).__name__}")
+
+
+async def aggregate_dashboard_async(
+    *,
+    now_unix: Optional[float] = None,
+    autocommit_gate: Optional[Callable[[], Awaitable[Any]]] = None,
+) -> DashboardSnapshot:
+    """:func:`aggregate_dashboard` plus the AutoCommit evidence row.
+
+    DEPENDENCY INJECTION, not a global. ``autocommit_gate`` is the async
+    evaluator; the caller supplies it, and when absent the canonical one is
+    resolved lazily at the call site. Nothing is stored, no module state is
+    mutated, and no singleton is overridden — a test injects a stub and a
+    second concurrent caller is unaffected, because there is nothing shared
+    to affect.
+
+    Separate from the sync :func:`aggregate_dashboard` rather than replacing
+    it: the eight contract adapters are synchronous and cheap, this one
+    shells out to ``git``, and forcing every existing caller onto an event
+    loop to gain one row would be the tail wagging the dog. The sync
+    function is COMPOSED here, never duplicated.
+    """
+    snapshot = aggregate_dashboard(now_unix=now_unix)
+    gate = autocommit_gate
+    if gate is None:
+        try:
+            from backend.core.ouroboros.governance.auto_commit_graduation_gate import (  # noqa: E501
+                evaluate_graduation_evidence,
+            )
+            gate = evaluate_graduation_evidence
+        except Exception as exc:  # noqa: BLE001
+            return DashboardSnapshot(
+                aggregated_at_unix=snapshot.aggregated_at_unix,
+                rows=snapshot.rows + (DashboardRow(
+                    name=AUTOCOMMIT_ROW_NAME, source="contract",
+                    verdict=UnifiedGraduationVerdict.EVIDENCE_INSUFFICIENT,
+                    diagnostic=f"gate_unavailable:{type(exc).__name__}"),),
+                elapsed_s=snapshot.elapsed_s,
+            )
+    try:
+        report = await gate()
+        row = autocommit_row_from_report(report)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — one gate never fails the board
+        row = DashboardRow(
+            name=AUTOCOMMIT_ROW_NAME, source="contract",
+            verdict=UnifiedGraduationVerdict.EVIDENCE_INSUFFICIENT,
+            diagnostic=f"gate_error:{type(exc).__name__}")
+    return DashboardSnapshot(
+        aggregated_at_unix=snapshot.aggregated_at_unix,
+        rows=snapshot.rows + (row,),
+        elapsed_s=snapshot.elapsed_s,
     )
 
 

--- a/tests/governance/test_auto_commit_graduation_gate.py
+++ b/tests/governance/test_auto_commit_graduation_gate.py
@@ -382,10 +382,11 @@ def pins():
 
 class TestAstPinsCanonicalPass:
     def test_6_pins_registered(self, pins):
-        assert len(pins) == 6
+        assert len(pins) == 7
         assert {p.invariant_name for p in pins} == {
             "autocommit_grad_kind_taxonomy_closed",
             "autocommit_grad_verdict_taxonomy_closed",
+            "autocommit_grad_blocker_taxonomy_closed",
             "autocommit_grad_authority_asymmetry",
             "autocommit_grad_no_shell_subprocess",
             "autocommit_grad_no_hardcoded_markers",
@@ -431,6 +432,7 @@ class TestAstPinsSyntheticRegression:
             "    EVIDENCE_INSUFFICIENT = 'evidence_insufficient'\n"
             "    NO_GIT_HISTORY = 'no_git_history'\n"
             "    MASTER_OFF = 'master_off'\n"
+            "    EVIDENCE_LOST_TO_SQUASH = 'evidence_lost_to_squash'\n"
             "    SNEAKY = 'sneaky'\n"
         )
         v = _pin(

--- a/tests/governance/test_autocommit_evidence_attribution.py
+++ b/tests/governance/test_autocommit_evidence_attribution.py
@@ -1,0 +1,351 @@
+"""Regression spine for AutoCommit graduation evidence — Phase 2.
+
+The gate proves "AutoCommitter actually fired on a Yellow-tier op during
+each counted clean soak". Everything here is about whether that proof is
+HONEST: what it claims, what it refuses to claim, and what it must never
+quietly convert one into the other.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import auto_commit_graduation_gate as g
+from backend.core.ouroboros.governance import (
+    autocommit_evidence_attribution as attr,
+)
+from backend.core.ouroboros.governance import unified_graduation_dashboard as d
+from tests.source_probe import code_of
+
+OV = "Ouroboros+Venom"
+YEL = "Risk: NOTIFY_APPLY"
+
+
+def _classify(body: str):
+    return g.classify_commit_body(body, ov_marker=OV, yellow_marker=YEL)
+
+
+def _commit(h, epoch, *, session="", yellow=True, ov=True):
+    body = "fix(x): y\n\n"
+    if ov:
+        body += f"{OV} — Autonomous Self-Development Engine\n"
+    if yellow:
+        body += f"{YEL}\n"
+    trailer = attr.session_trailer_line(session)
+    if trailer:
+        body += trailer + "\n"
+    return (h, float(epoch), body)
+
+
+# -- the anchor ------------------------------------------------------------
+
+
+def test_the_writer_and_reader_spell_the_anchor_once():
+    """Two spellings of the trailer is a silent verification failure."""
+    assert attr.extract_session_id(
+        attr.session_trailer_line("soak-7") + "\n") == "soak-7"
+
+
+def test_an_absent_session_writes_no_trailer_rather_than_a_placeholder():
+    """`Session: unknown` would match nothing and read, later, as a
+    session that no longer exists."""
+    assert attr.session_trailer_line("") == ""
+    assert attr.session_trailer_line("   ") == ""
+
+
+def test_the_committer_stamps_the_trailer():
+    """Without it there is no clock-independent anchor at all."""
+    from backend.core.ouroboros.governance import auto_committer
+
+    code = code_of(auto_committer, "_build_commit_message")
+    assert "session_trailer_line" in code
+
+
+# -- clock skew: identity beats timestamps ---------------------------------
+
+
+def test_identity_attribution_ignores_the_clock_entirely():
+    """The Body and the Engine are different machines with different clocks.
+
+    A commit stamped hours outside its soak's window still belongs to that
+    soak if it says so.
+    """
+    commits = [_commit("a1", 999_999_999, session="soak-1")]
+    a = attr.attribute("soak-1", commits, window=(0.0, 1.0),
+                       classify=_classify)
+    assert a.provenance is attr.Provenance.SESSION_TRAILER
+    assert a.yellow_hashes == ("a1",)
+    assert a.counts_as_evidence
+
+
+def test_a_claimed_commit_is_never_stolen_by_another_soaks_window():
+    """Mixing identity and time would let skew pull in a claimed commit."""
+    commits = [_commit("a1", 50, session="soak-OTHER")]
+    a = attr.attribute("soak-1", commits, window=(0.0, 100.0),
+                       classify=_classify)
+    assert a.provenance is attr.Provenance.ABSENT
+    assert not a.counts_as_evidence
+
+
+def test_the_window_survives_only_as_a_labelled_inference():
+    """Pre-trailer history still counts — but says how it was established."""
+    commits = [_commit("a1", 50, session="")]
+    a = attr.attribute("soak-1", commits, window=(0.0, 100.0),
+                       classify=_classify)
+    assert a.provenance is attr.Provenance.TIME_WINDOW
+    assert a.counts_as_evidence
+    assert not a.provenance.is_proof
+    assert "not clock-independent proof" in a.reason
+
+
+def test_proof_and_inference_are_distinguishable_on_the_surface():
+    """A number that cannot be proven must not look like one that can."""
+    assert attr.Provenance.SESSION_TRAILER.is_proof
+    assert attr.Provenance.SQUASH_RECOVERED.is_proof
+    assert not attr.Provenance.TIME_WINDOW.is_proof
+    for p in attr.Provenance:
+        assert attr.PROVENANCE_REASON[p]
+
+
+# -- squash: unreadable is not absent --------------------------------------
+
+
+def test_a_squash_that_keeps_the_body_is_just_identity_again():
+    """`git merge --squash` and GitHub both concatenate bodies by default,
+    so the ordinary case needs no recovery at all."""
+    squashed = ("s1", 500.0,
+                f"squash\n\n{OV}\n{YEL}\n{attr.session_trailer_line('soak-1')}\n")
+    a = attr.attribute("soak-1", [squashed], window=(0.0, 100.0),
+                       classify=_classify)
+    assert a.provenance is attr.Provenance.SESSION_TRAILER
+
+
+def test_evidence_only_in_the_reflog_is_recovered_not_lost():
+    branch = [_commit("z9", 10, session="other")]
+    reflog = [_commit("a1", 50, session="soak-1")]
+    absent = attr.attribute("soak-1", branch, window=(0.0, 100.0),
+                            classify=_classify)
+    assert absent.provenance is attr.Provenance.ABSENT
+    out = attr.resolve_squash(absent, reflog, branch, window=(0.0, 100.0),
+                              classify=_classify)
+    assert out.provenance is attr.Provenance.SQUASH_RECOVERED
+    assert out.counts_as_evidence
+
+
+def test_a_proven_rewrite_with_no_recoverable_evidence_is_LOST_not_ABSENT():
+    """The operator squashed a PR; their soak count must not reset."""
+    branch = []
+    reflog = [_commit("gone1", 50, session="", ov=False, yellow=False)]
+    absent = attr.attribute("soak-1", branch, window=(0.0, 100.0),
+                            classify=_classify)
+    out = attr.resolve_squash(absent, reflog, branch, window=(0.0, 100.0),
+                              classify=_classify)
+    assert out.provenance is attr.Provenance.SQUASH_LOST
+    assert out.provenance.is_unverifiable
+    assert not out.counts_as_evidence, "a gate must not pass on unread data"
+
+
+def test_squash_lost_is_earned_by_a_visible_rewrite_never_by_absence():
+    """Otherwise any quiet soak launders itself into an excused one."""
+    branch = [_commit("b1", 50, session="", ov=False, yellow=False)]
+    reflog = list(branch)          # nothing rewritten away
+    absent = attr.attribute("soak-1", [], window=(0.0, 100.0),
+                            classify=_classify)
+    out = attr.resolve_squash(absent, reflog, branch, window=(0.0, 100.0),
+                              classify=_classify)
+    assert out.provenance is attr.Provenance.ABSENT
+
+
+def test_an_unreadable_reflog_is_not_evidence_of_a_squash():
+    """"we could not look" must never be recorded as "we looked and it
+    was gone" — different claims, and only one is about the history."""
+    absent = attr.attribute("soak-1", [], window=(0.0, 100.0),
+                            classify=_classify)
+    out = attr.resolve_squash(absent, None, [], window=(0.0, 100.0),
+                              classify=_classify)
+    assert out.provenance is attr.Provenance.ABSENT
+
+
+def test_recovery_never_raises_on_a_malformed_reflog():
+    absent = attr.attribute("soak-1", [], window=None, classify=_classify)
+    assert attr.resolve_squash(absent, [], [], window=None,
+                               classify=_classify).provenance is (
+        attr.Provenance.ABSENT)
+
+
+# -- the three-state accounting --------------------------------------------
+
+
+def test_the_third_state_exists_at_all():
+    """Two states force a lie about a squashed soak."""
+    assert hasattr(g.AutoCommitGraduationReport, "soaks_unverifiable")
+    assert g.AutoCommitEvidenceVerdict.EVIDENCE_LOST_TO_SQUASH
+
+
+def test_unverifiable_is_subtracted_from_missing_not_added_to_it():
+    """The arithmetic that protects the operator's soak count."""
+    code = code_of(g, "evaluate_graduation_evidence")
+    assert "len(attributions) - with_ev - unverifiable" in code
+
+
+def test_squash_loss_does_not_render_as_a_failure_on_the_board():
+    """EVIDENCE_FAILED would accuse a clean soak of having gone wrong."""
+    assert d._AUTOCOMMIT_VERDICT_MAP["evidence_lost_to_squash"] is (
+        d.UnifiedGraduationVerdict.EVIDENCE_GATHERING)
+
+
+# -- structural WHY, never a bare "locked" ---------------------------------
+
+
+def test_every_blocker_has_an_operator_sentence():
+    for b in g.GraduationBlocker:
+        assert g.BLOCKER_REASON[b], b
+
+
+def test_the_two_named_reasons_are_distinguishable():
+    """The mandate's own examples."""
+    soaks = g.BLOCKER_REASON[g.GraduationBlocker.INSUFFICIENT_CLEAN_SOAKS]
+    sig = g.BLOCKER_REASON[g.GraduationBlocker.MISSING_YELLOW_TIER_SIGNATURE]
+    assert "clean soaks" in soaks.lower()
+    assert "signature" in sig.lower()
+    assert soaks != sig
+
+
+def test_ready_carries_no_blocker_and_everything_else_carries_one():
+    V = g.AutoCommitEvidenceVerdict
+    assert g._blockers_for(V.READY, 0, 0) == ()
+    for missing, unver in ((1, 0), (0, 1), (1, 1), (0, 0)):
+        assert g._blockers_for(V.EVIDENCE_INSUFFICIENT, missing, unver), (
+            missing, unver)
+
+
+def test_the_stated_reason_is_derived_from_the_counts():
+    """Or a surface says "insufficient soaks" while the report says squash."""
+    B = g.GraduationBlocker
+    assert g._blockers_for(g.AutoCommitEvidenceVerdict.EVIDENCE_INSUFFICIENT,
+                           2, 0) == (B.MISSING_YELLOW_TIER_SIGNATURE,)
+    assert g._blockers_for(
+        g.AutoCommitEvidenceVerdict.EVIDENCE_LOST_TO_SQUASH, 0, 2) == (
+        B.VERIFICATION_LOST_VIA_SQUASH,)
+
+
+async def test_a_disabled_gate_says_how_to_enable_it(monkeypatch):
+    monkeypatch.delenv("JARVIS_AUTOCOMMIT_GRADUATION_GATE_ENABLED",
+                       raising=False)
+    rep = await g.evaluate_graduation_evidence()
+    assert rep.verdict is g.AutoCommitEvidenceVerdict.MASTER_OFF
+    assert rep.blockers == (g.GraduationBlocker.GATE_DISABLED,)
+    assert "JARVIS_AUTOCOMMIT_GRADUATION_GATE_ENABLED" in (
+        rep.blocker_reasons[0])
+
+
+# -- the binding: DI, no globals -------------------------------------------
+
+
+class _Report:
+    class _V:
+        value = "evidence_insufficient"
+    verdict = _V()
+    ledger_clean_count, ledger_required = 3, 3
+    soaks_with_evidence, soaks_missing_evidence, soaks_unverifiable = 2, 1, 0
+    blocker_reasons = ("Missing git cryptographic signature — one or more "
+                       "counted clean soaks produced no O+V commit",)
+    is_ready = False
+    per_soak_evidence = ()
+
+
+async def test_the_dashboard_takes_the_gate_by_injection():
+    async def _gate():
+        return _Report()
+
+    snap = await d.aggregate_dashboard_async(autocommit_gate=_gate)
+    row = next(r for r in snap.rows if r.name == d.AUTOCOMMIT_ROW_NAME)
+    assert row.verdict is d.UnifiedGraduationVerdict.EVIDENCE_INSUFFICIENT
+    assert "cryptographic signature" in row.diagnostic
+
+
+async def test_the_row_never_renders_a_bare_locked_state():
+    async def _gate():
+        return _Report()
+
+    snap = await d.aggregate_dashboard_async(autocommit_gate=_gate)
+    row = next(r for r in snap.rows if r.name == d.AUTOCOMMIT_ROW_NAME)
+    assert "locked" not in row.diagnostic.lower()
+    assert "clean=" in row.diagnostic and "unverifiable=" in row.diagnostic
+
+
+async def test_injection_stores_nothing_and_overrides_nothing():
+    """Zero globals: a second caller is unaffected by the first."""
+    async def _a():
+        return _Report()
+
+    class _Other(_Report):
+        class _V:
+            value = "ready"
+        verdict = _V()
+
+    async def _b():
+        return _Other()
+
+    first = await d.aggregate_dashboard_async(autocommit_gate=_a)
+    second = await d.aggregate_dashboard_async(autocommit_gate=_b)
+    third = await d.aggregate_dashboard_async(autocommit_gate=_a)
+    pick = lambda s: next(  # noqa: E731
+        r for r in s.rows if r.name == d.AUTOCOMMIT_ROW_NAME).raw_verdict
+    assert (pick(first), pick(second), pick(third)) == (
+        "evidence_insufficient", "ready", "evidence_insufficient")
+
+
+async def test_an_exploding_gate_never_takes_down_the_board():
+    async def _boom():
+        raise RuntimeError("git exploded")
+
+    snap = await d.aggregate_dashboard_async(autocommit_gate=_boom)
+    row = next(r for r in snap.rows if r.name == d.AUTOCOMMIT_ROW_NAME)
+    assert "gate_error:RuntimeError" in row.diagnostic
+    assert len(snap.rows) > 1, "the other gates still reported"
+
+
+async def test_the_sync_dashboard_is_composed_not_duplicated():
+    code = code_of(d, "aggregate_dashboard_async")
+    assert "aggregate_dashboard(" in code
+    assert "_CONTRACT_ADAPTERS" not in code
+
+
+async def test_the_verb_surfaces_the_gate():
+    """A gate an operator cannot ask about is the unmounted class again."""
+    from backend.core.ouroboros.battle_test import repl_dispatch_registry as rd
+
+    out = await rd.try_dispatch("/graduation autocommit")
+    assert out is not None and out.matched
+    assert "AutoCommitter" in out.text
+
+
+async def test_the_verb_renders_the_structural_reason():
+    from backend.core.ouroboros.governance.graduation_repl import (
+        _render_autocommit,
+    )
+
+    async def _gate():
+        return _Report()
+
+    res = await _render_autocommit(gate=_gate)
+    assert res.ok
+    assert "cryptographic signature" in res.text
+    assert "unverifiable" in res.text
+
+
+# -- composition discipline ------------------------------------------------
+
+
+def test_the_gate_composes_the_generic_ledger_and_does_not_reimplement_it():
+    code = code_of(g)
+    assert "GraduationLedger" in code
+    assert "_read_all" in code
+    assert "json.loads" not in code, "the ledger JSONL is re-parsed here"
+
+
+def test_attribution_holds_no_opinion_about_what_an_ov_commit_is():
+    """The gate owns that definition; this owns membership only."""
+    code = code_of(attr)
+    assert "Risk: NOTIFY_APPLY" not in code
+    assert "ov_marker" not in code

--- a/tests/governance/test_unified_graduation_dashboard.py
+++ b/tests/governance/test_unified_graduation_dashboard.py
@@ -294,83 +294,83 @@ def test_dashboard_snapshot_to_dict_has_summary():
 # ---------------------------------------------------------------------------
 
 
-def test_repl_unmatched_returns_matched_false():
+async def test_repl_unmatched_returns_matched_false():
     from backend.core.ouroboros.governance.graduation_repl import (
         dispatch_graduation_command,
     )
-    r = dispatch_graduation_command("/something_else")
+    r = (await dispatch_graduation_command("/something_else"))
     assert r.matched is False
 
 
-def test_repl_help_works_master_off():
+async def test_repl_help_works_master_off():
     """`/graduation help` MUST work even with master flag off
     (discoverability)."""
     from backend.core.ouroboros.governance.graduation_repl import (
         dispatch_graduation_command,
     )
-    r = dispatch_graduation_command("/graduation help")
+    r = (await dispatch_graduation_command("/graduation help"))
     assert r.ok is True
     assert "Unified Graduation Dashboard" in r.text
 
 
-def test_repl_status_blocks_master_off():
+async def test_repl_status_blocks_master_off():
     from backend.core.ouroboros.governance.graduation_repl import (
         dispatch_graduation_command,
     )
-    r = dispatch_graduation_command("/graduation status")
+    r = (await dispatch_graduation_command("/graduation status"))
     assert r.ok is False
     assert "disabled" in r.text.lower()
 
 
-def test_repl_status_works_master_on(monkeypatch):
+async def test_repl_status_works_master_on(monkeypatch):
     monkeypatch.setenv(
         "JARVIS_UNIFIED_GRADUATION_DASHBOARD_ENABLED", "true",
     )
     from backend.core.ouroboros.governance.graduation_repl import (
         dispatch_graduation_command,
     )
-    r = dispatch_graduation_command("/graduation status")
+    r = (await dispatch_graduation_command("/graduation status"))
     assert r.ok is True
     assert "total gates" in r.text
 
 
-def test_repl_no_subcommand_aliases_to_status(monkeypatch):
+async def test_repl_no_subcommand_aliases_to_status(monkeypatch):
     monkeypatch.setenv(
         "JARVIS_UNIFIED_GRADUATION_DASHBOARD_ENABLED", "true",
     )
     from backend.core.ouroboros.governance.graduation_repl import (
         dispatch_graduation_command,
     )
-    r = dispatch_graduation_command("/graduation")
+    r = (await dispatch_graduation_command("/graduation"))
     assert r.ok is True
     assert "total gates" in r.text
 
 
-def test_repl_unknown_subcommand(monkeypatch):
+async def test_repl_unknown_subcommand(monkeypatch):
     monkeypatch.setenv(
         "JARVIS_UNIFIED_GRADUATION_DASHBOARD_ENABLED", "true",
     )
     from backend.core.ouroboros.governance.graduation_repl import (
         dispatch_graduation_command,
     )
-    r = dispatch_graduation_command("/graduation gibberish")
+    r = (await dispatch_graduation_command("/graduation gibberish"))
     assert r.ok is False
     assert "unknown subcommand" in r.text.lower()
 
 
-def test_repl_contract_requires_name(monkeypatch):
+async def test_repl_contract_requires_name(monkeypatch):
     monkeypatch.setenv(
         "JARVIS_UNIFIED_GRADUATION_DASHBOARD_ENABLED", "true",
     )
     from backend.core.ouroboros.governance.graduation_repl import (
         dispatch_graduation_command,
     )
-    r = dispatch_graduation_command("/graduation contract")
+    r = (await dispatch_graduation_command("/graduation contract"))
     assert r.ok is False
     assert "name required" in r.text.lower()
 
 
-def test_repl_contract_lookup_substring_match(monkeypatch):
+async def test_repl_contract_lookup_substring_match(monkeypatch):
     """Contract lookup matches substring case-insensitively."""
     monkeypatch.setenv(
         "JARVIS_UNIFIED_GRADUATION_DASHBOARD_ENABLED", "true",
@@ -379,45 +379,45 @@ def test_repl_contract_lookup_substring_match(monkeypatch):
         dispatch_graduation_command,
     )
     # `phase10_purge` is one of the 8 contract names.
-    r = dispatch_graduation_command(
+    r = await dispatch_graduation_command(
         "/graduation contract phase10_purge",
     )
     assert r.ok is True
     assert "phase10_purge" in r.text
 
 
-def test_repl_contract_unknown_returns_not_found(monkeypatch):
+async def test_repl_contract_unknown_returns_not_found(monkeypatch):
     monkeypatch.setenv(
         "JARVIS_UNIFIED_GRADUATION_DASHBOARD_ENABLED", "true",
     )
     from backend.core.ouroboros.governance.graduation_repl import (
         dispatch_graduation_command,
     )
-    r = dispatch_graduation_command(
+    r = await dispatch_graduation_command(
         "/graduation contract zzz_does_not_exist",
     )
     assert r.ok is False
     assert "not found" in r.text.lower()
 
 
-def test_repl_details_with_limit(monkeypatch):
+async def test_repl_details_with_limit(monkeypatch):
     monkeypatch.setenv(
         "JARVIS_UNIFIED_GRADUATION_DASHBOARD_ENABLED", "true",
     )
     from backend.core.ouroboros.governance.graduation_repl import (
         dispatch_graduation_command,
     )
-    r = dispatch_graduation_command("/graduation details 3")
+    r = (await dispatch_graduation_command("/graduation details 3"))
     assert r.ok is True
     # Header line + 3 rows minimum.
     assert r.text.count("\n") >= 3
 
 
-def test_repl_parse_error_handled():
+async def test_repl_parse_error_handled():
     from backend.core.ouroboros.governance.graduation_repl import (
         dispatch_graduation_command,
     )
-    r = dispatch_graduation_command("/graduation 'unclosed")
+    r = (await dispatch_graduation_command("/graduation 'unclosed"))
     assert r.ok is False
     assert "parse error" in r.text.lower()
 
@@ -651,7 +651,7 @@ def test_register_flags_none_registry():
 # ---------------------------------------------------------------------------
 
 
-def test_repl_ready_renders_real_data(monkeypatch):
+async def test_repl_ready_renders_real_data(monkeypatch):
     """End-to-end: REPL `/graduation ready` composes the
     substrate aggregator and produces operator-readable output."""
     monkeypatch.setenv(
@@ -660,7 +660,7 @@ def test_repl_ready_renders_real_data(monkeypatch):
     from backend.core.ouroboros.governance.graduation_repl import (
         dispatch_graduation_command,
     )
-    r = dispatch_graduation_command("/graduation ready")
+    r = (await dispatch_graduation_command("/graduation ready"))
     assert r.ok is True
     # Either lists READY gates or says none are READY — both valid.
     assert (
@@ -669,12 +669,12 @@ def test_repl_ready_renders_real_data(monkeypatch):
     )
 
 
-def test_repl_failed_renders_real_data(monkeypatch):
+async def test_repl_failed_renders_real_data(monkeypatch):
     monkeypatch.setenv(
         "JARVIS_UNIFIED_GRADUATION_DASHBOARD_ENABLED", "true",
     )
     from backend.core.ouroboros.governance.graduation_repl import (
         dispatch_graduation_command,
     )
-    r = dispatch_graduation_command("/graduation failed")
+    r = (await dispatch_graduation_command("/graduation failed"))
     assert r.ok is True


### PR DESCRIPTION
`auto_commit_graduation_gate` composes the generic `GraduationLedger` and adds what the ledger cannot prove: that within each counted clean soak, an O+V commit actually carried the Yellow-tier marker. Without it, graduating AutoCommitter on clean-soak-count alone asserts a capability the evidence does not demonstrate — the overclaim its own docstring names.

It had **zero callers**. Now bound to `/graduation autocommit` and the unified dashboard, by injection.

## One root cause behind both edge cases

Attribution asked *"does this commit's timestamp fall inside this soak's window"* — windows from ledger epochs, commit times from `%ct`. Two failures fall out of that single decision:

- **Clock skew.** Body on the Mac, Engine on Windows WSL2 — a commit and a ledger row stamped by different clocks. Seconds of drift move evidence to the wrong soak or to none.
- **Squash.** Squashing a PR replaces N commits; the SHAs a window would match no longer exist. Zero Yellow-tier commits then reads identically to a soak that never fired AutoCommitter.

So: not two special cases. **Stop inferring membership from time when a commit can say where it belongs.**

`auto_committer` now stamps a `Session:` trailer, spelled once in `autocommit_evidence_attribution` and consumed from there by both writer and reader. Matching it is an exact string comparison — no clock on either side, correct across worktrees, durable through the squashes that concatenate bodies (which `git merge --squash` and GitHub both do by default).

Pre-trailer history keeps the window, reported as `Provenance.TIME_WINDOW` — an **inference**, never proof. Same discipline `operation_advisor` applies to blast radius: a number that cannot be proven says so rather than borrowing the authority of one that can.

A commit declaring an owner is excluded from every *other* soak's window. An inference must never overrule a declaration — caught by a test, not by review: the window was quietly crediting soak A with commits soak B had claimed.

## Three states, because two force a lie

`SQUASH_LOST` is neither evidence nor failure. It never counts toward graduation (a gate must not pass on what it could not read) and never against it (a soak count must not reset for ordinary PR hygiene). `soaks_unverifiable` is **subtracted from** `missing`, not added.

Claimed only on **positive proof of a rewrite** — the reflog holds commits in the window that are absent from the branch. Inventing it from an absence would let any quiet soak launder itself into an excused one. An unreadable reflog stays `ABSENT`: *"we could not look"* must never be recorded as *"we looked and it was gone"*. Recovery via `git log -g` promotes to `SQUASH_RECOVERED` where the objects survive.

## Structural why, never "locked"

`GraduationBlocker` is a closed 7-value taxonomy; every non-READY verdict carries at least one, **derived from the counts** so a surface cannot say "insufficient soaks" while the report says squash.

The Yellow marker inside that prose is derived from `_yellow_marker()` — an AST pin forbids the literal, and it was right: a hardcoded sentence would keep naming `NOTIFY_APPLY` after a tier rename.

## DI, no globals

`aggregate_dashboard_async(*, autocommit_gate=None)` composes the sync `aggregate_dashboard` and appends one row. Nothing stored, no singleton overridden — proven by a test that alternates two injected gates and gets each one's answer back. The sync path is untouched: eight cheap sync adapters shouldn't be forced onto an event loop to gain one row that shells to git. `/graduation autocommit` takes the same injection.

Two AST pins updated deliberately in the same change — the workflow they exist to force — plus a new one closing `GraduationBlocker`, since those sentences render verbatim to an operator.

## Measured, gate enabled, all three surfaces

```
verdict     ledger_not_eligible
clean soaks 0/3
evidence    0 proven · 0 missing · 0 unverifiable
⨯ Insufficient clean soaks — the generic ledger floor is not met yet
```

## Tests

234 green (30 new). The 10 reds in `test_auto_committer_*_guard` are pre-existing and reproduce identically at `af9de75f94`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the AutoCommit graduation evidence gate into the REPL and the unified dashboard, and replaces time-window attribution with commit-identity proof via a Session trailer. Previously we inferred membership from commit timestamps; now commits declare their soak by trailer, with reflog recovery, a third “unverifiable” state, and a new verdict to avoid overclaiming.

- Adds `Session:` trailer to `auto_committer` messages and attributes evidence via `autocommit_evidence_attribution` (identity first, window as labeled inference, reflog-assisted recovery).
- Introduces `EVIDENCE_LOST_TO_SQUASH` and `soaks_unverifiable`; adds closed `GraduationBlocker` taxonomy and operator-facing reasons derived from counts.
- Binds the gate by injection to `/graduation autocommit` and to an async `aggregate_dashboard_async`, projecting a single “autocommit_unattended_apply” row; maps “lost to squash” to EVIDENCE_GATHERING, not failure.
- Keeps sync dashboard composition intact; reads the reflog only on demand with timeout and entry cap.

**Rollout**

- Enable the gate: set JARVIS_AUTOCOMMIT_GRADUATION_GATE_ENABLED=true.
- Ensure `JARVIS_OUROBOROS_SESSION_ID` is set so `auto_committer` stamps the `Session:` trailer.
- Callers must await `graduation_repl.dispatch_graduation_command`; use `aggregate_dashboard_async` to include the new row.
- Optional: control reflog reads with JARVIS_AUTOCOMMIT_GRAD_REFLOG_TRACE (default on) and JARVIS_AUTOCOMMIT_GRAD_REFLOG_MAX.

<sup>Written for commit dadc91e44bd35ae2582bd9c0c1ff8a278dd4cbdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

