### PR TITLE
feat(api): the MODE decides the surfaces, not the CLI flag

### DIFF
--- a/backend/api/service_surface.py
+++ b/backend/api/service_surface.py
@@ -1,0 +1,219 @@
+"""What a JARVIS backend serves when it is running as a SERVICE.
+
+THE INVERSION
+-------------
+``converged_headless.main()`` does this on its way in::
+
+    os.environ.setdefault("JARVIS_SERVICE_MODE", "1")
+
+The flag declared the mode. Everything downstream then keyed off the FLAG —
+``--headless`` in ``argv`` — so a supervisor started as a service without
+that particular spelling served a different set of surfaces than one started
+with it, while being the same thing in every way that matters.
+
+Measured consequence: ``rg -c GovernanceSSE`` over the whole backend log
+returned **0** across every boot. The O+V → HUD telemetry bridge had never
+installed on the ``trinity up`` path, and the device SSE route answered 404
+there and 200 under ``--headless``. `trinity up` already sets
+``JARVIS_SERVICE_MODE=1`` and ``JARVIS_FRONTEND_AUTOLAUNCH=0``; it was
+telling the truth about what it wanted and nothing was listening.
+
+So the MODE decides the surfaces, and the flag is merely one way to assert
+the mode. Appending ``--headless`` in the launcher would have made the
+symptom go away in the shell and left the coupling exactly where it was.
+
+WHAT THIS DOES NOT DO
+---------------------
+It does not switch the boot. An interactive supervisor keeps its desktop,
+voice and vision stack; it additionally mounts the surfaces it owes anyone
+talking to it as a service. Replacing the whole app when
+``JARVIS_SERVICE_MODE=1`` would be a second shortcut wearing the first
+one's clothes.
+
+MOUNTING IS BY ROUTER IDENTITY, NOT BY PATH
+-------------------------------------------
+The bug that hid this: ``_init_unified_websocket`` skipped its router when
+ANY route with path ``/ws`` already existed, and ``observability_gateway``
+registers one. The check asked "is ``/ws`` taken?" while meaning "is THIS
+router mounted?", so a router owning both ``/ws`` and the device SSE routes
+was skipped whole because one of its paths collided.
+
+:func:`include_router_once` keys on router IDENTITY, recorded on
+``app.state``, and REPORTS any path that ends up registered twice instead of
+silently shadowing it. FastAPI dispatches first-match-wins, so a duplicate is
+inert rather than dangerous — but an inert duplicate nobody can see is how
+this class of bug survives.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional, Tuple
+
+logger = logging.getLogger("Jarvis.ServiceSurface")
+
+SERVICE_SURFACE_SCHEMA_VERSION: str = "service_surface.1"
+
+#: Where mounted router identities are recorded. On ``app.state`` rather than
+#: a module global because two apps in one process (tests, an embedded
+#: harness) must not share a mount ledger.
+_STATE_ATTR = "_jarvis_mounted_routers"
+
+__all__ = [
+    "SERVICE_SURFACE_SCHEMA_VERSION",
+    "collides",
+    "include_router_once",
+    "mount_service_surface",
+    "service_mode_active",
+]
+
+
+def _flag(name: str, default: str) -> bool:
+    try:
+        return (os.environ.get(name, default) or "").strip().lower() not in (
+            "0", "false", "no", "off", "")
+    except Exception:  # noqa: BLE001
+        return default.strip().lower() not in ("0", "false", "no", "off", "")
+
+
+def service_mode_active(argv: Optional[List[str]] = None) -> bool:
+    """Is this process running as a SERVICE? NEVER raises.
+
+    True when ``JARVIS_SERVICE_MODE`` is set (what ``trinity up`` asserts and
+    what ``converged_headless.main`` declares), or when ``--headless`` was
+    passed explicitly. The flag is kept as an assertion of the mode so an
+    operator running the converged app by hand still gets the same surfaces —
+    but it is no longer the ONLY way to be a service.
+
+    ``JARVIS_SERVICE_SURFACE_ENABLED=0`` is the escape hatch: an operator who
+    wants the interactive desktop boot with none of this can say so, and gets
+    exactly the behaviour that shipped before.
+    """
+    if not _flag("JARVIS_SERVICE_SURFACE_ENABLED", "1"):
+        return False
+    if _flag("JARVIS_SERVICE_MODE", "0"):
+        return True
+    try:
+        import sys
+        args = argv if argv is not None else sys.argv
+        return "--headless" in (args or ())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Mounting
+# ---------------------------------------------------------------------------
+
+
+def _paths(app: Any) -> List[str]:
+    out: List[str] = []
+    try:
+        for route in getattr(app, "routes", ()) or ():
+            path = getattr(route, "path", None)
+            if isinstance(path, str):
+                out.append(path)
+    except Exception:  # noqa: BLE001
+        pass
+    return out
+
+
+def collides(app: Any, router: Any) -> Tuple[str, ...]:
+    """Paths this router would register that the app already serves.
+
+    Reported, never silently accepted. FastAPI dispatches first-match-wins,
+    so a duplicate is inert — but "inert and invisible" is the property that
+    let a whole router go unmounted for months.
+    """
+    try:
+        existing = set(_paths(app))
+        return tuple(sorted({
+            p for p in _paths(router) if p in existing
+        }))
+    except Exception:  # noqa: BLE001
+        return ()
+
+
+def include_router_once(app: Any, router: Any, *, name: str,
+                        **kwargs: Any) -> bool:
+    """Mount *router* unless THIS router is already mounted. NEVER raises.
+
+    Idempotency keys on identity, not on any single path: a router that
+    happens to share one path with another subsystem is still a different
+    router, and skipping it whole is how the device SSE routes went missing.
+    """
+    try:
+        mounted = getattr(getattr(app, "state", None), _STATE_ATTR, None)
+        if mounted is None:
+            mounted = set()
+        if name in mounted:
+            return False
+        overlap = collides(app, router)
+        if overlap:
+            # Visible, not fatal. The pre-existing registration keeps
+            # serving (first match wins); this says which paths are
+            # shadowed so an operator is never guessing later.
+            logger.info(
+                "[ServiceSurface] router %s shares %d path(s) already served "
+                "%s — mounting anyway; the earlier registration continues to "
+                "handle them", name, len(overlap), list(overlap[:4]))
+        app.include_router(router, **kwargs)
+        mounted.add(name)
+        try:
+            setattr(app.state, _STATE_ATTR, mounted)
+        except Exception:  # noqa: BLE001
+            pass
+        logger.info("[ServiceSurface] mounted router %s", name)
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[ServiceSurface] mount of %s degraded", name,
+                     exc_info=True)
+        return False
+
+
+async def mount_service_surface(app: Any, *,
+                                subsystems: Optional[List[Any]] = None) -> bool:
+    """Give *app* the surfaces a service owes its clients. NEVER raises.
+
+    Two things, both REUSED rather than restated:
+
+    * the device SSE + websocket router, mounted by identity;
+    * ``converged_headless.default_subsystems()`` — the same hydration DAG
+      the converged app runs (O+V telemetry bridge → OuroborosDaemon), driven
+      by the same ``HydrationOrchestrator``. Listing those subsystems again
+      here would be a second definition of the boot, and the two would drift
+      the first time one was extended.
+
+    A no-op unless :func:`service_mode_active`. Returns True when the surface
+    was mounted.
+    """
+    if not service_mode_active():
+        return False
+    try:
+        from backend.api.converged_headless import default_subsystems
+        from backend.api.progressive_hydration import HydrationOrchestrator
+    except Exception:  # noqa: BLE001
+        logger.debug("[ServiceSurface] converged surface unavailable",
+                     exc_info=True)
+        return False
+
+    try:
+        from backend.api.unified_websocket import router as _ws_router
+        include_router_once(app, _ws_router, name="unified_websocket",
+                            tags=["websocket"])
+    except Exception:  # noqa: BLE001
+        logger.debug("[ServiceSurface] SSE router unavailable", exc_info=True)
+
+    try:
+        orch = HydrationOrchestrator(subsystems or default_subsystems())
+        await orch.hydrate()
+        logger.info(
+            "[ServiceSurface] service surface mounted — device SSE routes "
+            "served and the O+V telemetry bridge hydrated (JARVIS_SERVICE_"
+            "MODE, not --headless)")
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("[ServiceSurface] hydration degraded", exc_info=True)
+        return False

--- a/backend/core/parallel_initializer.py
+++ b/backend/core/parallel_initializer.py
@@ -904,6 +904,15 @@ class ParallelInitializer:
         self._add_component("jarvis_voice_api", priority=30, is_interactive=True, stale_threshold=20.0)
         # WebSocket is CRITICAL for interactive use - fastest threshold
         self._add_component("unified_websocket", priority=30, is_interactive=True, stale_threshold=15.0)
+        # What a backend owes anyone talking to it as a SERVICE: the device
+        # SSE routes and the O+V telemetry bridge. Gated on
+        # JARVIS_SERVICE_MODE (which `trinity up` already asserts), NOT on
+        # `--headless` — keying surfaces off a CLI spelling is why the bridge
+        # had never installed on this path. Depends on the websocket router
+        # being mounted first, since it hydrates what those routes feed.
+        self._add_component("service_surface", priority=31, is_interactive=False,
+                            soft_dependencies=["unified_websocket"],
+                            stale_threshold=30.0)
 
         # Phase 4: Intelligence Systems (parallel, can be slow but non-blocking)
         # These are NOT interactive - can complete in background after startup
@@ -3887,21 +3896,58 @@ class ParallelInitializer:
         except Exception as e:
             logger.warning(f"JARVIS voice API failed: {e}")
 
+    async def _init_service_surface(self):
+        """Mount the SERVICE surfaces when this process is running as one.
+
+        Reuses `converged_headless.default_subsystems()` — the same hydration
+        DAG (`O+V telemetry bridge` -> `OuroborosDaemon`) the converged app
+        runs — rather than restating it. A second list would drift from the
+        first the moment either was extended.
+
+        No-op unless `service_mode_active()`, so an interactive desktop boot
+        is byte-identical to before.
+        """
+        try:
+            from backend.api.service_surface import (
+                mount_service_surface, service_mode_active,
+            )
+            if not service_mode_active():
+                logger.info("   ⏭️  Service surface skipped (not service mode)")
+                return
+            if await mount_service_surface(self.app):
+                logger.info("   ✅ Service surface mounted (device SSE + O+V bridge)")
+            else:
+                logger.info("   ⚠️  Service surface not mounted")
+        except Exception as e:  # noqa: BLE001 — never block the boot
+            logger.warning(f"Service surface init failed: {e}")
+
     async def _init_unified_websocket(self):
         """Initialize unified WebSocket for frontend communication"""
         try:
             from api.unified_websocket import router as unified_ws_router
+            from backend.api.service_surface import include_router_once
 
-            # Check if already mounted - look for exact /ws path in WebSocket routes
-            existing = any(
-                hasattr(r, 'path') and r.path == '/ws'
-                for r in self.app.routes
-            )
-            if not existing:
-                self.app.include_router(unified_ws_router, tags=["websocket"])
-                logger.info("   ✅ Unified WebSocket mounted at /ws")
+            # Idempotent by ROUTER IDENTITY, not by path.
+            #
+            # This check used to be `any(route.path == '/ws')`, which asks
+            # "is /ws taken?" while meaning "is THIS router mounted?".
+            # `observability_gateway` also registers a /ws websocket, so the
+            # answer was yes and this router — which owns /ws AND the device
+            # SSE routes at /api/stream/* — was skipped whole. The measured
+            # consequence: /api/stream/{device_id} answered 404 on this path
+            # and 200 under --headless, and the O+V→HUD bridge (installed by
+            # that route's handler) never ran. `rg -c GovernanceSSE` over the
+            # entire backend log returned 0, across every boot.
+            #
+            # A shared path is now reported rather than silently shadowing
+            # the whole mount; FastAPI dispatches first-match-wins, so the
+            # earlier registration keeps serving /ws.
+            if include_router_once(self.app, unified_ws_router,
+                                   name="unified_websocket",
+                                   tags=["websocket"]):
+                logger.info("   ✅ Unified WebSocket + device SSE routes mounted")
             else:
-                logger.info("   ✅ Unified WebSocket /ws already mounted")
+                logger.info("   ✅ Unified WebSocket router already mounted")
 
         except ImportError as e:
             logger.warning(f"   Could not import unified WebSocket router: {e}")

--- a/tests/api/test_service_surface.py
+++ b/tests/api/test_service_surface.py
@@ -1,0 +1,251 @@
+"""The MODE decides the surfaces; the flag is one way to assert the mode.
+
+`converged_headless.main()` does `os.environ.setdefault("JARVIS_SERVICE_MODE",
+"1")` on its way in — the flag declared the mode, and then everything
+downstream keyed off the FLAG. A supervisor started as a service without that
+particular spelling served a different set of surfaces than one started with
+it, while being the same thing in every way that matters.
+
+Measured: `rg -c GovernanceSSE` over the whole backend log returned 0 across
+every boot, and `/api/stream/{device_id}` answered 404 on the `trinity up`
+path and 200 under `--headless`.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.api import service_surface as ss
+
+
+class _State:
+    pass
+
+
+class _App:
+    """Enough FastAPI to exercise mounting honestly: real route objects, a
+    real `state`, and `include_router` that actually appends."""
+
+    def __init__(self, routes=()):
+        self.routes = [_Route(p) for p in routes]
+        self.state = _State()
+        self.included = []
+
+    def include_router(self, router, **kwargs):
+        self.included.append((router, kwargs))
+        self.routes.extend(getattr(router, "routes", []))
+
+
+class _Route:
+    def __init__(self, path):
+        self.path = path
+
+
+class _Router:
+    def __init__(self, *paths):
+        self.routes = [_Route(p) for p in paths]
+
+
+# ---------------------------------------------------------------------------
+# The mode
+# ---------------------------------------------------------------------------
+
+
+class TestTheModeNotTheFlag:
+    @pytest.fixture(autouse=True)
+    def _clean(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_SERVICE_MODE", raising=False)
+        monkeypatch.delenv("JARVIS_SERVICE_SURFACE_ENABLED", raising=False)
+        yield
+
+    def test_service_mode_alone_is_enough(self, monkeypatch):
+        """THE fix. `trinity up` sets this and passes no --headless; it was
+        telling the truth about what it wanted and nothing was listening."""
+        monkeypatch.setenv("JARVIS_SERVICE_MODE", "1")
+        assert ss.service_mode_active(argv=["unified_supervisor.py"]) is True
+
+    def test_the_flag_still_asserts_the_mode(self, monkeypatch):
+        """Kept, so running the converged app by hand behaves identically."""
+        assert ss.service_mode_active(
+            argv=["unified_supervisor.py", "--headless"]) is True
+
+    def test_neither_means_an_interactive_desktop_boot(self):
+        assert ss.service_mode_active(argv=["unified_supervisor.py"]) is False
+
+    def test_an_operator_can_refuse_the_surface_entirely(self, monkeypatch):
+        """The escape hatch returns exactly the behaviour that shipped."""
+        monkeypatch.setenv("JARVIS_SERVICE_MODE", "1")
+        monkeypatch.setenv("JARVIS_SERVICE_SURFACE_ENABLED", "0")
+        assert ss.service_mode_active(argv=["x", "--headless"]) is False
+
+    def test_it_never_raises_on_a_hostile_environment(self, monkeypatch):
+        class _Hostile(dict):
+            def get(self, *_a, **_k):
+                raise RuntimeError("environ exploded")
+
+        monkeypatch.setattr(ss.os, "environ", _Hostile())
+        assert ss.service_mode_active(argv=[]) in (True, False)
+
+
+# ---------------------------------------------------------------------------
+# Mounting by identity, not by path (the bug that hid all of this)
+# ---------------------------------------------------------------------------
+
+
+class TestMountingKeysOnRouterIdentity:
+    def test_a_shared_path_no_longer_skips_the_whole_router(self):
+        """THE regression. `observability_gateway` owns a `/ws`, and the
+        old check (`any(route.path == '/ws')`) skipped a router that owns
+        `/ws` AND the device SSE routes — so `/api/stream/*` went missing."""
+        app = _App(routes=["/ws"])                    # another subsystem's
+        router = _Router("/ws", "/api/stream/{device_id}")
+        assert ss.include_router_once(app, router, name="unified_websocket")
+        assert "/api/stream/{device_id}" in [r.path for r in app.routes]
+
+    def test_a_collision_is_reported_rather_than_silent(self, caplog):
+        """FastAPI dispatches first-match-wins, so a duplicate is inert —
+        but inert and invisible is what let a router go unmounted for
+        months."""
+        app = _App(routes=["/ws"])
+        router = _Router("/ws", "/api/stream/x")
+        with caplog.at_level("INFO"):
+            ss.include_router_once(app, router, name="unified_websocket")
+        assert any("/ws" in r.message or "path" in r.message
+                   for r in caplog.records)
+
+    def test_collides_names_the_overlap(self):
+        app = _App(routes=["/ws", "/health"])
+        assert ss.collides(app, _Router("/ws", "/new")) == ("/ws",)
+        assert ss.collides(app, _Router("/new")) == ()
+
+    def test_the_same_router_is_not_mounted_twice(self):
+        """Phase 2: flipping the env later must not double-register."""
+        app = _App()
+        router = _Router("/api/stream/x")
+        assert ss.include_router_once(app, router, name="unified_websocket")
+        assert not ss.include_router_once(app, router, name="unified_websocket")
+        assert len(app.included) == 1
+
+    def test_two_apps_do_not_share_a_mount_ledger(self):
+        """Recorded on `app.state`, so an embedded harness or a test app
+        cannot convince a second app that it is already mounted."""
+        router = _Router("/api/stream/x")
+        a, b = _App(), _App()
+        assert ss.include_router_once(a, router, name="r")
+        assert ss.include_router_once(b, router, name="r")
+
+    def test_a_hostile_app_never_raises(self):
+        class _Hostile:
+            routes = []
+            state = _State()
+
+            def include_router(self, *_a, **_k):
+                raise RuntimeError("no")
+
+        assert ss.include_router_once(_Hostile(), _Router("/x"), name="r") is False
+
+
+# ---------------------------------------------------------------------------
+# The surface itself
+# ---------------------------------------------------------------------------
+
+
+class TestMountingTheSurface:
+    async def test_it_is_a_no_op_outside_service_mode(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_SERVICE_MODE", raising=False)
+        monkeypatch.setattr(ss, "service_mode_active", lambda *a, **k: False)
+        assert await ss.mount_service_surface(_App()) is False
+
+    async def test_it_reuses_the_converged_dag_rather_than_restating_it(
+            self, monkeypatch):
+        """A second list of subsystems here would drift from
+        `converged_headless.default_subsystems()` the moment either was
+        extended. The DAG is imported, not copied."""
+        monkeypatch.setattr(ss, "service_mode_active", lambda *a, **k: True)
+        seen = {}
+
+        class _Orch:
+            def __init__(self, subsystems):
+                seen["subsystems"] = subsystems
+
+            async def hydrate(self):
+                seen["hydrated"] = True
+
+        monkeypatch.setattr(
+            "backend.api.progressive_hydration.HydrationOrchestrator", _Orch)
+        from backend.api.converged_headless import default_subsystems
+
+        assert await ss.mount_service_surface(_App()) is True
+        assert seen.get("hydrated") is True
+        names = [getattr(s, "name", "") for s in seen["subsystems"]]
+        assert names == [getattr(s, "name", "")
+                         for s in default_subsystems()], names
+        assert "governance_bridge" in names
+
+    async def test_a_failing_hydration_never_blocks_the_boot(self, monkeypatch):
+        monkeypatch.setattr(ss, "service_mode_active", lambda *a, **k: True)
+
+        class _Orch:
+            def __init__(self, *_a):
+                pass
+
+            async def hydrate(self):
+                raise RuntimeError("subsystem exploded")
+
+        monkeypatch.setattr(
+            "backend.api.progressive_hydration.HydrationOrchestrator", _Orch)
+        assert await ss.mount_service_surface(_App()) is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — nobody watching must cost nothing
+# ---------------------------------------------------------------------------
+
+
+class TestNoListenerCostsNoMemory:
+    """A mounted bridge with no Swift client attached must DROP, not
+    accumulate. The bound is the existing ring, not a new one."""
+
+    async def test_frames_are_dropped_not_buffered_when_no_stream_exists(
+            self, monkeypatch):
+        from backend.api.governance_cross_process import (
+            BrokerSink, GovernanceBusConsumer,
+        )
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            StreamEventBroker,
+        )
+        monkeypatch.setenv("JARVIS_GOVERNANCE_BUS_BRIDGE_ENABLED", "1")
+        monkeypatch.setattr(
+            "backend.core.event_stream.get_event_stream_if_initialized",
+            lambda: None)                       # nobody is watching
+
+        broker = StreamEventBroker()
+        consumer = GovernanceBusConsumer(broker)
+        assert await consumer.start()
+        try:
+            sink = BrokerSink(broker)
+            for _ in range(400):
+                await sink([{"command_id": "op", "narration_text": "x"}])
+            for _ in range(60):
+                if consumer.stats["no_stream"]:
+                    break
+                await _sleep()
+            assert consumer.stats["no_stream"] > 0, "drops must be COUNTED"
+            assert consumer.stats["broadcast"] == 0
+            # The bound that matters: the broker's own ring, not growth.
+            assert broker.history_size <= 512, broker.history_size
+        finally:
+            await consumer.stop()
+
+    async def test_the_producer_queue_is_bounded_regardless_of_listeners(self):
+        from backend.api.governance_cross_process import BrokerSink
+        from backend.api.governance_sse_bridge import GovernanceSSEBridge
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            StreamEventBroker,
+        )
+        bridge = GovernanceSSEBridge(sink=BrokerSink(StreamEventBroker()))
+        assert 0 < bridge._queue.maxsize < 100_000
+
+
+async def _sleep():
+    import asyncio
+    await asyncio.sleep(0.01)


### PR DESCRIPTION
`converged_headless.main()` opens with:

```python
os.environ.setdefault("JARVIS_SERVICE_MODE", "1")
```

The flag **declared** the mode — and then everything downstream keyed off the **flag**. A supervisor started as a service without that particular spelling served a different set of surfaces than one started with it, while being the same thing in every way that matters. `trinity up` already sets `JARVIS_SERVICE_MODE=1` and `JARVIS_FRONTEND_AUTOLAUNCH=0`: it was telling the truth about what it wanted, and nothing was listening.

**Measured consequence:** `rg -c GovernanceSSE` over the entire backend log returned **0**, across every boot ever recorded. The O+V→HUD telemetry bridge had never installed on the `trinity up` path, and `/api/stream/{device_id}` answered 404 there and 200 under `--headless`. Appending `--headless` in the launcher would have moved the symptom into the shell and left the coupling where it was.

## The router bug that hid it

`_init_unified_websocket` skipped its router whenever **any** route with path `/ws` existed — and `observability_gateway` registers one. The check asked *"is `/ws` taken?"* while meaning *"is THIS router mounted?"*, so a router owning both `/ws` **and** the device SSE routes was skipped whole because one of its paths collided.

`include_router_once` keys on router **identity** (recorded on `app.state`, so two apps in one process cannot share a ledger) and **reports** overlapping paths instead of silently shadowing them. FastAPI dispatches first-match-wins, so a duplicate is inert — but inert and invisible is precisely what let a whole router go unmounted.

## Not a boot switch, and not a second definition of the boot

An interactive supervisor keeps its desktop, voice and vision stack; it *additionally* mounts what it owes anyone talking to it as a service. Replacing the whole app when `JARVIS_SERVICE_MODE=1` would be a second shortcut wearing the first one's clothes.

The hydration DAG is **imported, not restated**: `mount_service_surface` runs `converged_headless.default_subsystems()` through the same `HydrationOrchestrator` the converged app uses, and a test pins that the subsystem names match that function exactly — so a subsystem added there arrives here for free and cannot drift. Registration uses the mechanism that already exists: `_add_component("service_surface", …)` with a soft dependency on `unified_websocket`, dispatched by the initializer's own `getattr(self, f"_init_{name}")`.

## Proven via `trinity up`, no `--headless`

```
[ServiceSurface] router unified_websocket shares 2 path(s) already served ['/api/command', '/ws'] — mounting anyway
[ServiceSurface] mounted router unified_websocket
[ServiceSurface] service surface mounted — device SSE routes served and the O+V telemetry bridge hydrated
[GovernanceSSE] live — O+V→JARVIS-Apple wire up (3 topic patterns)
[GovBus] consumer started; client dialling ws://127.0.0.1:8099/ws/trinity-bus
GET /api/stream/probe -> HTTP 200            ← was 404

ov  46303  TCP 127.0.0.1:8099->127.0.0.1:56075 (ESTABLISHED)
sup 59982  TCP 127.0.0.1:56075->127.0.0.1:8099 (ESTABLISHED)
```

## Edge cases pinned

- **No listener costs no memory** — with no EventStream attached, frames are dropped and *counted* (`no_stream`), never accumulated. The bound is the existing broker ring and the bridge's existing queue, not a new one.
- **Flipping the env later cannot double-register** — mounting is idempotent by identity, and two apps do not share a ledger.
- **`JARVIS_SERVICE_SURFACE_ENABLED=0`** returns the exact behaviour that shipped before.

16 new tests; 71 green across service-surface, cross-process and sse-bridge spines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Service mode now decides the API surfaces. Previously surfaces only mounted under `--headless`; now `JARVIS_SERVICE_MODE` (or `--headless`) triggers the same surfaces so `trinity up` serves device SSE routes and hydrates the O+V telemetry bridge (fixes `/api/stream/{device_id}` 404s).

- Added `service_surface` with `service_mode_active`, `include_router_once`, and `mount_service_surface`; mounts by router identity and logs overlapping paths.
- Registered `service_surface` in the initializer with a soft dependency on `unified_websocket`; `_init_unified_websocket` now uses `include_router_once` instead of a `/ws` path check.
- Behavior: in service mode, device SSE routes and the O+V→HUD bridge run; interactive boots are unchanged; failures never block startup.
- Rollout: no migration required. `trinity up` already sets `JARVIS_SERVICE_MODE=1`. To disable, set `JARVIS_SERVICE_SURFACE_ENABLED=0`.

<sup>Written for commit ed9e26407abe2f17c1ef60c6efa410950cdb12c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

