### PR TITLE
feat(governance): `ov` owns the O+V lifecycle — one owner, declared

### DIFF
--- a/backend/core/ouroboros/cli/trinity_doctor.py
+++ b/backend/core/ouroboros/cli/trinity_doctor.py
@@ -44,7 +44,7 @@ import subprocess
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 
 class Status(str, Enum):
@@ -187,17 +187,62 @@ def _is_placeholder(val: str) -> bool:
 
 
 def check_python_runtime() -> CheckResult:
+    """Validate the interpreter that will RUN the service, not this one.
+
+    These are different processes and can be different Pythons: `doctor`
+    runs under whatever invoked ``trinity``, while the backend runs under
+    ``_service_python()``. Checking the wrong one is worse than not
+    checking — on 2026-08-15 this reported ``READY — Python 3.11.10`` while
+    every ``trinity up`` was dying in under two seconds under a 3.9.6
+    interpreter that could not import ``uuid6``. A preflight that passes
+    for a process nobody will start is a preflight that only ever agrees.
+
+    The version is asked of that interpreter by RUNNING it rather than
+    inferred from its path: a venv is a symlink farm, and the name of a
+    directory is not evidence about the binary inside it.
+    """
     import sys
-    v = sys.version_info
+
+    try:
+        from backend.core.ouroboros.cli.trinity_launcher import _service_python
+        service = _service_python()
+    except Exception:  # noqa: BLE001 — fall back to this interpreter
+        service = sys.executable
+
+    same = os.path.realpath(service) == os.path.realpath(sys.executable)
+    if same:
+        v = sys.version_info
+        got: Tuple[int, int, int] = (v.major, v.minor, v.micro)
+    else:
+        try:
+            probe = subprocess.run(
+                [service, "-c",
+                 "import sys;print('%d %d %d' % sys.version_info[:3])"],
+                capture_output=True, text=True, timeout=20)
+            if probe.returncode != 0:
+                return CheckResult(
+                    "python-runtime", Status.FAIL,
+                    detail=(f"service interpreter {service} is not runnable: "
+                            f"{(probe.stderr or '').strip()[:120]}"),
+                )
+            got = tuple(int(p) for p in probe.stdout.split())  # type: ignore
+        except Exception as exc:  # noqa: BLE001
+            return CheckResult(
+                "python-runtime", Status.FAIL,
+                detail=f"could not probe {service}: {type(exc).__name__}",
+            )
+
     # Repo mandate: Python 3.9+ (no asyncio.timeout).
-    if (v.major, v.minor) < (3, 9):
+    if got[:2] < (3, 9):
         return CheckResult(
             "python-runtime", Status.FAIL,
-            detail=f"Python {v.major}.{v.minor} < 3.9 required",
+            detail=f"service Python {got[0]}.{got[1]} < 3.9 required "
+                   f"({service})",
         )
+    where = "" if same else f" — service interpreter {service}"
     return CheckResult(
         "python-runtime", Status.READY,
-        detail=f"Python {v.major}.{v.minor}.{v.micro}",
+        detail=f"Python {got[0]}.{got[1]}.{got[2]}{where}",
     )
 
 

--- a/backend/core/ouroboros/cli/trinity_launcher.py
+++ b/backend/core/ouroboros/cli/trinity_launcher.py
@@ -94,6 +94,22 @@ def _service_env() -> dict:
     env["JARVIS_SERVICE_MODE"] = "1"
     env["JARVIS_FRONTEND_AUTOLAUNCH"] = "0"
     env["OUROBOROS_BATTLE_HEADLESS"] = "1"
+    # `_service_python` has ALREADY chosen the interpreter, and the child
+    # would otherwise choose a different one: `unified_supervisor.
+    # _ensure_venv_python()` re-execs into the first `venv/` or `.venv/` it
+    # finds beside the script, discarding what it was launched with. That
+    # mechanism predates this launcher — it exists to rescue a bare
+    # `python3 unified_supervisor.py`, which is exactly the case where
+    # nobody has chosen — and two authorities on one question means the
+    # loser is whichever ran first.
+    #
+    # Observed 2026-08-15: a Python 3.9.6 `.venv` left in the repo in March
+    # captured every `trinity up`. The supervisor re-exec'd into it and died
+    # in 1.9s on `ModuleNotFoundError: uuid6`, while the interpreter this
+    # function had selected could import everything. `trinity status` then
+    # reported ZOMBIE/DEADLOCKED, because from outside a process that never
+    # bound its transports and one that wedged look identical.
+    env["JARVIS_SKIP_VENV_CHECK"] = "1"
     return env
 
 

--- a/backend/core/ouroboros/governance/lifecycle_ownership.py
+++ b/backend/core/ouroboros/governance/lifecycle_ownership.py
@@ -1,0 +1,137 @@
+"""Who owns the O+V lifecycle. One question, one answer, one place.
+
+THE BUG THIS EXISTS TO MAKE IMPOSSIBLE
+--------------------------------------
+Two processes both booted ``GovernedLoopService``:
+
+* ``ov`` → ``scripts/ouroboros_battle_test`` → GLS. Seconds, nothing else.
+* ``unified_supervisor`` → ``_ensure_governance_pipeline()`` → GLS, as a
+  fallback, 107 seconds into a boot dominated by GCP retries and audio
+  degradation, under a 30-second stopwatch it then lost.
+
+Observed 2026-08-15: the supervisor's copy hydrated the operator's dial,
+exceeded its 30s budget by 1.8s, and was abandoned by ``wait_for`` — while
+``asyncio.shield`` kept it running. The process then held
+``_governed_loop = None`` and logged ``GLS failed:`` with an empty reason
+(``TimeoutError`` stringifies to ""), so an orphaned governed loop was live
+inside a process that believed governance was absent.
+
+Neither owner was wrong. Having two was. This module makes ownership a
+DECLARED fact rather than a race between whichever boot path ran first.
+
+WHY A ROLE AND NOT A BOOLEAN
+----------------------------
+``JARVIS_GOVERNANCE_DISABLED=1`` on the supervisor would answer "should I
+skip?" without ever saying who does it instead, and the second reader of
+that flag would have to guess. A role names the owner, so every consumer
+asks the same question and gets an answer that is true for the whole system:
+``ov`` owns the loop, the supervisor owns the body (audio, vision, HUD).
+
+BYPASS IS NOT DEGRADATION
+-------------------------
+A supervisor that skips governance because ``ov`` owns it is working exactly
+as designed, and must not log a warning, set a failure reason, or report a
+degraded mode. Warning about intended behaviour is how an operator learns to
+ignore warnings — the same economics the audit ratchets are built on.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Tuple
+
+logger = logging.getLogger("Ouroboros.LifecycleOwnership")
+
+LIFECYCLE_OWNERSHIP_SCHEMA_VERSION: str = "lifecycle_ownership.1"
+
+#: The `ov` cockpit process — `scripts/ouroboros_battle_test` boots the
+#: 6-layer stack directly and imports nothing from the monolith.
+OWNER_OV: str = "ov"
+
+#: The 98K-line kernel. Owns the BODY — audio, vision, the HUD bridge — and
+#: after 2026-08-15 no longer races `ov` for the governed loop.
+OWNER_SUPERVISOR: str = "supervisor"
+
+#: Every owner this system recognises. Closed, like `_VALID_SOURCES`: an
+#: ownership vocabulary a deployment could invent privately is one nobody
+#: else can reason about.
+VALID_OWNERS: Tuple[str, ...] = (OWNER_OV, OWNER_SUPERVISOR)
+
+#: `ov` by default — the process an operator starts when they want O+V, and
+#: the one whose whole reason to exist is this loop. The supervisor booting
+#: it was always the fallback, and a fallback that runs by default is just a
+#: second owner wearing a modest name.
+DEFAULT_OWNER: str = OWNER_OV
+
+ENV_VAR: str = "JARVIS_GOVERNANCE_OWNER"
+
+__all__ = [
+    "DEFAULT_OWNER",
+    "ENV_VAR",
+    "LIFECYCLE_OWNERSHIP_SCHEMA_VERSION",
+    "OWNER_OV",
+    "OWNER_SUPERVISOR",
+    "VALID_OWNERS",
+    "bypass_note",
+    "governance_owner",
+    "owns_governance",
+    "ov_owns_governance",
+    "supervisor_owns_governance",
+]
+
+
+def governance_owner() -> str:
+    """The declared owner of the O+V lifecycle. NEVER raises.
+
+    An unrecognised value resolves to the default rather than failing the
+    boot: this is read on a startup path, and a typo in one env var must not
+    be able to take the organism down. It is logged at INFO with the value
+    seen, because a silently-corrected setting is one nobody ever fixes.
+    """
+    try:
+        raw = (os.environ.get(ENV_VAR) or "").strip().lower()
+    except Exception:  # noqa: BLE001
+        return DEFAULT_OWNER
+    if not raw:
+        return DEFAULT_OWNER
+    if raw in VALID_OWNERS:
+        return raw
+    logger.info(
+        "[LifecycleOwnership] %s=%r is not one of %s — using %r",
+        ENV_VAR, raw, list(VALID_OWNERS), DEFAULT_OWNER,
+    )
+    return DEFAULT_OWNER
+
+
+def owns_governance(component: str) -> bool:
+    """Does *component* own the governed loop in this deployment?
+
+    The one predicate both construction sites consult. Two call sites asking
+    the question two ways is how the dual ownership arose in the first place.
+    """
+    return governance_owner() == (component or "").strip().lower()
+
+
+def supervisor_owns_governance() -> bool:
+    return owns_governance(OWNER_SUPERVISOR)
+
+
+def ov_owns_governance() -> bool:
+    return owns_governance(OWNER_OV)
+
+
+def bypass_note(component: str) -> str:
+    """The line a bypassing component logs. INFO-shaped, never alarming.
+
+    Says who DOES own it, so an operator reading a supervisor log that never
+    mentions governance again is told where it went rather than left to
+    conclude it broke.
+    """
+    owner = governance_owner()
+    return (
+        f"governance lifecycle owned by {owner!r}, not {component!r} — "
+        f"skipping the governed loop here by design "
+        f"(set {ENV_VAR}={OWNER_SUPERVISOR} to invert)"
+    )

--- a/tests/cli/test_trinity_doctor.py
+++ b/tests/cli/test_trinity_doctor.py
@@ -222,3 +222,71 @@ def test_doctor_main_exit_code(monkeypatch):
         return r
     monkeypatch.setattr(doc, "run_doctor", _clean)
     assert doc.doctor_main(_C()) == 0
+
+
+class TestPythonRuntimeChecksTheRightProcess:
+    """`doctor` and the backend are different processes and can be
+    different Pythons. On 2026-08-15 this check reported
+    ``READY — Python 3.11.10`` while every ``trinity up`` was dying under a
+    3.9.6 interpreter — it had validated the interpreter running the check
+    instead of the one about to run the service. A preflight that inspects
+    the wrong process only ever agrees with itself.
+    """
+
+    @staticmethod
+    def _fake_interpreter(tmp_path: Path, reports: str) -> Path:
+        """An executable that answers the version probe with *reports*.
+
+        A real file with a real exec bit, because the check RUNS it — the
+        version is asked of the binary, never inferred from its path, since
+        a venv is a symlink farm and a directory name is not evidence.
+        """
+        fake = tmp_path / "python-fake"
+        fake.write_text(f"#!/bin/sh\necho '{reports}'\n")
+        fake.chmod(0o755)
+        return fake
+
+    def test_it_fails_on_a_service_interpreter_below_the_floor(
+            self, tmp_path, monkeypatch):
+        fake = self._fake_interpreter(tmp_path, "3 8 0")
+        monkeypatch.setattr(
+            "backend.core.ouroboros.cli.trinity_launcher._service_python",
+            lambda: str(fake))
+        r = doc.check_python_runtime()
+        assert r.status is doc.Status.FAIL
+        assert "3.8" in r.detail and str(fake) in r.detail
+
+    def test_it_reports_the_service_interpreter_it_validated(
+            self, tmp_path, monkeypatch):
+        fake = self._fake_interpreter(tmp_path, "3 11 10")
+        monkeypatch.setattr(
+            "backend.core.ouroboros.cli.trinity_launcher._service_python",
+            lambda: str(fake))
+        r = doc.check_python_runtime()
+        assert r.status is doc.Status.READY
+        assert str(fake) in r.detail, "an operator must see WHICH python passed"
+
+    def test_an_unrunnable_service_interpreter_is_a_failure(
+            self, tmp_path, monkeypatch):
+        """The case that matters most: the path exists in config and cannot
+        execute. Reporting READY here is how a boot loop stays invisible."""
+        monkeypatch.setattr(
+            "backend.core.ouroboros.cli.trinity_launcher._service_python",
+            lambda: str(tmp_path / "does-not-exist"))
+        r = doc.check_python_runtime()
+        assert r.status is doc.Status.FAIL
+
+    def test_it_never_raises_when_the_launcher_is_unavailable(
+            self, monkeypatch):
+        """A diagnostic that crashes is worse than useless."""
+        import builtins
+        real = builtins.__import__
+
+        def _boom(name, *a, **k):
+            if "trinity_launcher" in name:
+                raise ImportError("simulated")
+            return real(name, *a, **k)
+
+        monkeypatch.setattr(builtins, "__import__", _boom)
+        r = doc.check_python_runtime()
+        assert r.status in (doc.Status.READY, doc.Status.FAIL)

--- a/tests/cli/test_trinity_launcher.py
+++ b/tests/cli/test_trinity_launcher.py
@@ -85,3 +85,44 @@ class TestTrinityRouting:
                "backend/core/ouroboros/cli/trinity_launcher.py").read_text()
         assert "os.system(" not in src           # no os.system CALL
         assert "start_new_session=True" in src   # detached, no orphan
+
+
+class TestInterpreterAuthority:
+    """Whoever launches the child decides which Python runs it.
+
+    Observed 2026-08-15: a Python 3.9.6 `.venv` left in the repo in March
+    captured every `trinity up`. `_service_python()` correctly selected the
+    hermetic 3.11.10 interpreter, `unified_supervisor._ensure_venv_python()`
+    re-exec'd out of it into the stale one, and the backend died in 1.9s on
+    `ModuleNotFoundError: uuid6`. From outside, `trinity status` could only
+    say ZOMBIE/DEADLOCKED — a process that never bound its transports and one
+    that wedged are indistinguishable.
+    """
+
+    def test_the_service_env_disables_the_childs_own_venv_reexec(self):
+        """Two authorities on one question means the loser is whoever ran
+        first. The launcher has already chosen, so the child must not."""
+        assert tl._service_env().get("JARVIS_SKIP_VENV_CHECK") == "1"
+
+    def test_the_hermetic_interpreter_is_preferred_when_it_exists(
+            self, tmp_path, monkeypatch):
+        """Executed against a real file on disk, not a mocked predicate:
+        `venv_exists` tests for an executable bit, and a fake that answers
+        True for a path with no binary would prove nothing."""
+        fake = tmp_path / "bin" / "python"
+        fake.parent.mkdir(parents=True)
+        fake.write_text("#!/bin/sh\nexit 0\n")
+        fake.chmod(0o755)
+        monkeypatch.setattr(
+            "backend.core.ouroboros.cli.trinity_env.venv_dir",
+            lambda: tmp_path)
+        assert tl._service_python() == str(fake)
+
+    def test_it_falls_back_to_the_current_interpreter_when_absent(
+            self, tmp_path, monkeypatch):
+        """A missing hermetic venv is not a reason to refuse to boot."""
+        import sys
+        monkeypatch.setattr(
+            "backend.core.ouroboros.cli.trinity_env.venv_dir",
+            lambda: tmp_path / "nope")
+        assert tl._service_python() == sys.executable

--- a/tests/governance/test_lifecycle_ownership.py
+++ b/tests/governance/test_lifecycle_ownership.py
@@ -1,0 +1,140 @@
+"""One owner for the O+V lifecycle, and both claimants agree who it is.
+
+The bug: `ov` and `unified_supervisor` both booted GovernedLoopService. On
+2026-08-15 the supervisor's copy hydrated the operator's dial, exceeded a
+fixed 30s budget by 1.8s, and was abandoned by `wait_for` while
+`asyncio.shield` kept it running — leaving an orphaned governed loop inside
+a process holding `_governed_loop = None`, reporting `GLS failed:` with an
+empty reason because `TimeoutError` stringifies to "".
+
+Neither owner was wrong; having two was.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from backend.core.ouroboros.governance import lifecycle_ownership as lo
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+class TestTheDeclaredOwner:
+    def test_ov_owns_it_by_default(self, monkeypatch):
+        """The process an operator starts when they want O+V is the one
+        whose whole reason to exist is this loop."""
+        monkeypatch.delenv(lo.ENV_VAR, raising=False)
+        assert lo.governance_owner() == lo.OWNER_OV
+        assert lo.ov_owns_governance() is True
+        assert lo.supervisor_owns_governance() is False
+
+    def test_the_supervisor_can_be_given_it_back(self, monkeypatch):
+        """An inversion an operator can perform without editing code — the
+        fallback still exists, it just no longer runs unasked."""
+        monkeypatch.setenv(lo.ENV_VAR, lo.OWNER_SUPERVISOR)
+        assert lo.supervisor_owns_governance() is True
+        assert lo.ov_owns_governance() is False
+
+    def test_exactly_one_owner_can_hold_it(self, monkeypatch):
+        """The property the whole module exists for. Not two, ever."""
+        for owner in lo.VALID_OWNERS:
+            monkeypatch.setenv(lo.ENV_VAR, owner)
+            holders = [c for c in lo.VALID_OWNERS if lo.owns_governance(c)]
+            assert holders == [owner], holders
+
+    def test_an_unknown_owner_resolves_to_the_default(self, monkeypatch):
+        """Read on a startup path: a typo in one env var must not be able to
+        take the organism down."""
+        monkeypatch.setenv(lo.ENV_VAR, "hud")
+        assert lo.governance_owner() == lo.DEFAULT_OWNER
+
+    def test_whitespace_and_case_are_not_a_different_owner(self, monkeypatch):
+        monkeypatch.setenv(lo.ENV_VAR, "  SUPERVISOR  ")
+        assert lo.supervisor_owns_governance() is True
+
+    def test_an_empty_value_is_not_an_owner(self, monkeypatch):
+        monkeypatch.setenv(lo.ENV_VAR, "   ")
+        assert lo.governance_owner() == lo.DEFAULT_OWNER
+
+    def test_it_never_raises_when_the_environment_is_unreadable(
+            self, monkeypatch):
+        class _Hostile(dict):
+            def get(self, *_a, **_k):
+                raise RuntimeError("environ exploded")
+
+        monkeypatch.setattr(lo.os, "environ", _Hostile())
+        assert lo.governance_owner() == lo.DEFAULT_OWNER
+
+    def test_the_bypass_note_names_the_owner_and_the_way_back(
+            self, monkeypatch):
+        """A supervisor log that never mentions governance again must say
+        where it went, not leave the operator to conclude it broke."""
+        monkeypatch.delenv(lo.ENV_VAR, raising=False)
+        note = lo.bypass_note(lo.OWNER_SUPERVISOR)
+        assert lo.OWNER_OV in note
+        assert lo.ENV_VAR in note and lo.OWNER_SUPERVISOR in note
+
+
+class TestBothClaimantsRouteThroughOnePredicate:
+    """A wiring pin, and honest about being one: it proves the two
+    construction sites CONSULT the predicate, while the tests above prove
+    what the predicate answers. Gating only one site would leave the race
+    intact on whichever boot path won that particular boot — and the
+    supervisor cannot be imported to check this behaviourally, because
+    importing it re-execs the interpreter (`_ensure_venv_python` fires at
+    import, not just under `__main__`).
+    """
+
+    @staticmethod
+    def _kernel_class() -> ast.ClassDef:
+        tree = ast.parse((REPO / "unified_supervisor.py").read_text(
+            encoding="utf-8", errors="replace"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "JarvisSystemKernel":
+                return node
+        raise AssertionError("JarvisSystemKernel not found")
+
+    def test_every_governed_loop_construction_is_gated(self):
+        kernel = self._kernel_class()
+        # Each `GovernedLoopService(...)` call, and the guard that must
+        # dominate it somewhere in its enclosing function.
+        constructing = []
+        for fn in ast.walk(kernel):
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            builds = any(
+                isinstance(n, ast.Call)
+                and getattr(n.func, "id", "") == "GovernedLoopService"
+                for n in ast.walk(fn))
+            if not builds:
+                continue
+            gated = any(
+                isinstance(n, ast.Call)
+                and getattr(n.func, "attr", "") == "_owns_governance_loop"
+                for n in ast.walk(fn))
+            constructing.append((fn.name, gated))
+
+        assert constructing, "no GovernedLoopService construction found"
+        ungated = [name for name, gated in constructing if not gated]
+        assert not ungated, (
+            f"these construct the governed loop without consulting "
+            f"_owns_governance_loop: {ungated} — one ungated site restores "
+            f"the dual ownership this closes")
+
+    def test_the_predicate_delegates_rather_than_reimplementing(self):
+        """A second spelling of the rule is a second rule. The supervisor
+        must ASK `lifecycle_ownership`, not parse the env itself."""
+        kernel = self._kernel_class()
+        pred = next(
+            f for f in kernel.body
+            if isinstance(f, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and f.name == "_owns_governance_loop")
+        imported = {
+            alias.name
+            for n in ast.walk(pred) if isinstance(n, ast.ImportFrom)
+            for alias in n.names
+        }
+        assert "supervisor_owns_governance" in imported
+        assert not any(
+            isinstance(n, ast.Attribute) and n.attr == "environ"
+            for n in ast.walk(pred)), "reads the environment directly"

--- a/unified_supervisor.py
+++ b/unified_supervisor.py
@@ -80539,6 +80539,49 @@ class JarvisSystemKernel:
         finally:
             await session.close()  # R2-#5: Clean up the single session
 
+    def _owns_governance_loop(self) -> bool:
+        """Does THIS process own the O+V lifecycle? NEVER raises.
+
+        The single predicate both governed-loop construction sites consult —
+        this one and the Trinity-window path below. Asking the question two
+        ways is how the dual ownership arose: `ov` boots the same
+        GovernedLoopService in its own process, and the loser was whichever
+        boot path happened to run first.
+
+        Answered by `governance.lifecycle_ownership`, which is also readable
+        by `ov`, so the two processes cannot hold different beliefs about who
+        is in charge. Fails OPEN to the historical behaviour: an unreadable
+        ownership declaration must not be able to take governance away from a
+        deployment that has always had it here.
+        """
+        try:
+            from backend.core.ouroboros.governance.lifecycle_ownership import (
+                OWNER_SUPERVISOR, bypass_note, governance_owner,
+                supervisor_owns_governance,
+            )
+        except Exception:  # noqa: BLE001
+            self.logger.debug("[Kernel] ownership module unavailable",
+                              exc_info=True)
+            return True
+        try:
+            if supervisor_owns_governance():
+                return True
+            # INFO, once, naming the owner — a supervisor log that never
+            # mentions governance again should say where it went, not leave
+            # the operator to conclude it broke.
+            if not getattr(self, "_governance_bypass_logged", False):
+                self.logger.info("[Kernel] %s", bypass_note(OWNER_SUPERVISOR))
+                self._governance_bypass_logged = True
+            # Not a failure and not "pending" — leaving the reason at its
+            # startup default would tell a later reader governance is still
+            # coming. It is not coming, on purpose, and the field should say
+            # which process has it.
+            self._governance_init_reason = f"owned_by_{governance_owner()}"
+            return False
+        except Exception:  # noqa: BLE001
+            self.logger.debug("[Kernel] ownership check degraded", exc_info=True)
+            return True
+
     async def _ensure_governance_pipeline(self) -> None:
         """Initialize the Ouroboros governance pipeline independently of Trinity.
 
@@ -80579,6 +80622,25 @@ class JarvisSystemKernel:
                 return
 
         # Step 2: GovernedLoopService (Zone 6.8)
+        #
+        # ---- Lifecycle ownership (2026-08-15) ----------------------------
+        # `ov` boots the same GovernedLoopService in its own process, in
+        # seconds, importing nothing from this file. Two owners meant the
+        # loser was whichever ran first: this path hydrated the operator's
+        # dial, blew its 30s budget by 1.8s, and was abandoned by `wait_for`
+        # while `shield` kept it running — an orphaned governed loop inside a
+        # process that then held `_governed_loop = None` and reported the
+        # failure as an empty string (`TimeoutError` stringifies to "").
+        #
+        # Only the LOOP is gated. The GovernanceStack above stays: it is the
+        # policy/gate machinery other supervisor surfaces read, and skipping
+        # it would decouple more than the one thing that was contended.
+        #
+        # Bypass is NOT degradation — no warning, no init_reason, no mode
+        # change. Warning about intended behaviour is how an operator learns
+        # to ignore warnings.
+        if not self._owns_governance_loop():
+            return
         if self._governance_stack and self._governance_stack._started and self._governed_loop is None:
             try:
                 from backend.core.ouroboros.governance.governed_loop_service import (
@@ -82702,7 +82764,14 @@ class JarvisSystemKernel:
 
                             # ---- Zone 6.8: Governed Self-Programming Loop ----
                             # v400.0: Skip if fallback path already initialized GLS
-                            if self._governance_stack and self._governance_stack._started and self._governed_loop is None:
+                            # ---- Lifecycle ownership (2026-08-15): the OTHER owner ----
+                            # The Trinity-window twin of the fallback below. `ov` boots the
+                            # same GovernedLoopService in its own process; gating only one
+                            # of the two sites would leave the race intact on whichever
+                            # path won that boot. Same predicate, so they cannot disagree.
+                            if not self._owns_governance_loop():
+                                pass
+                            elif self._governance_stack and self._governance_stack._started and self._governed_loop is None:
                                 try:
                                     from backend.core.ouroboros.governance.governed_loop_service import (
                                         GovernedLoopConfig,


### PR DESCRIPTION
Two processes both booted `GovernedLoopService`. Neither was wrong; having two was.

| owner | path | shape |
|---|---|---|
| `ov` | → `ouroboros_battle_test` → GLS | seconds, imports nothing from the monolith |
| `unified_supervisor` | → `_ensure_governance_pipeline()` → GLS | a *fallback*, 107s in, on a fixed 30s stopwatch |

## What that cost, observed 2026-08-15

The supervisor's copy hydrated the operator's dial, exceeded its budget by 1.8s, and was abandoned by `wait_for` — while `asyncio.shield` kept it **running**. The process then held `_governed_loop = None` and logged `GLS failed:` with nothing after the colon, because `TimeoutError` stringifies to `""`. An orphaned governed loop, inside a process that believed governance was absent, reporting a failure with no reason.

## A role, not a boolean

`JARVIS_GOVERNANCE_DISABLED=1` answers "should I skip?" without ever saying who does it instead, and the second reader of that flag has to guess. `JARVIS_GOVERNANCE_OWNER ∈ {ov, supervisor}` (default `ov`) names the owner, so every consumer asks one question and gets an answer that is true for the whole system. `ov` owns the loop; the supervisor owns the body — audio, vision, the HUD bridge.

## Both sites, one predicate

The supervisor builds the loop in **two** places — the Trinity-window path and the fallback. Gating one would leave the race intact on whichever path won that boot, so both consult `_owns_governance_loop()`, delegating to `lifecycle_ownership`, which `ov` can read too — the two processes cannot hold different beliefs about who is in charge. Fails **open**: an unreadable ownership declaration must not take governance away from a deployment that has always had it there.

Only the **loop** is gated. The GovernanceStack still builds — it is the policy/gate machinery other supervisor surfaces read, and skipping it would decouple more than the one thing that was contended.

Bypass is not degradation: no warning, no mode change, and `_governance_init_reason` becomes `owned_by_ov` rather than staying `pending_startup`, which would tell a later reader governance is still coming. It is not coming, on purpose.

## The interpreter fixes that made the diagnosis possible

`trinity up` could not boot at all. A Python 3.9.6 `.venv` left in the repo in March captured every launch: `_service_python()` selected the hermetic 3.11.10 interpreter and `unified_supervisor._ensure_venv_python()` re-exec'd out of it, dying in 1.9s on `ModuleNotFoundError: uuid6` while `trinity status` could only report `ZOMBIE/DEADLOCKED` — from outside, a process that never bound its transports and one that wedged are identical.

- `_service_env()` now sets `JARVIS_SKIP_VENV_CHECK=1`. The launcher has already chosen the interpreter; the child must not choose another. The re-exec still rescues a bare `python3 unified_supervisor.py` — the case where nobody has chosen.
- `trinity doctor` validates the interpreter that will **run the service**, asked by running it. It had reported `READY — Python 3.11.10` while every boot died under 3.9.6: a preflight that inspects the wrong process only ever agrees with itself.

## Evidence

Verified in a live standalone daemon booted through `ov`:

```
[ProactiveMode] restored dial explore for <this checkout>
[GLS] proactive dial hydrated: persisted=explore effective=explore
[IntakeLayer] AuditDriftSensor registered enabled=True
[AuditDrift] subscribed to fs.changed.* — 300s settle timer
[AuditDrift] started (poll 1800s, settle 300s)
```

10 new ownership tests — including a pin that fails if a future `GovernedLoopService` construction appears ungated — plus 29 green across the trinity launcher/doctor spines. That pin is AST-based deliberately: the monolith re-execs the interpreter on **import**, not just under `__main__`, so it cannot be imported into a test process to be exercised behaviourally.

## Known and not addressed here

The HUD's O+V feed goes dark under this split: `governance_sse_bridge` is bus-to-bus (no GLS reference to break), but `TrinityEventBus._receive_loop` drops `event.source == self.local_repo`, and both processes are `RepoType.JARVIS` — the transport is cross-*repo*, not cross-*process*. The bus-bridge that closes it is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare a single owner for the O+V governed loop and gate supervisor construction behind it. Previously both `ov` and `unified_supervisor` started `GovernedLoopService`, causing races and orphaned loops; now `ov` owns by default and the supervisor skips its loop when not the owner.

- Adds `backend/core/ouroboros/governance/lifecycle_ownership.py` with `JARVIS_GOVERNANCE_OWNER ∈ {ov, supervisor}` (default `ov`). Both supervisor call sites use one predicate. Only the loop is gated; the GovernanceStack still builds. When bypassing, set `_governance_init_reason=owned_by_{owner}` and log a single INFO. In the supervisor, ownership resolution fails open to “owned here” if the module is unavailable.
- Launcher asserts interpreter authority by setting `JARVIS_SKIP_VENV_CHECK=1` so the child does not re-exec into a stale `.venv`. `trinity_doctor` now validates the service interpreter chosen by `_service_python()` by running it and reporting that binary’s version or a failure.

**Migration**
- Deployments that relied on the supervisor owning the loop must set `JARVIS_GOVERNANCE_OWNER=supervisor` in the service environment.

<sup>Written for commit e35f081cf34ddd09132b3b85a0fe9d99f2fb430c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

