### PR TITLE
fix(proactive): read the dial this checkout persisted — it had no read surface

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -6706,6 +6706,46 @@ class GovernedLoopService:
                     exc_info=True,
                 )
 
+            # PRD §30.11 Q4: READ the dial this checkout persisted.
+            #
+            # `ProactiveModeStore.remember()` wrote `.jarvis/proactive_mode.
+            # json` and NOTHING read it back — a write surface with no read
+            # surface. The operator set a rung, the file recorded it, and the
+            # controller kept answering with its in-memory default. Enabling
+            # the ladder therefore resolved to `safe_auto` (grants mutation)
+            # while the persisted judgement said `explore` (withholds it):
+            # the dial appeared to work and inverted its own meaning.
+            #
+            # Hydrated HERE because this is where the organism acquires the
+            # authority the dial governs. Registered as a standing voter
+            # rather than assigned, so it composes through the same
+            # strictest-wins path every cockpit uses — one composition rule,
+            # not a privileged back door. To loosen it an operator sets the
+            # dial, which persists, which moves this floor; the loop closes
+            # through the surface that already exists.
+            #
+            # Before `_bg_pool` can emit: a rung that withholds INITIATIVE
+            # must be in force before anything can take any.
+            try:
+                from backend.core.ouroboros.governance.proactive_mode_store import (  # noqa: E501,PLC0415
+                    get_store as _pm_store,
+                )
+                from backend.core.ouroboros.governance.proactive_mode import (  # noqa: E501,PLC0415
+                    PERSISTED_DIAL_VOTER_ID as _pm_voter,
+                    get_controller as _pm_controller,
+                )
+                _rung = await _pm_store().hydrate()
+                _eff = _pm_controller().request(_pm_voter, _rung)
+                logger.info(
+                    "[GLS] proactive dial hydrated: persisted=%s effective=%s",
+                    _rung, getattr(_eff, "name", _eff))
+            except Exception:  # noqa: BLE001 — a dial fault must not block boot
+                # Degrades to the controller default, which is the behaviour
+                # that shipped before this hydrate existed. Never to a LOOSER
+                # rung than the file asked for by guessing.
+                logger.debug(
+                    "[GLS] proactive dial hydrate skipped", exc_info=True)
+
             # PRD §27.5: bind the in-flight op registry for `/why`.
             #
             # An operator asks about the op they are WATCHING, which is by

--- a/backend/core/ouroboros/governance/proactive_mode.py
+++ b/backend/core/ouroboros/governance/proactive_mode.py
@@ -810,6 +810,20 @@ _singleton: Optional[ProactiveModeController] = None
 _singleton_lock = threading.Lock()
 
 
+#: Voter id for the rung this CHECKOUT persisted, hydrated at boot.
+#:
+#: A named constant rather than a literal at the call site because two
+#: spellings would register two voters — and under strictest-wins a stale
+#: duplicate can only ever make the organism quieter than the operator asked
+#: for, which is the failure that hides itself.
+#:
+#: Distinct from any cockpit id so the standing judgement and a live
+#: cockpit's request compose instead of overwriting each other: the file says
+#: what this repository is allowed to do, the cockpit says what the person
+#: watching wants right now, and the stricter of the two wins.
+PERSISTED_DIAL_VOTER_ID: str = "__persisted_dial__"
+
+
 def get_controller() -> ProactiveModeController:
     global _singleton
     with _singleton_lock:

--- a/tests/governance/test_proactive_mode_store.py
+++ b/tests/governance/test_proactive_mode_store.py
@@ -250,3 +250,67 @@ def test_the_snapshot_is_serialisable(repo):
         await s.hydrate(repo)
         return s.snapshot()
     json.dumps(asyncio.run(_go()))
+
+
+# -- the boot hydrate: a write surface needs a read surface ----------------
+
+
+async def test_the_persisted_rung_is_read_back_at_boot(monkeypatch, tmp_path):
+    """`remember()` wrote and NOTHING read it back.
+
+    The controller kept answering with its in-memory default, so enabling
+    the ladder resolved to `safe_auto` — which GRANTS mutation — while the
+    file said `explore`, which withholds it. The dial appeared to work and
+    inverted its own meaning, which is worse than not having one.
+    """
+    from backend.core.ouroboros.governance import proactive_mode as pm
+
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_STATE_PATH",
+                       str(tmp_path / "dial.json"))
+    st.reset_store()
+    store = st.get_store()
+    assert await store.remember("explore")
+
+    controller = pm.ProactiveModeController()
+    controller.request(pm.PERSISTED_DIAL_VOTER_ID, await store.hydrate())
+    eff = controller.effective()
+    assert eff.name == "explore"
+    assert eff.authority is pm.Authority.PROPOSE, "apply rights not withheld"
+
+
+async def test_a_cockpit_cannot_loosen_past_the_persisted_floor(
+        monkeypatch, tmp_path):
+    """The file says what this checkout may do; the cockpit says what the
+    person wants now. The STRICTER wins, or a standing judgement would be
+    one keystroke from being discarded."""
+    from backend.core.ouroboros.governance import proactive_mode as pm
+
+    monkeypatch.setenv("JARVIS_PROACTIVE_MODE_ENABLED", "true")
+    controller = pm.ProactiveModeController()
+    controller.request(pm.PERSISTED_DIAL_VOTER_ID, "explore")
+    assert controller.request("cockpit-A", "promote").name == "explore"
+
+
+def test_the_boot_seam_actually_hydrates():
+    """A hydrate with no caller is the defect this fixes, one level up."""
+    from tests.source_probe import code_of
+
+    from backend.core.ouroboros.governance import governed_loop_service as gls
+
+    code = code_of(gls)
+    assert "hydrate()" in code, "the persisted dial is never read at boot"
+    assert "PERSISTED_DIAL_VOTER_ID" in code
+
+
+def test_the_voter_id_is_named_once():
+    """Two spellings register two voters, and under strictest-wins a stale
+    duplicate can only make the organism quieter than asked — silently."""
+    from backend.core.ouroboros.governance import proactive_mode as pm
+
+    from tests.source_probe import code_of
+
+    assert pm.PERSISTED_DIAL_VOTER_ID
+    assert '"__persisted_dial__"' not in code_of(
+        __import__("backend.core.ouroboros.governance.governed_loop_service",
+                   fromlist=["x"]))


### PR DESCRIPTION
`ProactiveModeStore.remember()` wrote `.jarvis/proactive_mode.json` and **nothing read it back**. The only `.hydrate()` callers in the tree belong to `merkle_cartographer` and `topology_sentinel` — different stores. The §30.11 Q4 per-worktree dial was a write surface with no read surface.

## It inverted its own meaning

Not merely inert. With the ladder enabled, the controller answered from its in-memory default while the file said something else — and the two differ in the direction that matters:

```
persisted on disk : explore     (initiative, NO apply rights)
controller default: safe_auto   (initiative AND apply rights)
mutation_permitted: True
```

An operator who set `explore` to get proposals *without* mutation would have been granted mutation. A dial that appears to work and means the opposite is worse than no dial, because it is trusted.

```
BEFORE hydrate : safe_auto | mutation True
AFTER  hydrate : explore   | mutation False
                 "🔍 explore: reads, searches, plans — no mutation reaches VALIDATE"
```

## Where, and why there

`GovernedLoopService.start()`, beside the `/why` live-source and proactive-sink injections — where the organism acquires the authority the dial governs — and **before `_bg_pool` can emit**, because a rung that withholds *initiative* must be in force before anything can take any.

## Registered as a voter, not assigned

It composes through the same strictest-wins path every cockpit uses rather than being written into the controller directly: one composition rule, not a privileged back door.

The file says what this repository is allowed to do; a cockpit says what the person watching wants now; the stricter wins. Proven by a test where a cockpit requesting `promote` still resolves to `explore`. To loosen it, an operator moves the dial — which persists, which moves the floor. The loop closes through the surface that already exists.

`PERSISTED_DIAL_VOTER_ID` is named once: two spellings would register two voters, and under strictest-wins a stale duplicate can only ever make the organism *quieter* than the operator asked for — the failure that hides itself.

Fail-soft degrades to the controller default, exactly the behaviour that shipped before this hydrate existed — never to a **looser** rung than the file asked for by guessing.

## Note

This is the third unmounted-capability defect found in my own work this session, and all three were caught by **execution** rather than by search. Pinned here by a test that asserts the boot seam calls `hydrate()` at all.

131 tests green across the mode and ratchet suites (+4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reads and applies the proactive dial persisted by `ProactiveModeStore` at boot. Previously the controller ignored `.jarvis/proactive_mode.json` and defaulted to `safe_auto` (mutation allowed); now it hydrates the saved rung (e.g., `explore`) before background work, so mutation is withheld when the file says so.

- Notes for reviewers
  - Hydrates in `GovernedLoopService.start()` and registers a standing voter via `PERSISTED_DIAL_VOTER_ID`; composes through the same strictest-wins path as cockpits.
  - Executes before `_bg_pool` can emit; logs persisted and effective rungs.
  - Fail-soft: on hydrate error, degrades to the controller default; never guesses a looser rung.
  - Tests assert boot hydrate, strictest-wins with a cockpit (`promote` vs `explore`), and a single voter id.

- Rollout
  - If a repo persisted `explore`, the system will no longer mutate on boot. Adjust the dial to `safe_auto` or `promote` if mutation is desired.

<sup>Written for commit 2f5e37cecfdaae4ffd5bbfd884716508defff7a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

