### PR TITLE
fix(hud): install when the dependency is ready, not when the caller runs

### DIFF
--- a/backend/api/governance_cross_process.py
+++ b/backend/api/governance_cross_process.py
@@ -198,28 +198,103 @@ class BrokerSink:
         return delivered
 
 
+def _producer_retry_s() -> float:
+    """``JARVIS_GOVERNANCE_BUS_PRODUCER_RETRY_S`` — default 5s."""
+    try:
+        return max(0.5, min(60.0, float(
+            (os.environ.get("JARVIS_GOVERNANCE_BUS_PRODUCER_RETRY_S") or "").strip()
+            or 5.0)))
+    except Exception:  # noqa: BLE001
+        return 5.0
+
+
+def _producer_deadline_s() -> float:
+    """``JARVIS_GOVERNANCE_BUS_PRODUCER_WAIT_S`` — default 600s.
+
+    Bounded because a retry with no end is a task that outlives the reason
+    it was started; if the bus has not appeared in ten minutes, something is
+    wrong that a quieter loop will not fix, and the operator should be told
+    once rather than never.
+    """
+    try:
+        return max(0.0, min(3600.0, float(
+            (os.environ.get("JARVIS_GOVERNANCE_BUS_PRODUCER_WAIT_S") or "").strip()
+            or 600.0)))
+    except Exception:  # noqa: BLE001
+        return 600.0
+
+
 async def install_governance_bus_producer(
-    *, broker: Any = None,
+    *, broker: Any = None, wait_for_bus: bool = True,
 ) -> Optional[Any]:
     """`ov` side: forward O+V activity onto the bus. NEVER raises.
 
-    Returns the installed bridge, or None when disabled or when the bus is
-    not up yet (the caller may retry — ``install`` is idempotent).
+    WAITS for the bus rather than assuming it. Measured on a live boot:
+
+        15:52:18  [GLS] proactive dial hydrated     <- installed here
+        15:53:22  [TrinityEventBus] Started         <- 64s LATER
+
+    ``GovernanceSSEBridge.install()`` returns ``False`` — not an error —
+    when the bus is absent, so a fixed install point that loses that race
+    produces no exception, no log line, and a permanently inert forwarder.
+    That is the failure mode this repo has paid for repeatedly, and it is
+    not fixed by moving to a different fixed point: the next boot reorders
+    and the race comes back. It is fixed by installing when the DEPENDENCY
+    is ready instead of when the caller happens to run.
+
+    Returns the bridge if it installed immediately, else the retry Task
+    (truthy, so a caller can await or cancel it), else None.
     """
     if not bridge_enabled() or not _loop_is_remote():
         return None
     try:
         from backend.api.governance_sse_bridge import GovernanceSSEBridge
         bridge = GovernanceSSEBridge(sink=BrokerSink(broker))
-        if not await bridge.install():
+        if await bridge.install():
+            logger.info(
+                "[GovBus] producer installed — O+V activity forwards onto "
+                "the bus as %r frames", "governance_forward")
+            return bridge
+        if not wait_for_bus or _producer_deadline_s() <= 0:
             return None
         logger.info(
-            "[GovBus] producer installed — O+V activity forwards onto the "
-            "bus as %r frames",
-            "governance_forward")
-        return bridge
+            "[GovBus] producer waiting for TrinityEventBus (retry %.0fs, "
+            "up to %.0fs) — install is idempotent",
+            _producer_retry_s(), _producer_deadline_s())
+        return asyncio.get_event_loop().create_task(
+            _install_producer_when_bus_arrives(bridge),
+            name="governance-bus-producer-wait")
     except Exception:  # noqa: BLE001
         logger.debug("[GovBus] producer install degraded", exc_info=True)
+        return None
+
+
+async def _install_producer_when_bus_arrives(bridge: Any) -> Optional[Any]:
+    """Retry until the bus exists or the deadline passes. NEVER raises."""
+    deadline = asyncio.get_event_loop().time() + _producer_deadline_s()
+    try:
+        while asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(_producer_retry_s())
+            try:
+                if await bridge.install():
+                    logger.info(
+                        "[GovBus] producer installed — O+V activity forwards "
+                        "onto the bus as %r frames", "governance_forward")
+                    return bridge
+            except Exception:  # noqa: BLE001
+                logger.debug("[GovBus] producer retry degraded", exc_info=True)
+        # Said ONCE, at a level an operator sees: a forwarder that never
+        # installed is indistinguishable from a quiet organism, and that
+        # ambiguity is exactly what this whole arc exists to remove.
+        logger.warning(
+            "[GovBus] producer never installed — TrinityEventBus did not "
+            "appear within %.0fs; O+V activity will not reach the HUD",
+            _producer_deadline_s())
+        return None
+    except asyncio.CancelledError:
+        return None
+    except Exception:  # noqa: BLE001
+        logger.debug("[GovBus] producer wait ended", exc_info=True)
         return None
 
 

--- a/backend/core/ouroboros/cli/trinity_launcher.py
+++ b/backend/core/ouroboros/cli/trinity_launcher.py
@@ -73,14 +73,32 @@ def _backend_socket() -> Path:
 
 
 def _backend_alive() -> bool:
-    """Zero-trust probe of the backend's attach socket (reuse the ov
-    thin-client probe). NEVER raises."""
+    """Is the SUPERVISOR up? NEVER raises.
+
+    Probes what the supervisor itself owns — its pid and its HTTP port —
+    and deliberately NOT the cockpit attach socket.
+
+    That socket used to be a fine proxy: one process owned the governed loop
+    and the body, so any transport answering meant the backend was up. Since
+    `ov` took ownership of the loop it owns that socket too, and this probe
+    read it as evidence of a supervisor that was not running: `trinity up`
+    printed "organism already awake" and started nothing, while
+    `trinity status` — which looks at all three signals — correctly said
+    ``partial readiness (pid=None, tcp=refused, uds=live)``.
+
+    Two daemons cannot share one liveness signal. This asks the question the
+    caller actually means: is there a supervisor to talk to.
+    """
     try:
-        from backend.core.ouroboros.cli.thin_client import probe_socket
-        from backend.core.ouroboros.battle_test.cockpit_attach import (
-            attach_socket_path,
+        from backend.core.ouroboros.cli.thin_client import probe_http
+        from backend.core.ouroboros.cli.trinity_status import (
+            supervisor_pid, _health_port, _strict_timeout,
         )
-        return asyncio.run(probe_socket(attach_socket_path())) == "live"
+        if supervisor_pid() is not None:
+            return True
+        return asyncio.run(
+            probe_http("127.0.0.1", _health_port(), _strict_timeout())
+        ) == "live"
     except Exception:
         return False
 

--- a/tests/api/test_governance_cross_process.py
+++ b/tests/api/test_governance_cross_process.py
@@ -511,3 +511,95 @@ class TestTheLinkCarriesAFrameOverARealSocket:
                 pass
             await runner.cleanup()
             gbs.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# The install must not race its own dependency
+# ---------------------------------------------------------------------------
+
+
+class TestTheProducerWaitsForTheBus:
+    """Measured on a live boot: the install point ran 64s BEFORE
+    `[TrinityEventBus] Started`. `GovernanceSSEBridge.install()` returns
+    False — not an error — when the bus is absent, so the forwarder was
+    permanently inert with no exception and no log line. Moving to a
+    different fixed point would only re-lose the race on a boot that
+    reorders.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fast(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_GOVERNANCE_OWNER", "ov")
+        monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_PRODUCER_RETRY_S", "0.5")
+        monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_PRODUCER_WAIT_S", "10")
+        yield
+
+    async def test_it_installs_once_the_bus_appears(self, monkeypatch):
+        """The regression that matters: absent bus at call time, present a
+        moment later, forwarder live without anyone re-calling."""
+        state = {"bus_up": False, "installs": 0}
+
+        class _Bridge:
+            def __init__(self, *a, **k):
+                pass
+
+            async def install(self):
+                state["installs"] += 1
+                return state["bus_up"]
+
+        monkeypatch.setattr(
+            "backend.api.governance_sse_bridge.GovernanceSSEBridge", _Bridge)
+        task = await gxp.install_governance_bus_producer()
+        assert task is not None, "must not give up when the bus is merely late"
+        state["bus_up"] = True
+        result = await asyncio.wait_for(task, timeout=8)
+        assert result is not None
+        assert state["installs"] >= 2, "it retried rather than gave up"
+
+    async def test_an_immediately_available_bus_needs_no_retry(
+            self, monkeypatch):
+        class _Bridge:
+            def __init__(self, *a, **k):
+                pass
+
+            async def install(self):
+                return True
+
+        monkeypatch.setattr(
+            "backend.api.governance_sse_bridge.GovernanceSSEBridge", _Bridge)
+        out = await gxp.install_governance_bus_producer()
+        assert out is not None and not isinstance(out, asyncio.Task)
+
+    async def test_it_gives_up_loudly_rather_than_retrying_forever(
+            self, monkeypatch, caplog):
+        """A task that outlives its reason is worse than a warning. A
+        forwarder that never installed is indistinguishable from a quiet
+        organism, so the give-up is said once at a level an operator sees."""
+        monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_PRODUCER_WAIT_S", "1")
+
+        class _Bridge:
+            def __init__(self, *a, **k):
+                pass
+
+            async def install(self):
+                return False
+
+        monkeypatch.setattr(
+            "backend.api.governance_sse_bridge.GovernanceSSEBridge", _Bridge)
+        with caplog.at_level("WARNING"):
+            task = await gxp.install_governance_bus_producer()
+            assert await asyncio.wait_for(task, timeout=8) is None
+        assert any("never installed" in r.message for r in caplog.records)
+
+    async def test_waiting_can_be_declined(self, monkeypatch):
+        class _Bridge:
+            def __init__(self, *a, **k):
+                pass
+
+            async def install(self):
+                return False
+
+        monkeypatch.setattr(
+            "backend.api.governance_sse_bridge.GovernanceSSEBridge", _Bridge)
+        assert await gxp.install_governance_bus_producer(
+            wait_for_bus=False) is None

--- a/tests/cli/test_trinity_launcher.py
+++ b/tests/cli/test_trinity_launcher.py
@@ -126,3 +126,61 @@ class TestInterpreterAuthority:
             "backend.core.ouroboros.cli.trinity_env.venv_dir",
             lambda: tmp_path / "nope")
         assert tl._service_python() == sys.executable
+
+
+class TestSupervisorLivenessIsNotTheCockpitsSocket:
+    """Two daemons cannot share one liveness signal.
+
+    `_backend_alive` probed `cockpit_attach.sock`, which was a fine proxy
+    while one process owned both the governed loop and the body. Once `ov`
+    took the loop it took that socket, and `trinity up` began printing
+    "organism already awake" and starting nothing — while `trinity status`,
+    which looks at pid + tcp + uds, correctly reported
+    `partial readiness (pid=None, tcp=refused, uds=live)`.
+    """
+
+    def test_a_live_cockpit_socket_is_not_a_live_supervisor(self, monkeypatch):
+        """THE regression. `ov` running must not convince `trinity up` that
+        a supervisor exists."""
+        monkeypatch.setattr(
+            "backend.core.ouroboros.cli.trinity_status.supervisor_pid",
+            lambda: None)
+
+        async def _refused(*_a, **_k):
+            return "refused"
+
+        monkeypatch.setattr(
+            "backend.core.ouroboros.cli.thin_client.probe_http", _refused)
+
+        async def _live_uds(*_a, **_k):
+            return "live"           # the cockpit socket IS answering
+
+        monkeypatch.setattr(
+            "backend.core.ouroboros.cli.thin_client.probe_socket", _live_uds)
+        assert tl._backend_alive() is False
+
+    def test_a_registered_pid_is_enough(self, monkeypatch):
+        monkeypatch.setattr(
+            "backend.core.ouroboros.cli.trinity_status.supervisor_pid",
+            lambda: 4242)
+        assert tl._backend_alive() is True
+
+    def test_a_live_http_port_is_enough(self, monkeypatch):
+        monkeypatch.setattr(
+            "backend.core.ouroboros.cli.trinity_status.supervisor_pid",
+            lambda: None)
+
+        async def _live(*_a, **_k):
+            return "live"
+
+        monkeypatch.setattr(
+            "backend.core.ouroboros.cli.thin_client.probe_http", _live)
+        assert tl._backend_alive() is True
+
+    def test_it_never_raises(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("no pid for you")
+
+        monkeypatch.setattr(
+            "backend.core.ouroboros.cli.trinity_status.supervisor_pid", _boom)
+        assert tl._backend_alive() in (True, False)


### PR DESCRIPTION
Both defects were found by **arming the thing and watching**, and both were silent by construction — no exception, no log line, just a capability that was never there.

## 1. The producer raced the bus by 64 seconds

```
15:52:18  [GLS] proactive dial hydrated      ← producer installed here
15:53:22  [TrinityEventBus] Started          ← 64 s LATER
```

`GovernanceSSEBridge.install()` returns `False` — not an error — when the bus is absent, so a fixed install point that loses that race produces silence and a permanently inert forwarder. Moving to a *different* fixed point only re-loses the race on a boot that reorders, so the fix installs when the **dependency** is ready: a bounded retrying wait (5 s cadence, 600 s ceiling, both env-tunable) that stops on success and says so **once at WARNING** if it gives up. A forwarder that never installed is indistinguishable from a quiet organism, and that ambiguity is what this arc exists to remove.

Proven live:

```
[GovBus] producer waiting for TrinityEventBus (retry 5s, up to 600s) — install is idempotent
[GovBus] producer installed — O+V activity forwards onto the bus as 'governance_forward' frames
```

## 2. Two daemons cannot share one liveness signal

`trinity up` printed *"organism already awake"* and started nothing, while `trinity status` correctly said `partial readiness (pid=None, tcp=refused, uds=live)`.

`_backend_alive()` probed `cockpit_attach.sock` — a fine proxy while **one** process owned both the governed loop and the body. `ov` owns the loop now, so it owns that socket, and the supervisor's liveness probe was reading another daemon's transport. It now asks what the caller actually means: is there a **supervisor** — its registered pid, or its HTTP port. The cockpit socket belongs to the cockpit.

## Evidence — the wire is live between the two production daemons

```
ov  46303   TCP 127.0.0.1:8099->127.0.0.1:55508 (ESTABLISHED)
sup 56248   TCP 127.0.0.1:55508->127.0.0.1:8099 (ESTABLISHED)
```

78 green across the cross-process, launcher and doctor spines (8 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs the HUD governance bus producer when the bus is actually ready and fixes supervisor liveness detection to stop conflating the cockpit socket with the supervisor. Previously the producer installed at a fixed point and became silently inert if the bus was absent; now it waits with bounded retries, and `trinity up` no longer treats a live cockpit socket as a live supervisor.

- Producer install now waits for the bus with retries (default retry 5s, deadline 600s; tune with `JARVIS_GOVERNANCE_BUS_PRODUCER_RETRY_S` and `JARVIS_GOVERNANCE_BUS_PRODUCER_WAIT_S`). On success it logs once at INFO; on timeout it logs once at WARNING and stops. `install_governance_bus_producer` returns the bridge if immediate, otherwise a truthy `asyncio.Task`; pass `wait_for_bus=False` to skip waiting. Install is idempotent.
- `_backend_alive` now checks the supervisor’s own signals (`supervisor_pid()` or HTTP health via `probe_http`) and does not read the cockpit’s `attach.sock`. This prevents “organism already awake” when only the cockpit is running.
- Adds focused tests for producer wait semantics and supervisor liveness probing.

<sup>Written for commit ffd454d007ccaa82e6cf3b6bf188dc0a256ef33c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

