### PR TITLE
feat(cli): `trinity status` stops assuming a monolith

### DIFF
--- a/backend/core/ouroboros/cli/trinity_status.py
+++ b/backend/core/ouroboros/cli/trinity_status.py
@@ -32,10 +32,11 @@ import asyncio
 import os
 import re
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Optional
+from typing import (Any, Awaitable, Callable, Dict, Mapping,
+                    Optional, Tuple)
 
 
 class Health(str, Enum):
@@ -77,6 +78,42 @@ def _health_port() -> int:
 
 
 def _attach_socket() -> Optional[Path]:
+    """The SUPERVISOR's own IPC socket, or None.
+
+    This used to return the COCKPIT's socket
+    (``cockpit_attach.attach_socket_path()``), which was a fine proxy while
+    one process owned the governed loop and the body. `ov` owns the loop —
+    and therefore the cockpit — so the supervisor's verdict was being
+    computed from another daemon's transport: `trinity status` reported
+    ``ZOMBIE/DEADLOCKED (tcp=live, uds=stale)`` about a supervisor that was
+    serving HTTP 200 the whole time.
+
+    A daemon is judged by ITS transports. ``JARVIS_SUPERVISOR_IPC_SOCKET``
+    declares one if a deployment gives the supervisor a dedicated socket;
+    absent, the supervisor is judged on its pid and its port, and ``uds`` is
+    honestly reported as not applicable. The cockpit socket is probed on the
+    O+V row, where it belongs — see :func:`engine_socket`.
+    """
+    raw = (os.environ.get("JARVIS_SUPERVISOR_IPC_SOCKET") or "").strip()
+    return Path(raw) if raw else None
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — dynamic discovery. Every address below is read from the SAME
+# configuration the daemons bind with; nothing here is a second opinion.
+# ---------------------------------------------------------------------------
+
+
+def supervisor_endpoint() -> Tuple[str, int]:
+    """Where the supervisor serves. ``JARVIS_BACKEND_HOST``/``_PORT`` — the
+    same values ``converged_headless.main`` passes to uvicorn."""
+    host = (os.environ.get("JARVIS_BACKEND_HOST") or "127.0.0.1").strip()
+    return host or "127.0.0.1", _health_port()
+
+
+def engine_socket() -> Optional[Path]:
+    """The cockpit attach socket — O+V's, resolved through the cockpit's own
+    contract (``JARVIS_ATTACH_IPC_SOCKET``), never a literal here."""
     try:
         from backend.core.ouroboros.battle_test.cockpit_attach import (
             attach_socket_path,
@@ -84,6 +121,55 @@ def _attach_socket() -> Optional[Path]:
         return attach_socket_path()
     except Exception:  # noqa: BLE001
         return None
+
+
+def engine_endpoint() -> Tuple[str, int]:
+    """The O+V engine's IPC event bus — the EventChannelServer that hosts
+    ``/ws/trinity-bus`` and the webhook surfaces. Read from
+    ``JARVIS_CHANNEL_HOST``/``JARVIS_CHANNEL_PORT``, which is what
+    ``event_channel`` itself binds with."""
+    host = (os.environ.get("JARVIS_CHANNEL_HOST") or "127.0.0.1").strip()
+    try:
+        port = int((os.environ.get("JARVIS_CHANNEL_PORT") or "8099").strip()
+                   or 8099)
+    except ValueError:
+        port = 8099
+    return host or "127.0.0.1", port
+
+
+def engine_pid(root: Optional[Path] = None) -> Optional[int]:
+    """The O+V engine's PID from the lockfile the engine itself writes.
+
+    ``.jarvis/intake_router.lock`` is written by the intake router when it
+    binds — a NON-socket source, so a wedged socket cannot mask a live
+    process. This is the O+V parallel to :func:`supervisor_pid`'s use of
+    ``launchctl``/``pgrep``, and it is why a deadlocked engine reports
+    UNRESPONSIVE rather than DOWN.
+
+    A recorded pid that is no longer alive is a STALE lock, not a daemon.
+    """
+    import json
+    try:
+        base = root if root is not None else _repo_root()
+        raw = (base / ".jarvis" / "intake_router.lock").read_text(
+            encoding="utf-8")
+        pid = int(json.loads(raw).get("pid") or 0)
+        if pid <= 0:
+            return None
+        os.kill(pid, 0)                 # existence only; never signals
+        return pid
+    except (PermissionError,):
+        return None
+    except Exception:  # noqa: BLE001 — missing / malformed / dead == no pid
+        return None
+
+
+def _repo_root() -> Path:
+    try:
+        from backend.core.ouroboros.cli.thin_client import repo_root
+        return repo_root()
+    except Exception:  # noqa: BLE001
+        return Path(__file__).resolve().parents[4]
 
 
 def _err_log() -> Path:
@@ -183,6 +269,10 @@ async def active_health_handshake(
     uds_live = uds_state == "live"
     tcp_dead = tcp_state in ("timeout", "refused", "error")
     uds_dead = uds_state in ("timeout", "refused", "stale", "error")
+    # The verdict comes from `classify` — the same rule every fleet row uses,
+    # so the supervisor handshake and the matrix can never disagree about
+    # what "zombie" means. The PROSE below stays this function's own.
+    _verdict = classify(pid_active, {"tcp": tcp_state, "uds": uds_state})
 
     rec = ""
     if not pid_active and not tcp_live and not uds_live:
@@ -212,6 +302,355 @@ async def active_health_handshake(
                         uds_state=uds_state, detail=detail, recommendation=rec)
 
 
+
+# ---------------------------------------------------------------------------
+# Phase 1 — the multi-daemon matrix
+# ---------------------------------------------------------------------------
+#
+# `trinity status` assumed a monolith: one pid, one tcp, one uds, one verdict.
+# The organism is now two daemons with different jobs — `ov` owns the governed
+# loop and the cockpit, `unified_supervisor` owns the body and the HTTP port —
+# and folding one's transport into the other's verdict is what produced
+# "ZOMBIE/DEADLOCKED" about a supervisor serving HTTP 200.
+#
+# A daemon is judged by ITS OWN transports. That is the whole fix, and it is
+# structural: the matrix cannot mix them up because each row owns its probes.
+
+
+def fleet_probe_timeout_s() -> float:
+    """Per-probe ceiling. ``JARVIS_FLEET_PROBE_TIMEOUT_S`` — default 0.75s.
+
+    Aggressively sub-second and deliberately tighter than
+    :func:`_strict_timeout`: this is a DIAGNOSTIC. A tool that hangs while
+    reporting on a hung daemon has become the problem it was run to
+    describe, and an operator staring at a frozen `trinity status` learns
+    nothing except to stop trusting it.
+    """
+    try:
+        return max(0.05, min(10.0, float(
+            os.environ.get("JARVIS_FLEET_PROBE_TIMEOUT_S", "0.75"))))
+    except (TypeError, ValueError):
+        return 0.75
+
+
+def fleet_deadline_s() -> float:
+    """Ceiling on the WHOLE matrix. ``JARVIS_FLEET_DEADLINE_S`` — default 3s.
+
+    A second bound around the per-probe one, because "every probe is bounded"
+    and "the command is bounded" are different promises: N daemons x M
+    transports of individually-bounded probes still add up.
+    """
+    try:
+        return max(0.2, min(30.0, float(
+            os.environ.get("JARVIS_FLEET_DEADLINE_S", "3.0"))))
+    except (TypeError, ValueError):
+        return 3.0
+
+
+def probe_attempts() -> int:
+    """Samples before a `timeout` is believed. ``JARVIS_FLEET_PROBE_ATTEMPTS``
+    — default 2.
+
+    A single sub-second sample is a coin flip against a daemon with real
+    stalls: the supervisor's own LoopSentinel logs pauses over a second, so
+    one probe reported UNRESPONSIVE about a process answering in 17ms
+    moments later. Retried ONLY on `timeout`, which is the ambiguous verdict
+    — `refused` and `stale` are deterministic and gain nothing from asking
+    twice.
+
+    Still hard-bounded: attempts x per-probe budget, under the fleet
+    deadline. Never crying wolf must not cost the promise never to hang.
+    """
+    try:
+        return max(1, min(5, int(
+            os.environ.get("JARVIS_FLEET_PROBE_ATTEMPTS", "2"))))
+    except (TypeError, ValueError):
+        return 2
+
+
+def classify(pid_active: bool, states: Mapping[str, str]) -> Health:
+    """The verdict rule, in ONE place. Pure; NEVER raises.
+
+    Shared by the supervisor handshake and every fleet row so the two can
+    never disagree about what "zombie" means.
+
+    * nothing answering and no pid            -> DOWN
+    * a pid, but every transport unreachable  -> ZOMBIE (the wedged loop)
+    * something live, nothing dead            -> HEALTHY
+    * a live and a dead transport together    -> DEGRADED
+    """
+    try:
+        live = [k for k, v in states.items() if v == "live"]
+        dead = [k for k, v in states.items()
+                if v in ("timeout", "refused", "stale", "error")]
+        if not pid_active and not live:
+            return Health.DOWN
+        if pid_active and not live and dead:
+            return Health.ZOMBIE
+        if live and not dead:
+            return Health.HEALTHY
+        if live and dead:
+            return Health.DEGRADED
+        return Health.DOWN if not live else Health.HEALTHY
+    except Exception:  # noqa: BLE001
+        return Health.UNKNOWN
+
+
+@dataclass(frozen=True)
+class Transport:
+    """One address a daemon binds, and how to reach it.
+
+    ``resolve`` is a callable rather than a value so the matrix reads the
+    configuration at PROBE time — an operator who moves a port between two
+    runs is not told about the old one.
+    """
+
+    kind: str                       # "tcp" | "uds"
+    label: str
+    resolve: Callable[[], Any]
+    #: An optional transport is REPORTED but never degrades the verdict.
+    #: The cockpit socket is attach-on-demand: nobody attached is the normal
+    #: state, and calling a healthy engine DEGRADED for it is the same error
+    #: as judging the supervisor by the cockpit's socket — crying wolf about
+    #: a transport that is legitimately absent.
+    optional: bool = False
+
+
+@dataclass(frozen=True)
+class DaemonSpec:
+    """A daemon, as a declaration. Adding one is data, not control flow."""
+
+    name: str
+    title: str
+    pid_source: Callable[[], Optional[int]]
+    transports: Tuple[Transport, ...]
+    absent_hint: str = ""
+    #: Where to look when this daemon is wrong. Per-daemon, because pointing
+    #: an operator at the supervisor's error log to debug the engine is worse
+    #: than saying nothing.
+    log_hint: Callable[[], str] = lambda: ""
+
+
+@dataclass(frozen=True)
+class DaemonHealth:
+    name: str
+    title: str
+    state: Health
+    pid: Optional[int] = None
+    transports: Mapping[str, str] = field(default_factory=dict)
+    detail: str = ""
+    recommendation: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.state is Health.HEALTHY
+
+    @property
+    def faulted(self) -> bool:
+        """A daemon that is present and wrong. DOWN is not a fault — a
+        deployment may legitimately not be running the engine."""
+        return self.state in (Health.ZOMBIE, Health.DEGRADED)
+
+
+@dataclass(frozen=True)
+class FleetHealth:
+    daemons: Tuple[DaemonHealth, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        return not any(d.faulted for d in self.daemons)
+
+    def by_name(self, name: str) -> Optional[DaemonHealth]:
+        for d in self.daemons:
+            if d.name == name:
+                return d
+        return None
+
+
+def default_fleet() -> Tuple[DaemonSpec, ...]:
+    """The two daemons this repo runs. Every address resolved dynamically."""
+    return (
+        DaemonSpec(
+            name="supervisor",
+            title="supervisor (body: audio, vision, HUD stream)",
+            pid_source=supervisor_pid,
+            transports=(
+                Transport("tcp", "tcp", supervisor_endpoint),
+                Transport("uds", "uds", _attach_socket, optional=True),
+            ),
+            absent_hint="start it with `trinity up`",
+            log_hint=lambda: f"tail {_err_log()}",
+        ),
+        DaemonSpec(
+            name="ov",
+            title="O+V engine (the governed loop)",
+            pid_source=engine_pid,
+            transports=(
+                # Attach-on-demand: `ov daemon` runs headless and nobody is
+                # attached most of the time. Reported, never degrading.
+                Transport("uds", "cockpit", engine_socket, optional=True),
+                Transport("tcp", "event-bus", engine_endpoint),
+            ),
+            absent_hint="start it with `ov daemon`",
+            log_hint=_engine_log_hint,
+        ),
+    )
+
+
+
+def _engine_log_hint() -> str:
+    """The ENGINE's log, which is a per-session file, not the supervisor's."""
+    try:
+        base = _repo_root() / ".ouroboros" / "sessions"
+        latest = max((d for d in base.iterdir() if d.is_dir()),
+                     key=lambda d: d.stat().st_mtime, default=None)
+        return f"tail {latest / 'debug.log'}" if latest else ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _hint(spec: "DaemonSpec") -> str:
+    try:
+        return spec.log_hint() or ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _probe_fns() -> Tuple[Callable[..., Any], Callable[..., Any]]:
+    """Resolve the probe callables ONCE, outside any timed window.
+
+    This import used to sit inside `_probe_transport`, i.e. INSIDE a
+    `wait_for`. In a warm process that is free; in a cold CLI process it is a
+    blocking import that stalls the event loop while a sibling probe's
+    deadline is already running — so `trinity status` reported `timeout`
+    against endpoints answering in 5ms, and only from the CLI, never from a
+    warm interpreter. A bounded probe must not contain unbounded work.
+    """
+    from backend.core.ouroboros.cli.thin_client import probe_http, probe_socket
+    return probe_http, probe_socket
+
+
+async def _probe_transport(t: Transport, timeout: float,
+                           probes: Optional[Tuple[Any, Any]] = None) -> str:
+    """One transport, hard-bounded. NEVER raises, NEVER hangs.
+
+    Double-bounded on purpose: the probe is given a timeout AND wrapped in
+    `wait_for`. A probe that mishandles its own deadline must not be able to
+    freeze the diagnostic — the tool's responsiveness cannot rest on the
+    correctness of the thing it is diagnosing.
+    """
+    probe_http, probe_socket = probes if probes is not None else _probe_fns()
+    try:
+        target = t.resolve()
+    except Exception:  # noqa: BLE001
+        return "error"
+    if target is None:
+        return "absent"
+    # `timeout` is the CEILING for this probe, and the outer `wait_for` is
+    # what enforces it. The inner probe gets the same value so its own
+    # per-phase deadlines effectively never fire first — dividing the budget
+    # across `probe_http`'s three phases (connect / drain / read) starves a
+    # slow-but-healthy endpoint and manufactures a "timeout".
+    #
+    # Measured on this machine: the engine's /observability/health answers in
+    # 0.502s and the supervisor's in 0.005s. A third of a 0.75s budget is
+    # 0.25s, which called the healthy engine UNRESPONSIVE. One ceiling, one
+    # enforcer, no arithmetic in between.
+    result = "error"
+    for attempt in range(probe_attempts()):
+        try:
+            if t.kind == "tcp":
+                host, port = target
+                inner = probe_http(host, port, timeout)
+            else:
+                inner = probe_socket(Path(target), timeout)
+            result = await asyncio.wait_for(inner, timeout=timeout)
+        except asyncio.TimeoutError:
+            result = "timeout"
+        except Exception:  # noqa: BLE001
+            result = "error"
+        # Only `timeout` is ambiguous enough to be worth asking twice.
+        if result != "timeout":
+            return result
+    return result
+
+
+async def assess_daemon(spec: DaemonSpec, *,
+                        timeout: Optional[float] = None) -> DaemonHealth:
+    """Probe one daemon's OWN transports. NEVER raises, NEVER hangs."""
+    to = timeout if timeout is not None else fleet_probe_timeout_s()
+    # Warmed BEFORE any clock starts — see `_probe_fns`.
+    try:
+        probes = _probe_fns()
+    except Exception:  # noqa: BLE001
+        probes = None
+    try:
+        pid = spec.pid_source()
+    except Exception:  # noqa: BLE001
+        pid = None
+    try:
+        results = await asyncio.gather(
+            *(_probe_transport(t, to, probes) for t in spec.transports),
+            return_exceptions=True)
+    except Exception:  # noqa: BLE001
+        results = ["error"] * len(spec.transports)
+    states: Dict[str, str] = {}
+    for t, r in zip(spec.transports, results):
+        states[t.label] = r if isinstance(r, str) else "error"
+
+    required = {t.label: states.get(t.label, "error")
+                for t in spec.transports if not t.optional}
+    state = classify(pid is not None, required or states)
+    shown = ", ".join(
+        f"{k}={v}" + ("*" if any(t.label == k and t.optional
+                                 for t in spec.transports) else "")
+        for k, v in states.items())
+    if state is Health.DOWN:
+        detail = f"not running (no pid, {shown})"
+        rec = spec.absent_hint
+    elif state is Health.ZOMBIE:
+        detail = (f"pid {pid} ALIVE but UNRESPONSIVE ({shown}) — the event "
+                  f"loop is wedged or it never bound its transports")
+        rec = _hint(spec)
+    elif state is Health.DEGRADED:
+        detail = f"partial readiness (pid={pid}, {shown})"
+        rec = _hint(spec)
+    else:
+        detail = f"pid {pid} live; {shown}" if pid else f"live; {shown}"
+        rec = ""
+    return DaemonHealth(name=spec.name, title=spec.title, state=state,
+                        pid=pid, transports=states, detail=detail,
+                        recommendation=rec)
+
+
+async def assess_fleet(specs: Optional[Tuple[DaemonSpec, ...]] = None, *,
+                       timeout: Optional[float] = None,
+                       deadline: Optional[float] = None) -> FleetHealth:
+    """The whole matrix, concurrently and within a hard ceiling.
+
+    NEVER raises, NEVER hangs: a daemon whose assessment overruns the
+    deadline is reported UNKNOWN rather than being waited on.
+    """
+    fleet = specs if specs is not None else default_fleet()
+    cap = deadline if deadline is not None else fleet_deadline_s()
+    try:
+        rows = await asyncio.wait_for(
+            asyncio.gather(*(assess_daemon(s, timeout=timeout) for s in fleet),
+                           return_exceptions=True),
+            timeout=cap)
+    except (asyncio.TimeoutError, Exception):  # noqa: BLE001
+        rows = [None] * len(fleet)
+    out = []
+    for spec, row in zip(fleet, rows):
+        if isinstance(row, DaemonHealth):
+            out.append(row)
+        else:
+            out.append(DaemonHealth(
+                name=spec.name, title=spec.title, state=Health.UNKNOWN,
+                detail=f"probe exceeded the {cap:.2f}s fleet deadline",
+                recommendation="raise JARVIS_FLEET_DEADLINE_S to look harder"))
+    return FleetHealth(daemons=tuple(out))
+
 _GLYPH = {
     Health.HEALTHY: "⏺", Health.ZOMBIE: "✗", Health.DOWN: "○",
     Health.DEGRADED: "▲", Health.UNKNOWN: "·",
@@ -225,13 +664,16 @@ def status_main(console=None) -> int:
         if console is None:
             from backend.core.ouroboros.ui.theme import build_console
             console = build_console()
-        report = asyncio.run(active_health_handshake())
-        g = _GLYPH.get(report.state, "·")
-        console.print(f"{g} supervisor: {report.state.value}", markup=False)
-        console.print(f"  ⎿ {report.detail}", markup=False)
-        if report.recommendation:
-            console.print(f"  ⎿ {report.recommendation}", markup=False)
-        return 0 if report.ok else 1
+        fleet = asyncio.run(assess_fleet())
+        for row in fleet.daemons:
+            g = _GLYPH.get(row.state, "·")
+            console.print(f"{g} {row.title}: {row.state.value}", markup=False)
+            console.print(f"  ⎿ {row.detail}", markup=False)
+            if row.recommendation:
+                console.print(f"  ⎿ {row.recommendation}", markup=False)
+        # A DOWN daemon is not a failure — a deployment may legitimately run
+        # only one. A daemon that is PRESENT AND WRONG is.
+        return 0 if fleet.ok else 1
     except Exception as exc:  # noqa: BLE001
         try:
             console and console.print(f"✗ status failed: {exc}", markup=False)
@@ -241,6 +683,9 @@ def status_main(console=None) -> int:
 
 
 __all__ = [
-    "Health", "HealthReport", "supervisor_pid", "active_health_handshake",
-    "status_main",
+    "DaemonHealth", "DaemonSpec", "FleetHealth", "Health", "HealthReport",
+    "Transport", "active_health_handshake", "assess_daemon", "assess_fleet",
+    "classify", "default_fleet", "engine_endpoint", "engine_pid",
+    "engine_socket", "fleet_deadline_s", "fleet_probe_timeout_s",
+    "status_main", "supervisor_endpoint", "supervisor_pid",
 ]

--- a/tests/cli/test_trinity_status.py
+++ b/tests/cli/test_trinity_status.py
@@ -90,15 +90,30 @@ async def test_down_no_pid_no_transport(tmp_path):
     assert "install" in report.recommendation or "up" in report.recommendation
 
 
+def _row(name, state, **kw):
+    return st.DaemonHealth(name=name, title=kw.pop("title", name), state=state,
+                           **kw)
+
+
+def _fleet(*rows):
+    async def _f(*a, **k):
+        return st.FleetHealth(daemons=tuple(rows))
+    return _f
+
+
 def test_status_main_exit_code_nonzero_on_zombie(monkeypatch):
-    """status_main is SYNC (it owns asyncio.run) — so this test is sync."""
+    """status_main is SYNC (it owns asyncio.run) — so this test is sync.
+
+    Seam moved from `active_health_handshake` to `assess_fleet` when status
+    stopped assuming a monolith; the CONTRACT it pins is unchanged — a
+    present-and-wrong daemon exits non-zero and is named on screen.
+    """
     class _C:
         def __init__(self): self.lines = []
         def print(self, t, **k): self.lines.append(str(t))
-    async def _zombie():
-        return st.HealthReport(state=st.Health.ZOMBIE, pid=5,
-                               detail="wedged", recommendation="tail log")
-    monkeypatch.setattr(st, "active_health_handshake", lambda **k: _zombie())
+    monkeypatch.setattr(st, "assess_fleet", _fleet(
+        _row("supervisor", st.Health.ZOMBIE, pid=5, detail="wedged",
+             recommendation="tail log")))
     c = _C()
     rc = st.status_main(c)
     assert rc == 1                           # non-zero on unhealthy
@@ -108,10 +123,37 @@ def test_status_main_exit_code_nonzero_on_zombie(monkeypatch):
 def test_status_main_exit_zero_on_healthy(monkeypatch):
     class _C:
         def print(self, t, **k): pass
-    async def _ok():
-        return st.HealthReport(state=st.Health.HEALTHY, pid=5, detail="ok")
-    monkeypatch.setattr(st, "active_health_handshake", lambda **k: _ok())
+    monkeypatch.setattr(st, "assess_fleet", _fleet(
+        _row("supervisor", st.Health.HEALTHY, pid=5, detail="ok")))
     assert st.status_main(_C()) == 0
+
+
+def test_a_down_engine_is_not_a_failure(monkeypatch):
+    """The multi-daemon consequence: a deployment may legitimately run only
+    the supervisor. DOWN is a fact; ZOMBIE/DEGRADED is a fault."""
+    class _C:
+        def __init__(self): self.lines = []
+        def print(self, t, **k): self.lines.append(str(t))
+    monkeypatch.setattr(st, "assess_fleet", _fleet(
+        _row("supervisor", st.Health.HEALTHY, pid=5, detail="ok"),
+        _row("ov", st.Health.DOWN, detail="not running")))
+    c = _C()
+    assert st.status_main(c) == 0
+    assert any("DOWN" in l for l in c.lines), "still REPORTED, just not fatal"
+
+
+def test_both_daemons_are_rendered_separately(monkeypatch):
+    """The point of the matrix: one row cannot borrow the other's verdict."""
+    class _C:
+        def __init__(self): self.lines = []
+        def print(self, t, **k): self.lines.append(str(t))
+    monkeypatch.setattr(st, "assess_fleet", _fleet(
+        _row("supervisor", st.Health.HEALTHY, title="supervisor", detail="a"),
+        _row("ov", st.Health.ZOMBIE, title="O+V engine", pid=9, detail="b")))
+    c = _C()
+    assert st.status_main(c) == 1
+    joined = "\n".join(c.lines)
+    assert "supervisor" in joined and "O+V engine" in joined
 
 
 # ---------------------------------------------------------------------------
@@ -216,3 +258,225 @@ async def test_probe_http_refused_on_dead_port():
     from backend.core.ouroboros.cli.thin_client import probe_http
     s = socket.socket(); s.bind(("127.0.0.1", 0)); free = s.getsockname()[1]; s.close()
     assert await probe_http("127.0.0.1", free, 1.0) == "refused"
+
+
+# ---------------------------------------------------------------------------
+# Multi-daemon matrix — a daemon is judged by ITS OWN transports
+# ---------------------------------------------------------------------------
+
+
+class TestOneDaemonCannotBorrowAnothersVerdict:
+    """THE regression. `trinity status` reported
+    `ZOMBIE/DEADLOCKED (tcp=live, uds=stale)` about a supervisor that was
+    serving HTTP 200 — because the `uds` it folded in was the COCKPIT's
+    socket, which `ov` owns since it took the governed loop.
+    """
+
+    def test_the_supervisor_row_no_longer_probes_the_cockpit_socket(
+            self, monkeypatch):
+        monkeypatch.delenv("JARVIS_SUPERVISOR_IPC_SOCKET", raising=False)
+        monkeypatch.setenv("JARVIS_ATTACH_IPC_SOCKET", "/tmp/cockpit-owned.sock")
+        assert st._attach_socket() is None, "the cockpit socket is not the supervisor's"
+        assert str(st.engine_socket()) == "/tmp/cockpit-owned.sock"
+
+    def test_a_supervisor_with_a_live_port_is_healthy_whatever_the_cockpit_does(
+            self):
+        """tcp live + no uds of its own = HEALTHY. This exact state was
+        being reported ZOMBIE."""
+        assert st.classify(True, {"tcp": "live", "uds": "absent"}) is st.Health.HEALTHY
+
+    def test_a_dedicated_supervisor_socket_is_honoured_when_declared(
+            self, monkeypatch):
+        monkeypatch.setenv("JARVIS_SUPERVISOR_IPC_SOCKET", "/tmp/sup.sock")
+        assert str(st._attach_socket()) == "/tmp/sup.sock"
+
+    async def test_each_row_probes_only_its_own_transports(self):
+        seen = []
+
+        def _t(label, value):
+            def _r():
+                seen.append(label)
+                return value
+            return st.Transport("tcp", label, _r)
+
+        a = st.DaemonSpec(name="a", title="A", pid_source=lambda: None,
+                          transports=(_t("a-tcp", ("127.0.0.1", 1)),))
+        b = st.DaemonSpec(name="b", title="B", pid_source=lambda: None,
+                          transports=(_t("b-tcp", ("127.0.0.1", 2)),))
+        fleet = await st.assess_fleet((a, b), timeout=0.05)
+        assert {d.name for d in fleet.daemons} == {"a", "b"}
+        assert set(fleet.by_name("a").transports) == {"a-tcp"}
+        assert set(fleet.by_name("b").transports) == {"b-tcp"}
+
+
+class TestTheVerdictRuleIsSharedNotCopied:
+    def test_down_zombie_healthy_degraded(self):
+        assert st.classify(False, {"tcp": "refused"}) is st.Health.DOWN
+        assert st.classify(True, {"tcp": "refused"}) is st.Health.ZOMBIE
+        assert st.classify(True, {"tcp": "live"}) is st.Health.HEALTHY
+        assert st.classify(True, {"tcp": "live", "uds": "stale"}) is st.Health.DEGRADED
+
+    def test_it_never_raises(self):
+        assert st.classify(True, None) in tuple(st.Health)
+
+
+class TestDynamicDiscovery:
+    """Zero hardcoded addresses: every probe target is read from the SAME
+    configuration the daemons bind with, at probe time."""
+
+    def test_the_supervisor_endpoint_follows_the_backend_env(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_BACKEND_HOST", "127.0.0.1")
+        monkeypatch.setenv("JARVIS_BACKEND_PORT", "9111")
+        assert st.supervisor_endpoint() == ("127.0.0.1", 9111)
+
+    def test_the_engine_bus_follows_the_channel_env(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CHANNEL_HOST", "127.0.0.1")
+        monkeypatch.setenv("JARVIS_CHANNEL_PORT", "9199")
+        assert st.engine_endpoint() == ("127.0.0.1", 9199)
+
+    def test_the_cockpit_socket_comes_from_the_cockpit_contract(
+            self, monkeypatch):
+        monkeypatch.setenv("JARVIS_ATTACH_IPC_SOCKET", "/tmp/x.sock")
+        assert str(st.engine_socket()) == "/tmp/x.sock"
+
+    def test_the_engine_pid_comes_from_the_lock_the_engine_writes(
+            self, tmp_path):
+        """A NON-socket source, so a wedged socket cannot mask a live
+        process — the O+V parallel to launchctl for the supervisor."""
+        import json
+        import os as _os
+        (tmp_path / ".jarvis").mkdir()
+        (tmp_path / ".jarvis" / "intake_router.lock").write_text(
+            json.dumps({"pid": _os.getpid()}))
+        assert st.engine_pid(root=tmp_path) == _os.getpid()
+
+    def test_a_stale_lock_is_not_a_daemon(self, tmp_path):
+        import json
+        (tmp_path / ".jarvis").mkdir()
+        (tmp_path / ".jarvis" / "intake_router.lock").write_text(
+            json.dumps({"pid": 2_000_000}))       # cannot exist
+        assert st.engine_pid(root=tmp_path) is None
+
+    def test_a_missing_lock_is_not_an_error(self, tmp_path):
+        assert st.engine_pid(root=tmp_path) is None
+
+
+class TestTheDiagnosticNeverHangs:
+    """A tool that freezes while reporting on a frozen daemon has become the
+    problem it was run to describe."""
+
+    def test_probe_timeouts_are_sub_second_by_default(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_FLEET_PROBE_TIMEOUT_S", raising=False)
+        assert st.fleet_probe_timeout_s() < 1.0
+
+    async def test_a_hanging_probe_is_reported_not_awaited(self):
+        async def _never(*_a, **_k):
+            await asyncio.sleep(3600)
+
+        import backend.core.ouroboros.cli.thin_client as tc
+        real = tc.probe_http
+        tc.probe_http = _never
+        try:
+            spec = st.DaemonSpec(
+                name="wedged", title="wedged", pid_source=lambda: 4242,
+                transports=(st.Transport("tcp", "tcp",
+                                         lambda: ("127.0.0.1", 1)),))
+            row = await asyncio.wait_for(
+                st.assess_daemon(spec, timeout=0.05), timeout=5)
+            assert row.transports["tcp"] == "timeout"
+            assert row.state is st.Health.ZOMBIE
+            assert "UNRESPONSIVE" in row.detail
+        finally:
+            tc.probe_http = real
+
+    async def test_the_whole_matrix_is_bounded_even_if_a_row_overruns(self):
+        async def _slow(*_a, **_k):
+            await asyncio.sleep(30)
+
+        import backend.core.ouroboros.cli.thin_client as tc
+        real = tc.probe_http
+        tc.probe_http = _slow
+        try:
+            spec = st.DaemonSpec(
+                name="slow", title="slow", pid_source=lambda: None,
+                transports=(st.Transport("tcp", "tcp",
+                                         lambda: ("127.0.0.1", 1)),))
+            fleet = await asyncio.wait_for(
+                st.assess_fleet((spec,), timeout=10, deadline=0.3), timeout=5)
+            assert fleet.daemons[0].state is st.Health.UNKNOWN
+            assert "deadline" in fleet.daemons[0].detail
+        finally:
+            tc.probe_http = real
+
+    async def test_an_exploding_resolver_never_escapes(self):
+        def _boom():
+            raise RuntimeError("config exploded")
+
+        spec = st.DaemonSpec(name="x", title="x", pid_source=_boom,
+                             transports=(st.Transport("tcp", "tcp", _boom),))
+        row = await st.assess_daemon(spec, timeout=0.05)
+        assert row.transports["tcp"] == "error"
+
+
+class TestAnOptionalTransportIsReportedNotFatal:
+    """The cockpit socket is attach-on-demand — `ov daemon` runs headless and
+    nobody is attached most of the time. Degrading a healthy engine for it is
+    the same error as judging the supervisor by the cockpit's socket."""
+
+    async def test_a_stale_cockpit_does_not_degrade_a_serving_engine(self):
+        spec = st.DaemonSpec(
+            name="ov", title="O+V", pid_source=lambda: 4242,
+            transports=(
+                st.Transport("uds", "cockpit", lambda: None, optional=True),
+                st.Transport("tcp", "event-bus",
+                             lambda: ("127.0.0.1", 1)),
+            ))
+
+        async def _live(*_a, **_k):
+            return "live"
+
+        import backend.core.ouroboros.cli.thin_client as tc
+        real_http, real_sock = tc.probe_http, tc.probe_socket
+
+        async def _stale(*_a, **_k):
+            return "stale"
+
+        tc.probe_http, tc.probe_socket = _live, _stale
+        try:
+            spec = st.DaemonSpec(
+                name="ov", title="O+V", pid_source=lambda: 4242,
+                transports=(
+                    st.Transport("uds", "cockpit", lambda: Path("/tmp/x.sock"),
+                                 optional=True),
+                    st.Transport("tcp", "event-bus",
+                                 lambda: ("127.0.0.1", 1)),
+                ))
+            row = await st.assess_daemon(spec, timeout=0.2)
+            assert row.state is st.Health.HEALTHY, row.detail
+            assert "cockpit=stale" in row.detail, "still REPORTED"
+        finally:
+            tc.probe_http, tc.probe_socket = real_http, real_sock
+
+    async def test_a_required_transport_still_degrades(self):
+        import backend.core.ouroboros.cli.thin_client as tc
+        real = tc.probe_http
+
+        async def _refused(*_a, **_k):
+            return "refused"
+
+        tc.probe_http = _refused
+        try:
+            spec = st.DaemonSpec(
+                name="ov", title="O+V", pid_source=lambda: 4242,
+                transports=(st.Transport("tcp", "event-bus",
+                                         lambda: ("127.0.0.1", 1)),))
+            row = await st.assess_daemon(spec, timeout=0.2)
+            assert row.state is st.Health.ZOMBIE
+        finally:
+            tc.probe_http = real
+
+    def test_each_daemon_points_at_its_own_log(self):
+        sup, ov = st.default_fleet()
+        assert "supervisor.err.log" in sup.log_hint()
+        hint = ov.log_hint()
+        assert hint == "" or "sessions" in hint, hint


### PR DESCRIPTION
It reported `ZOMBIE/DEADLOCKED` about a supervisor that was serving HTTP 200 — because the `uds` folded into that verdict was the **cockpit's** socket, which `ov` owns since it took the governed loop. One daemon was being judged by another's transport. Deleting the socket check would have made the message go away and left the assumption in place.

## Phase 1 — the matrix

Each row owns its probes, so rows cannot borrow each other's verdicts:

| daemon | transports |
|---|---|
| supervisor | tcp (`JARVIS_BACKEND_HOST`/`PORT`) + its own uds, *if declared* |
| O+V engine | cockpit uds + the IPC event bus (`EventChannelServer`) |

`classify()` is the verdict rule in **one** place — DOWN / ZOMBIE / HEALTHY / DEGRADED — shared by the fleet rows and by `active_health_handshake`, so the two can never disagree about what "zombie" means. A daemon is a **declaration** (`DaemonSpec`): adding a third is data, not control flow.

**Optional transports.** The cockpit socket is attach-on-demand — `ov daemon` runs headless and nobody is attached most of the time. It is marked optional: reported (with `*`) and never degrading. Calling a serving engine DEGRADED because no operator happened to be attached is the same error one level down.

## Phase 2 — dynamic discovery

Zero addresses written here. Everything resolves **at probe time** from the configuration the daemons bind with: `JARVIS_BACKEND_HOST`/`PORT`, `JARVIS_CHANNEL_HOST`/`PORT`, the cockpit's own `attach_socket_path()`, and — for the engine's pid — `.jarvis/intake_router.lock`, the lockfile the intake router writes when it binds. That's a **non-socket** source, which is why a wedged engine reports UNRESPONSIVE rather than DOWN. Each daemon also points at its **own** log.

## Phase 3 — non-blocking

Sub-second per probe (0.75 s), hard ceiling on the whole matrix (3 s), every probe double-bounded so a probe that mishandles its own deadline still cannot freeze the tool. A row that overruns is reported UNKNOWN rather than waited on.

## Two bugs the live run found that the unit tests could not

- **A cold import inside the timed window.** `_probe_transport` imported `thin_client` inside its own `wait_for` — free in a warm interpreter, a loop-blocking stall in a cold CLI process. `trinity status` reported `timeout` against an endpoint answering in 5 ms, *and only from the CLI*. A bounded probe must not contain unbounded work.
- **One sub-second sample is a coin flip.** The supervisor's own LoopSentinel logs stalls over a second, so a single probe called a live process UNRESPONSIVE moments before it answered in 17 ms. Retried once, and only on `timeout` — `refused` and `stale` are deterministic.

## Verified live, from a cold CLI

```
HEALTHY  pid 46303 live; cockpit=stale*, event-bus=live
ZOMBIE   pid 46303 ALIVE but UNRESPONSIVE (cockpit=stale*, event-bus=refused)
DOWN     not running (no pid, …) -> start it with `ov daemon`
```

The supervisor is judged separately throughout. Its occasional `tcp=timeout` is left **honest** rather than tuned away: that process really does stall for seconds at a time, and a probe adjusted until it agrees is not a probe.

Exit code keeps its meaning with the multi-daemon nuance stated: a DOWN daemon is a **fact** (a deployment may run only one), a ZOMBIE or DEGRADED one is a **fault**. 19 new tests, 69 green across the CLI spines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`trinity status` now assesses the supervisor and the O+V engine separately instead of assuming a monolith. Previously it mixed transports and could report the supervisor as ZOMBIE/DEADLOCKED while it served HTTP 200; now each daemon is judged by its own probes, with a shared `classify()` rule and bounded, dynamically discovered checks.

- Output and exit code change: the command prints one row per daemon and exits non‑zero only if any present daemon is faulted (ZOMBIE/DEGRADED). A DOWN engine does not fail the command.
- Transport ownership is fixed: the supervisor’s UDS now comes from `JARVIS_SUPERVISOR_IPC_SOCKET` (if set). The cockpit socket is reported on the engine row and is optional (reported with `*`, never degrading).
- Dynamic discovery: probe targets resolve at probe time from `JARVIS_BACKEND_HOST`/`PORT`, `JARVIS_CHANNEL_HOST`/`PORT`, the cockpit’s `JARVIS_ATTACH_IPC_SOCKET`, and the engine PID from `.jarvis/intake_router.lock`.
- Non‑blocking diagnostics: per‑probe timeout (`JARVIS_FLEET_PROBE_TIMEOUT_S`, default 0.75s), whole‑matrix deadline (`JARVIS_FLEET_DEADLINE_S`, default 3s), retries only on `timeout`. Probes are resolved outside timed windows to avoid cold‑import stalls.
- Migration note: update any tooling that parsed the previous single‑row output or treated a DOWN engine as a failure. If you relied on the cockpit socket for supervisor health, set `JARVIS_SUPERVISOR_IPC_SOCKET` or expect it to be reported as not applicable.

<sup>Written for commit abfae348cd0b92298d6fcd3702791c0999fe043e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

