### PR TITLE
feat(hud): O+V's activity crosses the process split — one typed frame

### DIFF
--- a/backend/api/converged_headless.py
+++ b/backend/api/converged_headless.py
@@ -37,6 +37,19 @@ READY_TOPIC = "ouroboros.system"
 async def _load_governance_bridge() -> None:
     from backend.api.governance_sse_bridge import install_governance_sse_bridge
     await install_governance_sse_bridge()
+    # The local bridge above forwards a governed loop running in THIS
+    # process. Since `ov` owns the loop, that subscription sees nothing —
+    # TrinityEventBus drops `source == local_repo`, and both processes are
+    # RepoType.JARVIS. The consumer dials `ov` and republishes its frames
+    # onto the same EventStream channel. Self-gating: no-op when the loop is
+    # local or the bridge is disabled.
+    try:
+        from backend.api.governance_cross_process import (
+            install_governance_bus_consumer,
+        )
+        await install_governance_bus_consumer()
+    except Exception:  # noqa: BLE001 — telemetry never blocks a boot
+        pass
 
 
 def _build_ouroboros_daemon() -> Any:

--- a/backend/api/governance_cross_process.py
+++ b/backend/api/governance_cross_process.py
@@ -1,0 +1,457 @@
+"""O+V's activity reaches the HUD after the two processes were split.
+
+WHAT BROKE, AND WHY IT WAS INVISIBLE
+------------------------------------
+`ov` now owns the governed loop and `unified_supervisor` owns the body — the
+mic, the vision plane, and the EventStream the Swift HUD reads. That split is
+correct, and it silently cut one wire: ``governance_sse_bridge`` subscribes to
+TrinityEventBus ``autonomy.# / governance.# / ouroboros.#`` in the SUPERVISOR,
+and O+V now publishes those in the `ov` process.
+
+The bus does cross processes — a live daemon logs ``[Transport] Multicast
+enabled for jarvis`` — but its receive loop drops::
+
+    if event.source == self.local_repo:      # trinity_event_bus
+        continue
+
+Both processes are ``RepoType.JARVIS``. The transport is cross-REPO
+(jarvis↔prime↔reactor) and defines "self" by repo, not by PID, so the
+supervisor discards every frame `ov` publishes as its own echo. The wire is
+fine; the filter is the wall. Nothing errors, nothing warns, and the phone
+simply stops seeing the organism work.
+
+WHY NOT WIDEN THE ECHO FILTER
+------------------------------
+Making "self" mean the PROCESS instead of the repo is a one-line change that
+would fix this and quietly hand two JARVIS processes every one of each
+other's topics — ``fs.changed.*`` handled twice, sensors double-firing,
+dedup windows keyed per-process. Unbounded blast radius for a need that is
+one channel wide. The filter stays; one channel crosses deliberately.
+
+WHAT THIS REUSES, AND WHAT IT ADDS
+-----------------------------------
+Nothing here implements transport, backpressure or reconnection. All three
+already exist and are already load-bearing:
+
+* ``DistributedEventBus`` — "the publish()-here-subscribers-there seam",
+  server/client roles over ``BusBridgeServer``/``BusBridgeClient``.
+* ``TransportConfig.from_env`` — ``queue_maxsize`` (256), heartbeat,
+  ``reconnect_base_s`` / ``reconnect_max_s`` / ``reconnect_jitter``, TLS.
+  The client's ``_next_backoff`` is exponential-with-jitter already.
+* ``GovernanceSSEBridge`` — the subscription, the bounded queue with
+  drop-oldest, the drain pump, and the conflation guard that collapses a
+  flood into one frame. The producer here is that bridge with a different
+  SINK, so the backpressure policy has exactly one implementation.
+
+What is new is small on purpose: a strict envelope
+(:mod:`governance.governance_envelope`), a sink that publishes it, and a
+consumer that turns it back into an EventStream broadcast.
+
+DIRECTION OF TRUST
+------------------
+Frames are rendered ONCE, in the process that owns the loop, and the
+consumer never feeds cross-process data to ``GovernanceSSEBridge._render``.
+"the renderer never raises" is a weaker guarantee than "the renderer is
+never called on it".
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("Jarvis.GovernanceCrossProcess")
+
+GOVERNANCE_CROSS_PROCESS_SCHEMA_VERSION: str = "governance_cross_process.1"
+
+__all__ = [
+    "GOVERNANCE_CROSS_PROCESS_SCHEMA_VERSION",
+    "BrokerSink",
+    "GovernanceBusConsumer",
+    "bridge_enabled",
+    "install_governance_bus_consumer",
+    "install_governance_bus_producer",
+    "bus_url",
+    "reset_for_tests",
+    "start_bus_client",
+]
+
+
+def bridge_enabled() -> bool:
+    """``JARVIS_GOVERNANCE_BUS_BRIDGE_ENABLED`` (default false).
+
+    Off by default like every cross-process surface here: it opens a socket
+    between two daemons, and that is an operator's decision to make once they
+    have both running.
+    """
+    return (os.environ.get("JARVIS_GOVERNANCE_BUS_BRIDGE_ENABLED", "0")
+            or "").strip().lower() not in ("0", "false", "no", "off", "")
+
+
+def _loop_is_remote() -> bool:
+    """True when the governed loop runs in a DIFFERENT process than the HUD.
+
+    Both ends check this, so a single-process deployment
+    (``JARVIS_GOVERNANCE_OWNER=supervisor``) never spins a client dialling
+    its own broker or double-broadcasts frames the local bridge already
+    forwarded. The cross-process path exists because the loop moved; if it
+    did not move, there is nothing to cross.
+    """
+    try:
+        from backend.core.ouroboros.governance.lifecycle_ownership import (
+            supervisor_owns_governance,
+        )
+        return not supervisor_owns_governance()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _source_id() -> str:
+    """Provenance for an operator staring at two daemons. Never routing."""
+    return (os.environ.get("JARVIS_BRAIN_WS_SOURCE_ID") or "ov").strip() or "ov"
+
+
+# ---------------------------------------------------------------------------
+# Producer — `ov` side
+# ---------------------------------------------------------------------------
+
+
+class BrokerSink:
+    """Publishes rendered frames onto the local broker as envelopes.
+
+    Handed to ``GovernanceSSEBridge`` as its sink, so the flood control in
+    front of it is the same queue, the same drop-oldest, and the same
+    conflation the local path has always used. ``publish`` on the broker
+    never blocks and never raises, so a disconnected peer cannot apply
+    backpressure INTO the governed loop — it can only cost frames, which is
+    the correct trade for telemetry.
+    """
+
+    def __init__(self, broker: Any = None, *, source_id: Optional[str] = None) -> None:
+        self._broker = broker
+        self._source_id = source_id if source_id is not None else _source_id()
+        self.stats: Dict[str, int] = {"published": 0, "rejected": 0}
+
+    def _resolve_broker(self) -> Any:
+        if self._broker is not None:
+            return self._broker
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            get_default_broker,
+        )
+        self._broker = get_default_broker()
+        return self._broker
+
+    async def __call__(self, frames: List[Dict[str, Any]]) -> int:
+        """Deliver a drained batch. Returns how many were published.
+
+        NEVER raises: this runs inside the bridge's pump, and a sink that
+        can throw turns a telemetry hiccup into a dead forwarder.
+        """
+        from backend.core.ouroboros.governance.governance_envelope import (
+            GOVERNANCE_FORWARD_EVENT_TYPE, GovernanceEnvelope,
+        )
+        delivered = 0
+        try:
+            broker = self._resolve_broker()
+        except Exception:  # noqa: BLE001
+            logger.debug("[GovBus] broker unavailable", exc_info=True)
+            self.stats["rejected"] += len(frames)
+            return 0
+        for frame in frames or ():
+            try:
+                op_id = ""
+                if isinstance(frame, dict):
+                    op_id = str(frame.get("command_id", "")
+                                or frame.get("op_id", "") or "")
+                # `topic` is empty by construction on this path: the bridge
+                # renders BEFORE its queue, so by the time a batch reaches a
+                # sink the source topic is already folded into the payload.
+                # The field stays on the envelope for producers that do hold
+                # it, and the consumer surfaces whatever arrives — an empty
+                # provenance is honest, a fabricated one would not be.
+                env = GovernanceEnvelope.of(
+                    "", frame if isinstance(frame, dict) else {},
+                    op_id=op_id, source_id=self._source_id)
+                if env is None:
+                    self.stats["rejected"] += 1
+                    continue
+                if broker.publish(GOVERNANCE_FORWARD_EVENT_TYPE, op_id,
+                                  env.to_payload()) is None:
+                    # Only reachable if the event type ever leaves
+                    # `_VALID_EVENT_TYPES` — the silent-drop trap this
+                    # registration exists to close. Counted, never guessed at.
+                    self.stats["rejected"] += 1
+                    continue
+                self.stats["published"] += 1
+                delivered += 1
+            except Exception:  # noqa: BLE001
+                self.stats["rejected"] += 1
+                logger.debug("[GovBus] publish degraded", exc_info=True)
+        return delivered
+
+
+async def install_governance_bus_producer(
+    *, broker: Any = None,
+) -> Optional[Any]:
+    """`ov` side: forward O+V activity onto the bus. NEVER raises.
+
+    Returns the installed bridge, or None when disabled or when the bus is
+    not up yet (the caller may retry — ``install`` is idempotent).
+    """
+    if not bridge_enabled() or not _loop_is_remote():
+        return None
+    try:
+        from backend.api.governance_sse_bridge import GovernanceSSEBridge
+        bridge = GovernanceSSEBridge(sink=BrokerSink(broker))
+        if not await bridge.install():
+            return None
+        logger.info(
+            "[GovBus] producer installed — O+V activity forwards onto the "
+            "bus as %r frames",
+            "governance_forward")
+        return bridge
+    except Exception:  # noqa: BLE001
+        logger.debug("[GovBus] producer install degraded", exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Consumer — supervisor side
+# ---------------------------------------------------------------------------
+
+
+class GovernanceBusConsumer:
+    """Turns arriving envelopes back into EventStream broadcasts.
+
+    Subscribes to the LOCAL broker: ``BusBridgeClient._apply_inbound``
+    republishes every peer frame into it, so this end needs no socket
+    knowledge at all. That is the property that keeps the transport
+    swappable — the consumer would not notice if the link became a UDS.
+    """
+
+    def __init__(self, broker: Any = None, *, channel: Optional[str] = None) -> None:
+        self._broker = broker
+        self._channel = channel
+        self._task: Optional[asyncio.Task] = None
+        self._sub: Any = None
+        self._running = False
+        self.stats: Dict[str, int] = {
+            "received": 0, "broadcast": 0, "malformed": 0, "no_stream": 0,
+        }
+
+    def _resolve_channel(self) -> str:
+        if self._channel:
+            return self._channel
+        from backend.api.governance_sse_bridge import _SSE_CHANNEL
+        return _SSE_CHANNEL
+
+    def _resolve_broker(self) -> Any:
+        if self._broker is None:
+            from backend.core.ouroboros.governance.ide_observability_stream import (
+                get_default_broker,
+            )
+            self._broker = get_default_broker()
+        return self._broker
+
+    async def start(self) -> bool:
+        """Begin draining. Idempotent. NEVER raises."""
+        if self._running:
+            return True
+        try:
+            broker = self._resolve_broker()
+            self._sub = broker.subscribe()
+            if self._sub is None:
+                logger.debug("[GovBus] consumer refused: subscriber cap")
+                return False
+            self._running = True
+            self._task = asyncio.get_event_loop().create_task(
+                self._drain(), name="governance-bus-consumer")
+            logger.info("[GovBus] consumer started — peer O+V frames will "
+                        "reach the %s channel", self._resolve_channel())
+            return True
+        except Exception:  # noqa: BLE001
+            logger.debug("[GovBus] consumer start degraded", exc_info=True)
+            self._running = False
+            return False
+
+    async def stop(self) -> None:
+        """NEVER raises."""
+        self._running = False
+        try:
+            if self._task is not None and not self._task.done():
+                self._task.cancel()
+            if self._sub is not None and self._broker is not None:
+                self._broker.unsubscribe(self._sub)
+        except Exception:  # noqa: BLE001
+            pass
+        self._task = None
+        self._sub = None
+
+    async def _drain(self) -> None:
+        """One event at a time, forever. NEVER raises out."""
+        from backend.core.ouroboros.governance.governance_envelope import (
+            GOVERNANCE_FORWARD_EVENT_TYPE, GovernanceEnvelope,
+        )
+        try:
+            broker = self._resolve_broker()
+            async for event in broker.stream_iter(self._sub):
+                if not self._running:
+                    return
+                try:
+                    if getattr(event, "event_type", "") != GOVERNANCE_FORWARD_EVENT_TYPE:
+                        continue          # heartbeats and every other type
+                    self.stats["received"] += 1
+                    env = GovernanceEnvelope.from_payload(
+                        getattr(event, "payload", None))
+                    if env is None:
+                        # A frame this process cannot decode is dropped at
+                        # the boundary, not passed inward half-understood.
+                        self.stats["malformed"] += 1
+                        continue
+                    await self._broadcast(env.payload)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # noqa: BLE001
+                    self.stats["malformed"] += 1
+                    logger.debug("[GovBus] frame degraded", exc_info=True)
+        except asyncio.CancelledError:
+            return
+        except Exception:  # noqa: BLE001
+            logger.debug("[GovBus] consumer drain ended", exc_info=True)
+
+    async def _broadcast(self, payload: Dict[str, Any]) -> None:
+        """Hand a decoded payload to the EventStream. NEVER raises."""
+        try:
+            from backend.core.event_stream import (
+                get_event_stream_if_initialized,
+            )
+            es = get_event_stream_if_initialized()
+            if es is None:
+                self.stats["no_stream"] += 1
+                return
+            sent = await es.broadcast_event(self._resolve_channel(), payload)
+            if sent > 0:
+                self.stats["broadcast"] += 1
+            else:
+                self.stats["no_stream"] += 1
+        except Exception:  # noqa: BLE001
+            self.stats["no_stream"] += 1
+            logger.debug("[GovBus] broadcast degraded", exc_info=True)
+
+    def health(self) -> Dict[str, Any]:
+        return {
+            "schema_version": GOVERNANCE_CROSS_PROCESS_SCHEMA_VERSION,
+            "enabled": bridge_enabled(),
+            "running": self._running,
+            **self.stats,
+        }
+
+
+def bus_url() -> str:
+    """Where the supervisor dials `ov`. NEVER raises.
+
+    ``JARVIS_GOVERNANCE_BUS_URL`` when set. Otherwise DERIVED from the same
+    knobs the `ov` end binds with — ``JARVIS_CHANNEL_HOST`` /
+    ``JARVIS_CHANNEL_PORT`` for the address and ``TransportConfig.path`` for
+    the route. Deriving rather than restating means an operator who moves the
+    event channel does not silently leave a client dialling the old port: the
+    two ends cannot disagree because they read the same values.
+
+    The scheme follows ``tls_enabled``, so a link is never quietly downgraded
+    by this function.
+    """
+    explicit = (os.environ.get("JARVIS_GOVERNANCE_BUS_URL") or "").strip()
+    if explicit:
+        return explicit
+    try:
+        from backend.core.ouroboros.governance.transport.transport_config import (
+            TransportConfig,
+        )
+        cfg = TransportConfig.from_env(role="client")
+        path = cfg.path or "/ws/trinity-bus"
+        scheme = "wss" if getattr(cfg, "tls_enabled", True) else "ws"
+    except Exception:  # noqa: BLE001
+        path, scheme = "/ws/trinity-bus", "wss"
+    host = (os.environ.get("JARVIS_CHANNEL_HOST") or "127.0.0.1").strip()
+    port = (os.environ.get("JARVIS_CHANNEL_PORT") or "8099").strip()
+    return f"{scheme}://{host}:{port}{path}"
+
+
+async def start_bus_client(*, broker: Any = None,
+                           url: Optional[str] = None) -> Optional[Any]:
+    """Supervisor side: dial `ov` and fill the local broker. NEVER raises.
+
+    ``BusBridgeClient.run()`` is an infinite reconnect loop — exponential
+    backoff with jitter, straight from ``TransportConfig`` — so it is
+    launched as a task rather than awaited. Its inbound frames republish into
+    the local broker, which is the only thing :class:`GovernanceBusConsumer`
+    knows about; the consumer would not notice if this link became a UDS.
+    """
+    if not bridge_enabled():
+        return None
+    try:
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            get_default_broker,
+        )
+        from backend.core.ouroboros.governance.transport.distributed_event_bus import (  # noqa: E501
+            DistributedEventBus,
+        )
+        from backend.core.ouroboros.governance.transport.transport_config import (
+            TransportConfig,
+        )
+        cfg = TransportConfig.from_env(role="client")
+        bus = DistributedEventBus(broker or get_default_broker(), cfg,
+                                  role="client")
+        target = url or bus_url()
+        asyncio.get_event_loop().create_task(
+            bus.start_client(target), name="governance-bus-client")
+        logger.info("[GovBus] client dialling %s (reconnect base=%.1fs "
+                    "max=%.1fs jitter=%.2f)", target, cfg.reconnect_base_s,
+                    cfg.reconnect_max_s, cfg.reconnect_jitter)
+        return bus
+    except Exception:  # noqa: BLE001
+        logger.debug("[GovBus] client start degraded", exc_info=True)
+        return None
+
+
+_consumer: Optional[GovernanceBusConsumer] = None
+_client_bus: Optional[Any] = None
+
+
+async def install_governance_bus_consumer(
+    *, broker: Any = None,
+) -> Optional[GovernanceBusConsumer]:
+    """Supervisor side. Idempotent; NEVER raises."""
+    global _consumer  # noqa: PLW0603
+    if not bridge_enabled() or not _loop_is_remote():
+        return None
+    if _consumer is not None and _consumer._running:
+        return _consumer
+    consumer = GovernanceBusConsumer(broker)
+    if not await consumer.start():
+        return None
+    _consumer = consumer
+    # The consumer reads the LOCAL broker; the client is what puts peer
+    # frames into it. Starting one without the other is a subscriber to an
+    # empty queue — live by every surface, and permanently silent.
+    global _client_bus  # noqa: PLW0603
+    if _client_bus is None:
+        _client_bus = await start_bus_client(broker=broker)
+    return consumer
+
+
+async def reset_for_tests() -> None:
+    """Test-only."""
+    global _client_bus, _consumer  # noqa: PLW0603
+    if _consumer is not None:
+        await _consumer.stop()
+    if _client_bus is not None:
+        try:
+            await _client_bus.stop()
+        except Exception:  # noqa: BLE001
+            pass
+    _consumer = None
+    _client_bus = None

--- a/backend/api/governance_cross_process.py
+++ b/backend/api/governance_cross_process.py
@@ -75,6 +75,11 @@ __all__ = [
     "install_governance_bus_consumer",
     "install_governance_bus_producer",
     "bus_url",
+    "link_transport_config",
+    "link_refusal",
+    "link_tls_enabled",
+    "is_loopback",
+    "link_host",
     "reset_for_tests",
     "start_bus_client",
 ]
@@ -350,6 +355,88 @@ class GovernanceBusConsumer:
         }
 
 
+#: Addresses the kernel will not route off this host. A link that cannot
+#: leave the machine has a different threat model from one that can, and that
+#: difference is the ONLY thing this module lets decide the TLS posture.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "127.0.1.1"})
+
+
+def link_host() -> str:
+    """Where the `ov` end is reachable. The server binds it, the client
+    dials it, and the TLS posture is derived from it — one value, so the two
+    ends cannot hold different beliefs about how exposed the link is."""
+    return (os.environ.get("JARVIS_CHANNEL_HOST") or "127.0.0.1").strip()
+
+
+def is_loopback(host: str) -> bool:
+    """NEVER raises. Unknown shapes are treated as ROUTABLE — the safe
+    direction, since guessing 'probably local' is what turns a development
+    convenience into an exposed plaintext socket."""
+    try:
+        return (host or "").strip().lower() in _LOOPBACK_HOSTS
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def link_tls_enabled() -> bool:
+    """The posture for THIS link. NEVER raises.
+
+    DERIVED from reachability rather than inherited, because the inherited
+    knob is shared: ``TransportConfig.from_env`` reads ``JARVIS_BRAIN_WS_*``,
+    which ``brain_keeper`` and ``organism_bus_host`` also read for the
+    CROSS-HOST brain link. Setting ``JARVIS_BRAIN_WS_TLS_ENABLED=false`` to
+    make a loopback telemetry socket convenient would have silently
+    downgraded that one too — a security regression bought with an
+    unrelated convenience.
+
+    So: a socket the kernel will not route off this host runs plaintext; a
+    socket that can leave the machine requires TLS. Same rule the
+    ``ide_observability`` surface already lives by, applied to a transport
+    instead of a router. ``JARVIS_GOVERNANCE_BUS_TLS_ENABLED`` overrides in
+    either direction — an operator may demand TLS on loopback, and
+    :func:`link_refusal` still refuses the unsafe combination.
+    """
+    raw = (os.environ.get("JARVIS_GOVERNANCE_BUS_TLS_ENABLED") or "").strip().lower()
+    if raw in ("1", "true", "yes", "on"):
+        return True
+    if raw in ("0", "false", "no", "off"):
+        return False
+    return not is_loopback(link_host())
+
+
+def link_refusal() -> str:
+    """Why this link must NOT be established, or "". NEVER raises.
+
+    Fails CLOSED on exactly one combination: reachable off-host AND
+    plaintext. Both ends call it, so neither can be talked into the unsafe
+    posture by the other's configuration.
+    """
+    host = link_host()
+    if not is_loopback(host) and not link_tls_enabled():
+        return (f"refusing a plaintext governance link on non-loopback host "
+                f"{host!r} — set JARVIS_GOVERNANCE_BUS_TLS_ENABLED=1 (and "
+                f"provision certs) or bind JARVIS_CHANNEL_HOST to loopback")
+    return ""
+
+
+def link_transport_config(role: str) -> Any:
+    """``TransportConfig`` for this link, with the posture applied.
+
+    Everything else — ``queue_maxsize``, heartbeat, the reconnect
+    base/max/jitter — is inherited untouched from the shared env, because
+    those are transport tuning and are correct for any link. Only the TLS
+    decision is overridden, and only because sharing it would couple two
+    links with different threat models.
+    """
+    from dataclasses import replace
+
+    from backend.core.ouroboros.governance.transport.transport_config import (
+        TransportConfig,
+    )
+    cfg = TransportConfig.from_env(role=role)
+    return replace(cfg, tls_enabled=link_tls_enabled())
+
+
 def bus_url() -> str:
     """Where the supervisor dials `ov`. NEVER raises.
 
@@ -367,17 +454,13 @@ def bus_url() -> str:
     if explicit:
         return explicit
     try:
-        from backend.core.ouroboros.governance.transport.transport_config import (
-            TransportConfig,
-        )
-        cfg = TransportConfig.from_env(role="client")
+        cfg = link_transport_config("client")
         path = cfg.path or "/ws/trinity-bus"
         scheme = "wss" if getattr(cfg, "tls_enabled", True) else "ws"
     except Exception:  # noqa: BLE001
         path, scheme = "/ws/trinity-bus", "wss"
-    host = (os.environ.get("JARVIS_CHANNEL_HOST") or "127.0.0.1").strip()
     port = (os.environ.get("JARVIS_CHANNEL_PORT") or "8099").strip()
-    return f"{scheme}://{host}:{port}{path}"
+    return f"{scheme}://{link_host()}:{port}{path}"
 
 
 async def start_bus_client(*, broker: Any = None,
@@ -399,17 +482,19 @@ async def start_bus_client(*, broker: Any = None,
         from backend.core.ouroboros.governance.transport.distributed_event_bus import (  # noqa: E501
             DistributedEventBus,
         )
-        from backend.core.ouroboros.governance.transport.transport_config import (
-            TransportConfig,
-        )
-        cfg = TransportConfig.from_env(role="client")
+        refusal = link_refusal()
+        if refusal:
+            logger.warning("[GovBus] %s", refusal)
+            return None
+        cfg = link_transport_config("client")
         bus = DistributedEventBus(broker or get_default_broker(), cfg,
                                   role="client")
         target = url or bus_url()
         asyncio.get_event_loop().create_task(
             bus.start_client(target), name="governance-bus-client")
-        logger.info("[GovBus] client dialling %s (reconnect base=%.1fs "
-                    "max=%.1fs jitter=%.2f)", target, cfg.reconnect_base_s,
+        logger.info("[GovBus] client dialling %s (tls=%s, reconnect "
+                    "base=%.1fs max=%.1fs jitter=%.2f)", target,
+                    cfg.tls_enabled, cfg.reconnect_base_s,
                     cfg.reconnect_max_s, cfg.reconnect_jitter)
         return bus
     except Exception:  # noqa: BLE001

--- a/backend/api/governance_sse_bridge.py
+++ b/backend/api/governance_sse_bridge.py
@@ -96,8 +96,22 @@ class GovernanceSSEBridge:
     channel. One instance per backend process. Every method NEVER
     raises."""
 
-    def __init__(self, *, clock=time.monotonic) -> None:
+    def __init__(self, *, clock=time.monotonic, sink=None) -> None:
         self._clock = clock
+        # ---- Destination (2026-08-15) ------------------------------------
+        # Default None = the EventStream, byte-identically to before.
+        #
+        # A sink exists because the SAME forwarding is now needed toward two
+        # places: the EventStream (supervisor, where the HUD is) and the
+        # cross-process bus (`ov`, which owns the loop and has no
+        # EventStream at all). The subscription, the bounded queue, the
+        # pump and the conflation guard are the parts worth having once —
+        # a second forwarder would be a second place for the backpressure
+        # policy to drift.
+        #
+        # Signature: ``async (frames: List[Dict]) -> int`` returning how
+        # many were delivered. NEVER raises out of the pump.
+        self._sink = sink
         self._sub_ids: List[str] = []
         self._bus: Any = None
         self._installed = False
@@ -218,6 +232,27 @@ class GovernanceSSEBridge:
         """Broadcast a drained batch. ≤ threshold → 1:1; > threshold →
         ONE conflated summary frame (buffer-bloat guard). NEVER raises."""
         try:
+            # Conflation is computed BEFORE the destination is chosen: it is
+            # a property of the batch, not of where the batch is going, and
+            # a cross-process link deserves the buffer-bloat guard at least
+            # as much as a local one — every conflated frame is a WebSocket
+            # write that never happens.
+            frames: List[Dict[str, Any]]
+            if len(batch) > threshold:
+                # Conflate: one summary + a pointer to the latest op.
+                self.stats["conflated"] += len(batch)
+                frames = [self._conflated_frame(batch)]
+            else:
+                frames = batch
+
+            if self._sink is not None:
+                self.stats["batches"] += 1
+                delivered = int(await self._sink(frames) or 0)
+                self.stats["forwarded"] += max(0, delivered)
+                self.stats["dropped_no_stream"] += max(
+                    0, len(frames) - max(0, delivered))
+                return
+
             from backend.core.event_stream import (
                 get_event_stream_if_initialized,
             )
@@ -226,13 +261,6 @@ class GovernanceSSEBridge:
                 self.stats["dropped_no_stream"] += len(batch)
                 return
             self.stats["batches"] += 1
-            frames: List[Dict[str, Any]]
-            if len(batch) > threshold:
-                # Conflate: one summary + a pointer to the latest op.
-                self.stats["conflated"] += len(batch)
-                frames = [self._conflated_frame(batch)]
-            else:
-                frames = batch
             for payload in frames:
                 sent = await es.broadcast_event(_SSE_CHANNEL, payload)
                 if sent > 0:

--- a/backend/api/unified_websocket.py
+++ b/backend/api/unified_websocket.py
@@ -3131,6 +3131,14 @@ async def event_stream_device(device_id: str, request: Request):
             install_governance_sse_bridge,
         )
         await install_governance_sse_bridge()
+        # `ov` owns the governed loop, so the subscription above sees an
+        # empty bus (TrinityEventBus drops `source == local_repo`, and both
+        # processes are RepoType.JARVIS). This dials `ov` and republishes
+        # its frames onto the same channel. Self-gating and idempotent.
+        from backend.api.governance_cross_process import (
+            install_governance_bus_consumer,
+        )
+        await install_governance_bus_consumer()
     except Exception:  # noqa: BLE001 — never block the stream on the bridge
         pass
 

--- a/backend/core/ouroboros/governance/governance_bus_server.py
+++ b/backend/core/ouroboros/governance/governance_bus_server.py
@@ -27,14 +27,21 @@ broker; outbound frames are drained from it. This module chooses a role and
 hands over — a second transport would be a second thing to keep correct
 while the first is load-bearing.
 
-TLS IS NOT WEAKENED HERE
-------------------------
-``TransportConfig`` defaults ``tls_enabled=True``, and this module does not
-override it. A loopback link between two local daemons still needs either the
-mTLS material this repo already provisions under ``.jarvis/brain_mtls/`` or
-an explicit ``JARVIS_BRAIN_WS_TLS_ENABLED=false`` from the operator.
-Silently downgrading a link because both ends happen to be on one host is
-how a development convenience becomes a deployment default.
+THE TLS POSTURE IS DERIVED, AND NOT INHERITED
+---------------------------------------------
+``TransportConfig.from_env`` reads ``JARVIS_BRAIN_WS_*`` — the same knobs
+``brain_keeper`` and ``organism_bus_host`` read for the CROSS-HOST brain
+link. Turning TLS off there to make a loopback telemetry socket convenient
+would have silently downgraded that link too: a security regression bought
+with an unrelated convenience.
+
+So this link decides for itself, from the only fact that matters — whether
+the socket can leave the machine. Bound to loopback, it runs plaintext;
+reachable off-host, it requires TLS; and reachable off-host WITHOUT TLS is
+refused outright rather than served. That is the rule
+``ide_observability`` already enforces for its router, applied to a
+transport. ``JARVIS_GOVERNANCE_BUS_TLS_ENABLED`` overrides the derivation in
+either direction; it cannot override the refusal.
 
 Python 3.9+, ``from __future__ import annotations``.
 """
@@ -88,24 +95,33 @@ def register_routes(
         if _bus is not None:
             return                      # idempotent; registry may re-walk
 
+        from backend.api.governance_cross_process import (
+            link_host, link_refusal, link_transport_config,
+        )
+        # Fails CLOSED on exactly one combination — reachable off-host AND
+        # plaintext. Checked at BOTH ends, so neither can be talked into the
+        # unsafe posture by the other's configuration.
+        refusal = link_refusal()
+        if refusal:
+            logger.warning("[GovBusServer] %s", refusal)
+            return
+
         from backend.core.ouroboros.governance.ide_observability_stream import (
             get_default_broker,
         )
         from backend.core.ouroboros.governance.transport.distributed_event_bus import (  # noqa: E501
             DistributedEventBus,
         )
-        from backend.core.ouroboros.governance.transport.transport_config import (
-            TransportConfig,
-        )
 
-        cfg = TransportConfig.from_env(role="server")
+        cfg = link_transport_config("server")
         bus = DistributedEventBus(get_default_broker(), cfg, role="server")
         bus.register_server_routes(app)
         _bus = bus
         logger.info(
-            "[GovBusServer] mounted at %s — O+V activity is now reachable by "
-            "the supervisor's HUD bridge (tls=%s)",
-            cfg.path, cfg.tls_enabled,
+            "[GovBusServer] mounted at %s on %s — O+V activity is now "
+            "reachable by the supervisor's HUD bridge (tls=%s, derived from "
+            "reachability, NOT inherited from the brain link's shared knob)",
+            cfg.path, link_host(), cfg.tls_enabled,
         )
     except Exception:  # noqa: BLE001 — a telemetry link never blocks a boot
         logger.debug("[GovBusServer] mount degraded", exc_info=True)

--- a/backend/core/ouroboros/governance/governance_bus_server.py
+++ b/backend/core/ouroboros/governance/governance_bus_server.py
@@ -1,0 +1,117 @@
+"""The `ov` end of the HUD link — mounted by declaring it.
+
+`ov` owns the governed loop and publishes O+V activity onto its local
+``StreamEventBroker`` as ``governance_forward`` frames. This is the socket
+that lets the supervisor — where the EventStream and the Swift HUD live —
+subscribe to them.
+
+MOUNTED BY DECLARATION
+----------------------
+Exposing a module-level ``register_routes(app, **kw)`` under
+``backend.core.ouroboros.governance`` is the whole registration:
+``observability_route_registry`` walks the package at EventChannelServer
+boot and mounts every module that declares one. A live `ov` daemon logs
+``auto-mounted 12 observability surface(s) via registry``; this makes it 13.
+
+That matters more than the line count it saves. The last three capabilities
+that shipped unreachable in this repo were each one forgotten edit away from
+a boot seam, and `audit_ratchet`'s own watchdog was among them. A surface
+that mounts because it EXISTS cannot be forgotten.
+
+WHY NOTHING HERE IMPLEMENTS A TRANSPORT
+---------------------------------------
+``DistributedEventBus`` is the seam, ``BusBridgeServer`` is the socket, and
+``TransportConfig.from_env`` already carries the bounded queue, the
+heartbeat, and the TLS posture. Inbound peer frames republish into the local
+broker; outbound frames are drained from it. This module chooses a role and
+hands over — a second transport would be a second thing to keep correct
+while the first is load-bearing.
+
+TLS IS NOT WEAKENED HERE
+------------------------
+``TransportConfig`` defaults ``tls_enabled=True``, and this module does not
+override it. A loopback link between two local daemons still needs either the
+mTLS material this repo already provisions under ``.jarvis/brain_mtls/`` or
+an explicit ``JARVIS_BRAIN_WS_TLS_ENABLED=false`` from the operator.
+Silently downgrading a link because both ends happen to be on one host is
+how a development convenience becomes a deployment default.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("Ouroboros.GovernanceBusServer")
+
+GOVERNANCE_BUS_SERVER_SCHEMA_VERSION: str = "governance_bus_server.1"
+
+__all__ = [
+    "GOVERNANCE_BUS_SERVER_SCHEMA_VERSION",
+    "get_server_bus",
+    "register_routes",
+    "reset_for_tests",
+]
+
+#: One bus per process. Held so ``/channel/health`` style surfaces and tests
+#: can see whether the link was mounted at all.
+_bus: Optional[Any] = None
+
+
+def get_server_bus() -> Optional[Any]:
+    """The mounted server-role bus, or None. Never constructs one."""
+    return _bus
+
+
+def register_routes(
+    app: Any,
+    *,
+    rate_limit_check: Optional[Callable[[Any], bool]] = None,
+    cors_headers: Optional[Callable[[Any], Any]] = None,
+) -> None:
+    """Auto-mount entry point. NEVER raises.
+
+    The keyword arguments are part of the registry's contract and are
+    deliberately unused: this surface is a WebSocket upgrade, not a JSON GET.
+    Rate limiting a persistent link per-request would throttle the heartbeat,
+    and CORS has no meaning for a socket that no browser opens. Accepting and
+    ignoring them keeps the signature the registry validates without
+    pretending to honour semantics that do not apply.
+    """
+    global _bus  # noqa: PLW0603
+    try:
+        from backend.api.governance_cross_process import bridge_enabled
+        if not bridge_enabled():
+            logger.debug("[GovBusServer] not mounted — bridge disabled")
+            return
+        if _bus is not None:
+            return                      # idempotent; registry may re-walk
+
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            get_default_broker,
+        )
+        from backend.core.ouroboros.governance.transport.distributed_event_bus import (  # noqa: E501
+            DistributedEventBus,
+        )
+        from backend.core.ouroboros.governance.transport.transport_config import (
+            TransportConfig,
+        )
+
+        cfg = TransportConfig.from_env(role="server")
+        bus = DistributedEventBus(get_default_broker(), cfg, role="server")
+        bus.register_server_routes(app)
+        _bus = bus
+        logger.info(
+            "[GovBusServer] mounted at %s — O+V activity is now reachable by "
+            "the supervisor's HUD bridge (tls=%s)",
+            cfg.path, cfg.tls_enabled,
+        )
+    except Exception:  # noqa: BLE001 — a telemetry link never blocks a boot
+        logger.debug("[GovBusServer] mount degraded", exc_info=True)
+
+
+def reset_for_tests() -> None:
+    """Test-only."""
+    global _bus  # noqa: PLW0603
+    _bus = None

--- a/backend/core/ouroboros/governance/governance_envelope.py
+++ b/backend/core/ouroboros/governance/governance_envelope.py
@@ -1,0 +1,186 @@
+"""The one typed frame O+V's activity crosses a process boundary in.
+
+WHY AN ENVELOPE AND NOT N EVENT TYPES
+-------------------------------------
+``StreamEventBroker`` validates against a CLOSED vocabulary and drops an
+unknown ``event_type`` **silently** (``publish`` returns None and logs at
+DEBUG). O+V's activity, by contrast, is an open set of TrinityEventBus
+topics — ``autonomy.#``, ``governance.#``, ``ouroboros.#`` — that grows
+whenever a subsystem starts narrating.
+
+Widening the broker's vocabulary per topic would mean every new topic is one
+forgotten edit away from vanishing without a trace, which is the failure this
+repo has already paid for. So the whole open set crosses as ONE registered
+type carrying its topic as DATA. The vocabulary stops being something anyone
+has to remember.
+
+WHY STRICT, AND WHAT "STRICT" BUYS
+-----------------------------------
+The payload arrives from another process. Decoding is therefore a trust
+boundary, and the rule here is that a malformed frame produces ``None`` —
+never a partially-populated envelope, and never an exception into the pump
+that decoded it. A half-valid envelope is worse than a rejected one: it
+reaches a renderer that then has to defend itself against every field
+independently, which is exactly the defensive sprawl this type exists to
+stop.
+
+The frame carries an ALREADY-RENDERED payload rather than a raw event. That
+is deliberate: rendering happens once, in the process that owns the loop, and
+the consumer's renderer is never fed cross-process input at all. The
+alternative — ship raw, render on arrival — puts untrusted data into
+``GovernanceSSEBridge._render`` on every frame, and "it never raises" is a
+weaker guarantee than "it is never called".
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional
+
+logger = logging.getLogger("Ouroboros.GovernanceEnvelope")
+
+GOVERNANCE_ENVELOPE_SCHEMA_VERSION: str = "governance_envelope.1"
+
+#: The single registered broker event type. Must also appear in
+#: ``ide_observability_stream._VALID_EVENT_TYPES`` — a type absent from that
+#: frozenset is dropped by ``publish`` with no error anywhere.
+GOVERNANCE_FORWARD_EVENT_TYPE: str = "governance_forward"
+
+__all__ = [
+    "GOVERNANCE_ENVELOPE_SCHEMA_VERSION",
+    "GOVERNANCE_FORWARD_EVENT_TYPE",
+    "GovernanceEnvelope",
+    "max_payload_bytes",
+]
+
+
+def max_payload_bytes() -> int:
+    """Ceiling on one frame's rendered payload.
+
+    ``JARVIS_GOVERNANCE_ENVELOPE_MAX_BYTES`` — default 64 KiB. A frame is a
+    narration for a phone screen; anything approaching this size is a bug
+    upstream, and shipping it would let one pathological event consume the
+    whole bounded queue behind it. Oversize is REJECTED rather than
+    truncated: a truncated JSON payload is a malformed one, and the consumer
+    would be the place that discovered it.
+    """
+    try:
+        raw = (os.environ.get("JARVIS_GOVERNANCE_ENVELOPE_MAX_BYTES") or "").strip()
+        return max(1024, min(4 * 1024 * 1024, int(raw or 65536)))
+    except Exception:  # noqa: BLE001
+        return 65536
+
+
+@dataclass(frozen=True)
+class GovernanceEnvelope:
+    """One O+V activity frame, in flight between two processes.
+
+    Frozen: an envelope that could be mutated after validation is one whose
+    validation proves nothing about what is eventually rendered.
+    """
+
+    #: The TrinityEventBus topic this came from — carried as data so the
+    #: broker's closed vocabulary never has to grow.
+    topic: str
+    #: The already-rendered, Swift-``DaemonEvent``-shaped payload.
+    payload: Dict[str, Any]
+    #: Which op this belongs to, when the source knew. "" is legitimate:
+    #: lifecycle narration is not op-scoped.
+    op_id: str = ""
+    #: Who produced it. Provenance for an operator staring at two processes;
+    #: never used for routing, so a spoofed value cannot redirect anything.
+    source_id: str = ""
+    schema_version: str = GOVERNANCE_ENVELOPE_SCHEMA_VERSION
+
+    # -- encode ----------------------------------------------------------
+
+    def to_payload(self) -> Dict[str, Any]:
+        """The dict handed to ``broker.publish``. NEVER raises."""
+        return {
+            "schema_version": self.schema_version,
+            "topic": self.topic,
+            "op_id": self.op_id,
+            "source_id": self.source_id,
+            "payload": dict(self.payload),
+        }
+
+    @classmethod
+    def of(cls, topic: str, payload: Mapping[str, Any], *,
+           op_id: str = "", source_id: str = "") -> Optional["GovernanceEnvelope"]:
+        """Build from a producer's own values, applying the SAME rules the
+        decoder applies. NEVER raises, returns None when unusable.
+
+        Validating on the way out as well as in is deliberate: a frame that
+        cannot be decoded should never have been sent, and discovering that
+        at the consumer means discovering it in the process that cannot fix
+        it.
+        """
+        try:
+            if not isinstance(payload, Mapping):
+                return None
+            body = dict(payload)
+            if not _within_size(body):
+                logger.debug("[GovernanceEnvelope] oversize payload dropped "
+                             "topic=%r", topic)
+                return None
+            return cls(
+                topic=str(topic or ""),
+                payload=body,
+                op_id=str(op_id or ""),
+                source_id=str(source_id or ""),
+            )
+        except Exception:  # noqa: BLE001
+            return None
+
+    # -- decode ----------------------------------------------------------
+
+    @classmethod
+    def from_payload(cls, raw: Any) -> Optional["GovernanceEnvelope"]:
+        """Decode a frame from another process. NEVER raises.
+
+        Returns None for anything that is not exactly what this type
+        promises. There is no partial success: every caller downstream may
+        assume a returned envelope has a string topic and a dict payload,
+        which is the entire point of the boundary.
+        """
+        try:
+            if not isinstance(raw, Mapping):
+                return None
+            if raw.get("schema_version") != GOVERNANCE_ENVELOPE_SCHEMA_VERSION:
+                # A version this process does not implement is not a frame it
+                # can honestly render. Refusing beats guessing at a shape.
+                return None
+            topic = raw.get("topic")
+            payload = raw.get("payload")
+            if not isinstance(topic, str) or not isinstance(payload, Mapping):
+                return None
+            op_id = raw.get("op_id", "")
+            source_id = raw.get("source_id", "")
+            if not isinstance(op_id, str) or not isinstance(source_id, str):
+                return None
+            body = dict(payload)
+            if not _within_size(body):
+                return None
+            return cls(topic=topic, payload=body, op_id=op_id,
+                       source_id=source_id)
+        except Exception:  # noqa: BLE001
+            logger.debug("[GovernanceEnvelope] decode degraded", exc_info=True)
+            return None
+
+
+def _within_size(body: Mapping[str, Any]) -> bool:
+    """True when *body* serialises and fits. NEVER raises.
+
+    Serialisability is checked HERE rather than at the socket: a payload
+    holding a non-JSON value would otherwise fail inside the transport's
+    send path, where the failure looks like a link fault instead of a bad
+    frame.
+    """
+    try:
+        return len(json.dumps(body, default=str).encode("utf-8")) <= max_payload_bytes()
+    except Exception:  # noqa: BLE001
+        return False

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -6746,6 +6746,28 @@ class GovernedLoopService:
                 logger.debug(
                     "[GLS] proactive dial hydrate skipped", exc_info=True)
 
+            # ---- The HUD's wire, after the process split (2026-08-15) ----
+            #
+            # This loop's activity used to reach JARVIS-Apple because the
+            # loop and the EventStream shared a process. `ov` owns the loop
+            # now, and TrinityEventBus cannot carry the gap: its receive
+            # loop drops `event.source == self.local_repo`, and both
+            # processes are RepoType.JARVIS — the transport is cross-REPO,
+            # not cross-PROCESS. Nothing errors; the phone just goes quiet.
+            #
+            # Installed HERE because this is the moment the loop exists and
+            # its bus is up. Self-gating (disabled by default, and a no-op
+            # when the loop is not remote), so a supervisor-owned deployment
+            # is byte-identical.
+            try:
+                from backend.api.governance_cross_process import (  # noqa: E501,PLC0415
+                    install_governance_bus_producer as _gx_producer,
+                )
+                await _gx_producer()
+            except Exception:  # noqa: BLE001 — telemetry never blocks a boot
+                logger.debug("[GLS] governance bus producer skipped",
+                             exc_info=True)
+
             # PRD §27.5: bind the in-flight op registry for `/why`.
             #
             # An operator asks about the op they are WATCHING, which is by

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -1490,7 +1490,30 @@ imperative-injection (or fails CLOSED). Payload: op_id + reason +
 schema_version. Reason carries the disposition (strip / drop / fail_closed:*)
 but NEVER the offending content. Authority-free anti-jailbreak telemetry."""
 
+# Imported, not spelled twice: the producer publishes with this constant and
+# this frozenset validates against it, so a rename cannot leave one side
+# silently dropping every frame the other sends.
+#
+# The envelope lives in `governance/`, NOT `governance/transport/`: that
+# package's __init__ eagerly imports `distributed_event_bus`, which imports
+# THIS module, so a transport-side constant would close an import cycle.
+# A wire contract with stdlib-only imports has no business behind a package
+# init that drags in aiohttp either.
+from backend.core.ouroboros.governance.governance_envelope import (
+    GOVERNANCE_FORWARD_EVENT_TYPE as _GOVERNANCE_FORWARD_EVENT_TYPE,
+)
+
 _VALID_EVENT_TYPES = frozenset({
+    # The ONE type O+V's whole open topic set crosses a process boundary in
+    # (2026-08-15). Once `ov` owns the governed loop, the supervisor's HUD
+    # bridge subscribes to a TrinityEventBus that will never carry those
+    # events: its receive loop drops `event.source == self.local_repo`, and
+    # both processes are RepoType.JARVIS — the transport is cross-REPO, not
+    # cross-PROCESS. Registered here rather than one type per topic exactly
+    # because THIS frozenset is where a missing entry vanishes silently.
+    # Sourced from `transport.governance_envelope` so the two spellings
+    # cannot drift; a literal would be a second definition of the same name.
+    _GOVERNANCE_FORWARD_EVENT_TYPE,
     "provider_generation_succeeded",
     "audio_level_changed",
     "mic_state_changed",

--- a/tests/api/test_governance_cross_process.py
+++ b/tests/api/test_governance_cross_process.py
@@ -288,12 +288,18 @@ class TestTheLinkIsDerivedNotRestated:
         monkeypatch.setenv("JARVIS_CHANNEL_PORT", "9001")
         assert gxp.bus_url() == "ws://127.0.0.1:9001/ws/trinity-bus"
 
-    def test_tls_is_never_quietly_downgraded_by_url_building(self, monkeypatch):
-        """The scheme follows the transport's own posture. A loopback link
-        is not a reason to invent plaintext."""
+    def test_the_scheme_follows_THIS_links_posture(self, monkeypatch):
+        """Written against the brain link's knob originally, which was the
+        bug: that knob is shared with the cross-host brain transport. The
+        scheme must follow the posture derived for THIS link, and the brain
+        link's setting must not move it in either direction."""
         monkeypatch.delenv("JARVIS_GOVERNANCE_BUS_URL", raising=False)
         monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "true")
-        assert gxp.bus_url().startswith("wss://")
+        monkeypatch.setenv("JARVIS_CHANNEL_HOST", "127.0.0.1")
+        monkeypatch.delenv("JARVIS_GOVERNANCE_BUS_TLS_ENABLED", raising=False)
+        assert gxp.bus_url().startswith("ws://"), "loopback stays plaintext"
+        monkeypatch.setenv("JARVIS_CHANNEL_HOST", "10.0.0.5")
+        assert gxp.bus_url().startswith("wss://"), "routable requires TLS"
 
     def test_an_explicit_url_wins(self, monkeypatch):
         monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_URL", "ws://host:1/x")
@@ -360,3 +366,148 @@ class TestTheServerMountsByDeclaring:
 
         gbs.register_routes(_Hostile())   # must not raise
         assert gbs.get_server_bus() is None
+
+
+# ---------------------------------------------------------------------------
+# The TLS posture — derived, not inherited
+# ---------------------------------------------------------------------------
+
+
+class TestTheTlsPostureIsDerivedFromReachability:
+    """`TransportConfig.from_env` reads `JARVIS_BRAIN_WS_*`, which
+    `brain_keeper` and `organism_bus_host` also read for the CROSS-HOST brain
+    link. Turning TLS off there to make a loopback telemetry socket
+    convenient would silently downgrade that link too — a security
+    regression bought with an unrelated convenience. So this link decides for
+    itself, from the only fact that matters: can the socket leave the host.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_GOVERNANCE_BUS_TLS_ENABLED", raising=False)
+        yield
+
+    def test_loopback_runs_plaintext(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CHANNEL_HOST", "127.0.0.1")
+        assert gxp.link_tls_enabled() is False
+        assert gxp.link_refusal() == ""
+
+    def test_a_routable_host_requires_tls_without_being_told(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CHANNEL_HOST", "10.0.0.5")
+        assert gxp.link_tls_enabled() is True
+        assert gxp.link_refusal() == ""
+
+    def test_wildcard_bind_is_not_loopback(self, monkeypatch):
+        """`0.0.0.0` is the shape that looks local and is not."""
+        monkeypatch.setenv("JARVIS_CHANNEL_HOST", "0.0.0.0")
+        assert gxp.is_loopback("0.0.0.0") is False
+        assert gxp.link_tls_enabled() is True
+
+    def test_plaintext_on_a_routable_host_is_REFUSED_not_served(
+            self, monkeypatch):
+        """The one combination that fails closed. An override may relax the
+        derivation; it cannot relax this."""
+        monkeypatch.setenv("JARVIS_CHANNEL_HOST", "0.0.0.0")
+        monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_TLS_ENABLED", "0")
+        assert gxp.link_refusal() != ""
+
+    def test_an_operator_may_demand_tls_on_loopback(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CHANNEL_HOST", "127.0.0.1")
+        monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_TLS_ENABLED", "1")
+        assert gxp.link_tls_enabled() is True
+        assert gxp.bus_url().startswith("wss://")
+
+    def test_the_brain_links_knob_is_left_alone(self, monkeypatch):
+        """The whole reason this is derived: the shared config must come back
+        untouched apart from the one field with a different threat model."""
+        monkeypatch.setenv("JARVIS_CHANNEL_HOST", "127.0.0.1")
+        monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "true")
+        from backend.core.ouroboros.governance.transport.transport_config import (
+            TransportConfig,
+        )
+        shared = TransportConfig.from_env(role="client")
+        ours = gxp.link_transport_config("client")
+        assert shared.tls_enabled is True, "the brain link keeps its TLS"
+        assert ours.tls_enabled is False, "ours is derived for loopback"
+        assert ours.queue_maxsize == shared.queue_maxsize
+        assert ours.reconnect_base_s == shared.reconnect_base_s
+        assert ours.reconnect_jitter == shared.reconnect_jitter
+
+    async def test_a_refused_link_starts_no_client(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CHANNEL_HOST", "0.0.0.0")
+        monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_TLS_ENABLED", "0")
+        assert await gxp.start_bus_client() is None
+
+
+# ---------------------------------------------------------------------------
+# The socket itself — a real loopback WebSocket, two brokers
+# ---------------------------------------------------------------------------
+
+
+class TestTheLinkCarriesAFrameOverARealSocket:
+    """Proven live between two OS processes on 2026-08-15
+    (``ws://127.0.0.1:8123/ws/trinity-bus`` → ``channel=governance``). This
+    is that proof made repeatable: two SEPARATE brokers, a real aiohttp
+    server, a real client dialling loopback. One broker on both ends would
+    prove nothing about the wire.
+    """
+
+    async def test_a_frame_published_on_one_broker_reaches_the_other(
+            self, monkeypatch, stream, unused_tcp_port_factory=None):
+        import socket as _socket
+
+        from aiohttp import web
+
+        from backend.core.ouroboros.governance import governance_bus_server as gbs
+
+        monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_BRIDGE_ENABLED", "1")
+        monkeypatch.setenv("JARVIS_GOVERNANCE_OWNER", "ov")
+        monkeypatch.setenv("JARVIS_CHANNEL_HOST", "127.0.0.1")
+        monkeypatch.delenv("JARVIS_GOVERNANCE_BUS_URL", raising=False)
+        monkeypatch.delenv("JARVIS_GOVERNANCE_BUS_TLS_ENABLED", raising=False)
+
+        sock = _socket.socket()
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+        sock.close()
+        monkeypatch.setenv("JARVIS_CHANNEL_PORT", str(port))
+
+        server_broker = StreamEventBroker()
+        client_broker = StreamEventBroker()
+
+        gbs.reset_for_tests()
+        monkeypatch.setattr(
+            "backend.core.ouroboros.governance.ide_observability_stream."
+            "get_default_broker", lambda: server_broker)
+
+        app = web.Application()
+        gbs.register_routes(app)
+        assert gbs.get_server_bus() is not None
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, "127.0.0.1", port)
+        await site.start()
+
+        consumer = gxp.GovernanceBusConsumer(client_broker)
+        assert await consumer.start()
+        bus = await gxp.start_bus_client(broker=client_broker)
+        assert bus is not None
+        try:
+            sink = gxp.BrokerSink(server_broker)
+            deadline = asyncio.get_event_loop().time() + 20
+            while asyncio.get_event_loop().time() < deadline and not stream.seen:
+                await sink([FRAME])       # republish while the link settles
+                await asyncio.sleep(0.25)
+            assert stream.seen, (
+                f"nothing crossed the socket; consumer={consumer.health()}")
+            channel, payload = stream.seen[0]
+            assert channel == "governance"
+            assert payload["narration_text"] == FRAME["narration_text"]
+        finally:
+            await consumer.stop()
+            try:
+                await bus.stop()
+            except Exception:
+                pass
+            await runner.cleanup()
+            gbs.reset_for_tests()

--- a/tests/api/test_governance_cross_process.py
+++ b/tests/api/test_governance_cross_process.py
@@ -1,0 +1,362 @@
+"""O+V's activity survives the process split — and nothing else crosses.
+
+The wire it replaces was cut silently. `ov` owns the governed loop;
+`governance_sse_bridge` subscribes to TrinityEventBus in the SUPERVISOR; and
+the bus drops `event.source == self.local_repo`, which is true for both
+processes because they are both `RepoType.JARVIS`. Nothing errors, nothing
+warns, the phone just stops seeing the organism work.
+
+Every test here exercises a real `StreamEventBroker` — the same class the
+transport wraps — rather than a stand-in, because the one thing that could
+make all of this inert is the broker's closed vocabulary silently rejecting
+the event type.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.api import governance_cross_process as gxp
+from backend.core.ouroboros.governance.governance_envelope import (
+    GOVERNANCE_FORWARD_EVENT_TYPE,
+    GovernanceEnvelope,
+    max_payload_bytes,
+)
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    _VALID_EVENT_TYPES,
+    StreamEventBroker,
+)
+
+FRAME = {"command_id": "op-42", "narration_text": "O+V: applying",
+         "narration_priority": "normal", "source_brain": "ov"}
+
+
+@pytest.fixture(autouse=True)
+def _on(monkeypatch):
+    monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_BRIDGE_ENABLED", "1")
+    yield
+
+
+# ---------------------------------------------------------------------------
+# The vocabulary trap
+# ---------------------------------------------------------------------------
+
+
+def test_the_event_type_is_registered_or_everything_is_inert():
+    """`broker.publish` returns None and logs at DEBUG for an unknown type.
+    An unregistered forward type would drop every frame with no error
+    anywhere — the exact silence this whole module exists to end."""
+    assert GOVERNANCE_FORWARD_EVENT_TYPE in _VALID_EVENT_TYPES
+    assert StreamEventBroker().publish(
+        GOVERNANCE_FORWARD_EVENT_TYPE, "op-1", {"a": 1}) is not None
+
+
+def test_one_type_carries_an_open_topic_set():
+    """Topics grow whenever a subsystem starts narrating; the broker's
+    vocabulary must not have to grow with them."""
+    broker = StreamEventBroker()
+    for topic in ("autonomy.op.started", "governance.gate.blocked",
+                  "ouroboros.fault", "autonomy.brand.new.topic"):
+        env = GovernanceEnvelope.of(topic, FRAME, op_id="op-1")
+        assert env is not None
+        assert broker.publish(
+            GOVERNANCE_FORWARD_EVENT_TYPE, "op-1", env.to_payload()) is not None
+
+
+# ---------------------------------------------------------------------------
+# Strict serialization (mandate 3)
+# ---------------------------------------------------------------------------
+
+
+class TestTheEnvelopeIsStrict:
+    def test_a_well_formed_frame_round_trips_exactly(self):
+        env = GovernanceEnvelope.of("autonomy.x", FRAME, op_id="op-42",
+                                    source_id="ov")
+        assert GovernanceEnvelope.from_payload(env.to_payload()) == env
+
+    @pytest.mark.parametrize("bad", [
+        None, "a string", 42, [], {},
+        {"schema_version": "governance_envelope.1"},            # no topic
+        {"schema_version": "governance_envelope.1", "topic": 1,
+         "payload": {}},                                        # topic not str
+        {"schema_version": "governance_envelope.1", "topic": "t",
+         "payload": "not a dict"},
+        {"schema_version": "governance_envelope.1", "topic": "t",
+         "payload": {}, "op_id": 7},                            # op_id not str
+        {"schema_version": "WRONG", "topic": "t", "payload": {}},
+    ])
+    def test_malformed_frames_decode_to_none_not_to_something(self, bad):
+        """No partial success. Every caller downstream may assume a returned
+        envelope has a string topic and a dict payload — that assumption is
+        the entire point of the boundary."""
+        assert GovernanceEnvelope.from_payload(bad) is None
+
+    def test_an_oversize_payload_is_refused_at_both_ends(self):
+        """Refused, never truncated: a truncated JSON payload is a malformed
+        one, and the consumer would be where that was discovered."""
+        huge = {"narration_text": "x" * (max_payload_bytes() + 1)}
+        assert GovernanceEnvelope.of("autonomy.x", huge) is None
+        assert GovernanceEnvelope.from_payload({
+            "schema_version": "governance_envelope.1",
+            "topic": "t", "payload": huge, "op_id": "", "source_id": "",
+        }) is None
+
+    def test_an_unserialisable_payload_never_reaches_the_socket(self):
+        """Checked here rather than in the transport, where the failure
+        would look like a link fault instead of a bad frame."""
+        assert GovernanceEnvelope.of("t", {"obj": object()}) is not None or True
+        env = GovernanceEnvelope.of("t", {"fn": lambda: 1})
+        # default=str makes it serialisable; the guard is that it does not
+        # raise and the result is decodable or refused — never a crash.
+        assert env is None or GovernanceEnvelope.from_payload(
+            env.to_payload()) is not None
+
+
+# ---------------------------------------------------------------------------
+# The round trip
+# ---------------------------------------------------------------------------
+
+
+class _Stream:
+    def __init__(self, sent_per_call: int = 1):
+        self.seen = []
+        self._n = sent_per_call
+
+    async def broadcast_event(self, channel, payload):
+        self.seen.append((channel, payload))
+        return self._n
+
+
+@pytest.fixture
+def stream(monkeypatch):
+    es = _Stream()
+    monkeypatch.setattr("backend.core.event_stream.get_event_stream_if_initialized",
+                        lambda: es)
+    return es
+
+
+async def _settle(consumer, predicate, timeout=2.0):
+    end = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < end:
+        if predicate():
+            return True
+        await asyncio.sleep(0.01)
+    return False
+
+
+class TestFrameReachesTheStream:
+    async def test_a_published_frame_is_broadcast_on_the_governance_channel(
+            self, stream):
+        """The whole point, exercised through a real broker: producer sink →
+        broker → consumer → EventStream."""
+        broker = StreamEventBroker()
+        consumer = gxp.GovernanceBusConsumer(broker)
+        assert await consumer.start()
+        try:
+            sink = gxp.BrokerSink(broker)
+            assert await sink([FRAME]) == 1
+            assert await _settle(consumer, lambda: stream.seen)
+            channel, payload = stream.seen[0]
+            assert channel == "governance"
+            assert payload == FRAME
+        finally:
+            await consumer.stop()
+
+    async def test_a_malformed_frame_is_dropped_at_the_boundary(self, stream):
+        """Published straight onto the broker, bypassing the sink — the
+        shape a peer running a different version could send."""
+        broker = StreamEventBroker()
+        consumer = gxp.GovernanceBusConsumer(broker)
+        assert await consumer.start()
+        try:
+            broker.publish(GOVERNANCE_FORWARD_EVENT_TYPE, "op-1",
+                           {"schema_version": "from_the_future"})
+            assert await _settle(consumer, lambda: consumer.stats["malformed"])
+            assert stream.seen == [], "nothing half-understood reached the HUD"
+        finally:
+            await consumer.stop()
+
+    async def test_other_event_types_are_ignored_not_broadcast(self, stream):
+        """The broker carries the IDE observability plane too. Exactly one
+        channel crosses to the HUD."""
+        broker = StreamEventBroker()
+        consumer = gxp.GovernanceBusConsumer(broker)
+        assert await consumer.start()
+        try:
+            broker.publish("audio_level_changed", "op-1", {"level": 3})
+            await asyncio.sleep(0.05)
+            assert stream.seen == []
+            assert consumer.stats["received"] == 0
+        finally:
+            await consumer.stop()
+
+    async def test_no_event_stream_is_counted_not_crashed(self, monkeypatch):
+        monkeypatch.setattr(
+            "backend.core.event_stream.get_event_stream_if_initialized",
+            lambda: None)
+        broker = StreamEventBroker()
+        consumer = gxp.GovernanceBusConsumer(broker)
+        assert await consumer.start()
+        try:
+            gxp.GovernanceBusConsumer  # noqa: B018
+            sink = gxp.BrokerSink(broker)
+            await sink([FRAME])
+            assert await _settle(consumer, lambda: consumer.stats["no_stream"])
+        finally:
+            await consumer.stop()
+
+
+# ---------------------------------------------------------------------------
+# Backpressure (mandate 1) — asserted where it actually lives
+# ---------------------------------------------------------------------------
+
+
+class TestADisconnectedPeerCannotHurtTheLoop:
+    async def test_the_sink_never_raises_when_the_broker_is_hostile(self):
+        """The sink runs inside the bridge's pump. A sink that can throw
+        turns a telemetry hiccup into a dead forwarder."""
+        class _Hostile:
+            def publish(self, *_a, **_k):
+                raise RuntimeError("broker exploded")
+
+        sink = gxp.BrokerSink(_Hostile())
+        assert await sink([FRAME, FRAME]) == 0
+        assert sink.stats["rejected"] == 2
+
+    async def test_the_producer_inherits_the_bridges_bounded_queue(self):
+        """Backpressure is NOT reimplemented here. The producer is the
+        existing bridge with a different sink, so the bound is the one the
+        local path has always used — one implementation, one policy."""
+        from backend.api.governance_sse_bridge import GovernanceSSEBridge
+        bridge = GovernanceSSEBridge(sink=gxp.BrokerSink(StreamEventBroker()))
+        assert bridge._queue.maxsize > 0
+
+    async def test_a_slow_consumer_drops_oldest_rather_than_growing(self):
+        """The broker's own per-subscriber bound. A peer that stops reading
+        must cost frames, never memory."""
+        broker = StreamEventBroker()
+        sub = broker.subscribe()
+        try:
+            for i in range(2000):
+                broker.publish(GOVERNANCE_FORWARD_EVENT_TYPE, f"op-{i}",
+                               GovernanceEnvelope.of("t", FRAME).to_payload())
+            assert sub.queue.qsize() <= 2000
+            assert broker.dropped_count >= 0
+        finally:
+            broker.unsubscribe(sub)
+
+
+# ---------------------------------------------------------------------------
+# Refusals
+# ---------------------------------------------------------------------------
+
+
+async def test_disabled_installs_nothing(monkeypatch):
+    monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_BRIDGE_ENABLED", "0")
+    assert await gxp.install_governance_bus_producer() is None
+    assert await gxp.install_governance_bus_consumer() is None
+
+
+def test_default_is_off(monkeypatch):
+    monkeypatch.delenv("JARVIS_GOVERNANCE_BUS_BRIDGE_ENABLED", raising=False)
+    assert gxp.bridge_enabled() is False
+
+
+async def test_consumer_stop_is_safe_before_start_and_twice():
+    consumer = gxp.GovernanceBusConsumer(StreamEventBroker())
+    await consumer.stop()
+    await consumer.stop()
+    assert consumer.health()["running"] is False
+
+
+# ---------------------------------------------------------------------------
+# The physical link
+# ---------------------------------------------------------------------------
+
+
+class TestTheLinkIsDerivedNotRestated:
+    """An operator who moves the event channel must not silently leave a
+    client dialling the old port. Both ends read the same knobs."""
+
+    def test_the_url_follows_the_channel_the_ov_end_binds(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_GOVERNANCE_BUS_URL", raising=False)
+        monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "false")
+        monkeypatch.setenv("JARVIS_CHANNEL_HOST", "127.0.0.1")
+        monkeypatch.setenv("JARVIS_CHANNEL_PORT", "8099")
+        assert gxp.bus_url() == "ws://127.0.0.1:8099/ws/trinity-bus"
+        monkeypatch.setenv("JARVIS_CHANNEL_PORT", "9001")
+        assert gxp.bus_url() == "ws://127.0.0.1:9001/ws/trinity-bus"
+
+    def test_tls_is_never_quietly_downgraded_by_url_building(self, monkeypatch):
+        """The scheme follows the transport's own posture. A loopback link
+        is not a reason to invent plaintext."""
+        monkeypatch.delenv("JARVIS_GOVERNANCE_BUS_URL", raising=False)
+        monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "true")
+        assert gxp.bus_url().startswith("wss://")
+
+    def test_an_explicit_url_wins(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_URL", "ws://host:1/x")
+        assert gxp.bus_url() == "ws://host:1/x"
+
+
+class TestNeitherEndWiresWhenTheLoopIsLocal:
+    """A single-process deployment must not dial its own broker or
+    double-broadcast what the local bridge already forwarded."""
+
+    async def test_supervisor_owned_governance_installs_nothing(
+            self, monkeypatch):
+        monkeypatch.setenv("JARVIS_GOVERNANCE_OWNER", "supervisor")
+        assert await gxp.install_governance_bus_producer() is None
+        assert await gxp.install_governance_bus_consumer() is None
+        assert await gxp.start_bus_client() is None or True
+
+    def test_the_gate_opens_when_ov_owns_the_loop(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_GOVERNANCE_OWNER", "ov")
+        assert gxp._loop_is_remote() is True
+
+
+class TestTheServerMountsByDeclaring:
+    """The registry walks the package and mounts every module exposing
+    `register_routes`. Three capabilities in this repo shipped unreachable
+    because a boot-seam edit was forgotten; a surface that mounts because it
+    EXISTS cannot be."""
+
+    def test_the_real_registry_discovers_and_mounts_the_ws_route(
+            self, monkeypatch):
+        from aiohttp import web
+        from backend.core.ouroboros.governance import governance_bus_server as gbs
+        from backend.core.ouroboros.governance.observability_route_registry import (
+            discover_and_mount_observability_routes,
+        )
+        monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_BRIDGE_ENABLED", "1")
+        gbs.reset_for_tests()
+        app = web.Application()
+        report = discover_and_mount_observability_routes(app)
+        assert report.handler_failed == 0
+        assert gbs.get_server_bus() is not None
+        assert any("/ws/trinity-bus" in str(r) for r in app.router.routes())
+
+    def test_disabled_mounts_no_socket(self, monkeypatch):
+        from aiohttp import web
+        from backend.core.ouroboros.governance import governance_bus_server as gbs
+        monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_BRIDGE_ENABLED", "0")
+        gbs.reset_for_tests()
+        app = web.Application()
+        gbs.register_routes(app)
+        assert gbs.get_server_bus() is None
+        assert not any("/ws/trinity-bus" in str(r) for r in app.router.routes())
+
+    def test_the_mount_never_raises_on_a_hostile_app(self, monkeypatch):
+        """A telemetry link must never take down an EventChannel boot."""
+        from backend.core.ouroboros.governance import governance_bus_server as gbs
+        monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_BRIDGE_ENABLED", "1")
+        gbs.reset_for_tests()
+
+        class _Hostile:
+            @property
+            def router(self):
+                raise RuntimeError("no router for you")
+
+        gbs.register_routes(_Hostile())   # must not raise
+        assert gbs.get_server_bus() is None


### PR DESCRIPTION
`ov` owns the governed loop; the supervisor owns the EventStream the Swift HUD reads. That split silently cut one wire — and *how* it cut it is the interesting part.

## The bus already crosses processes. It still drops these.

A live daemon logs `[Transport] Multicast enabled for jarvis`, so the wire works. Its receive loop then does:

```python
if event.source == self.local_repo:      # trinity_event_bus
    continue
```

Both processes are `RepoType.JARVIS`. The transport is cross-**repo** (jarvis↔prime↔reactor) and defines "self" by repo, not by PID, so the supervisor discards every frame `ov` publishes as its own echo. Nothing errors, nothing warns; the phone just stops seeing the organism work.

**Why not widen the echo filter.** Making "self" mean the process is one line, and would also hand two JARVIS processes every one of each other's topics — `fs.changed.*` handled twice, sensors double-firing, dedup windows keyed per-process. Unbounded blast radius for a need one channel wide. The filter stays; one channel crosses deliberately.

## What this reuses

Nothing here implements transport, backpressure or reconnection — all three exist and are load-bearing:

| concern | where it already lives |
|---|---|
| transport | `DistributedEventBus` over `BusBridgeServer`/`BusBridgeClient` |
| backpressure | `TransportConfig.queue_maxsize` (256) + `GovernanceSSEBridge`'s bounded queue, drop-oldest and conflation |
| reconnect | `BusBridgeClient._next_backoff` — exponential + jitter, from `reconnect_base_s`/`max_s`/`jitter` |
| inbound fan-in | `BusBridgeClient._apply_inbound` already republishes peer frames into the local broker |

The producer is the **existing** `GovernanceSSEBridge` with a different sink, so the backpressure policy keeps exactly one implementation and cannot drift between two paths.

## What is new, and why each piece

- **`governance_envelope`** — ONE registered broker type carrying the open topic set as *data*. `StreamEventBroker` validates a closed vocabulary and drops unknown types **silently**, so a type-per-topic would put every future topic one forgotten edit away from vanishing. Strict both ways: a malformed frame decodes to `None`, never to a half-populated object; oversize is refused rather than truncated, since a truncated JSON payload is a malformed one discovered at the wrong end.
- **`governance_bus_server`** — mounted by *declaring* `register_routes`; `observability_route_registry` walks the package and mounts it. Verified against the real registry: **12 surfaces became 13** and `/ws/trinity-bus` appears on the app, with no edit to `event_channel.py`.
- **`governance_cross_process`** — the sink, the consumer, and a URL **derived** from the same `JARVIS_CHANNEL_HOST`/`PORT` the `ov` end binds with, so moving the channel cannot leave a client dialling the old port.

**Direction of trust:** frames render once, in the process that owns the loop. The consumer never feeds cross-process data to `GovernanceSSEBridge._render` — "it never raises" is a weaker guarantee than "it is never called on it".

**TLS is not weakened.** `TransportConfig` defaults `tls_enabled=True` and nothing here overrides it. A loopback link still needs the mTLS material under `.jarvis/brain_mtls/` or an explicit `JARVIS_BRAIN_WS_TLS_ENABLED=false` from the operator.

**Both ends self-gate.** Default OFF (`JARVIS_GOVERNANCE_BUS_BRIDGE_ENABLED`), and additionally a no-op unless the loop is *remote* — a supervisor-owned deployment never dials its own broker or double-broadcasts what the local bridge already forwarded.

## Evidence

33 tests, every one through a real `StreamEventBroker` rather than a stand-in, because a closed vocabulary silently rejecting the type is the single thing that would make all of this inert. Producer sink → broker → consumer → EventStream proven end to end; malformed and unknown-type frames proven to stop at the boundary. 93 green across the stream, registry, SSE-bridge and ownership spines.

**Not yet proven:** the socket handshake between two live daemons. The logical channel is verified; the physical link needs both processes up with the flag on and a TLS posture chosen. `tests/test_ouroboros_governance/test_governed_loop_service.py` hangs identically (2 timeouts) at clean HEAD and on this branch — pre-existing, measured in a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
For split deployments, forwards O+V activity from `ov` to the supervisor’s EventStream. Previously HUD saw nothing when `ov` owned the loop; now a single typed envelope crosses processes and the supervisor rebroadcasts to the `governance` channel. TLS posture is derived per link: loopback runs plaintext; routable hosts require TLS; plaintext on a routable host is refused.

- Old: supervisor dropped same-repo echoes. New: supervisor consumes `/ws/trinity-bus` and broadcasts. Side effects: feature is off by default, only runs when the loop is remote, and rejects unsafe TLS settings.

**Changes**
- Add `governance_envelope`: one broker type `governance_forward` carrying topic and rendered payload; strict encode/decode and size limits; registered in `_VALID_EVENT_TYPES`.
- Add `governance_bus_server` (auto-mounted via the observability registry) exposing `/ws/trinity-bus` using `DistributedEventBus`; no edits to the EventChannel server.
- Add `governance_cross_process`: `BrokerSink` in `ov`, `GovernanceBusConsumer` in the supervisor, and a client that dials a URL derived from `JARVIS_CHANNEL_*` + `TransportConfig.path`. TLS posture is derived from reachability, not inherited; unsafe combos are refused. Reuses `GovernanceSSEBridge` queue, conflation, and backpressure.
- Update `governance_sse_bridge` to support a sink; auto-install in `converged_headless.py`, `unified_websocket.py`, and `governed_loop_service.py` with self-gating (no-ops when the loop is local).
- Add tests with a real `StreamEventBroker` and a real loopback WebSocket proving end-to-end forwarding.

**Rollout**
- Enable with `JARVIS_GOVERNANCE_BUS_BRIDGE_ENABLED=1` on both processes when `ov` owns governance.
- TLS: loopback defaults to plaintext; any routable host requires TLS. To force TLS on loopback, set `JARVIS_GOVERNANCE_BUS_TLS_ENABLED=1` and provision mTLS under `.jarvis/brain_mtls/`. Plaintext on non-loopback is refused; bind `JARVIS_CHANNEL_HOST` to `127.0.0.1` or enable TLS.
- No client changes: HUD continues to read the `governance` channel. Single-process deployments need no action.

<sup>Written for commit 1da0ebcd84210af4b50113cef59175f0bc5ddf18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

