### PR TITLE
fix(loop): offload the boot blockers; no OS binary may hold a worker

### DIFF
--- a/backend/agi_os/realtime_voice_communicator.py
+++ b/backend/agi_os/realtime_voice_communicator.py
@@ -269,15 +269,15 @@ class RealTimeVoiceCommunicator:
     def _discover_voices(self) -> None:
         """Discover available system voices."""
         try:
-            _voice_discover_timeout = float(os.getenv("JARVIS_VOICE_DISCOVER_TIMEOUT", "15"))
-            result = subprocess.run(
-                ['say', '-v', '?'],
-                capture_output=True,
-                text=True,
-                timeout=_voice_discover_timeout
-            )
+            # One cached, bounded query shared with `trinity_voice_coordinator`
+            # instead of a second 15s shell-out for the same immutable list.
+            # StallSampler caught this on the wedged main loop.
+            from backend.core.system_voices import voice_catalog_raw
+            catalog = voice_catalog_raw()
+            if catalog is None:
+                return
 
-            for line in result.stdout.split('\n'):
+            for line in catalog.split('\n'):
                 if line.strip():
                     parts = line.split()
                     if len(parts) >= 2:

--- a/backend/autonomy/uae_context_manager.py
+++ b/backend/autonomy/uae_context_manager.py
@@ -410,12 +410,10 @@ class UAEContextManager:
                 return appName & "|" & winName
             '''
 
+            from backend.core.bounded_subprocess import run_bounded
             result = await _off_loop(
-                subprocess.run,
-                ["osascript", "-e", script],
-                capture_output=True,
-                text=True,
-                timeout=2,
+                run_bounded, ["osascript", "-e", script],
+                timeout=2.0, text=True,
             )
 
             if result is not None and result.returncode == 0:
@@ -441,12 +439,10 @@ class UAEContextManager:
                 return mousePos
             '''
 
+            from backend.core.bounded_subprocess import run_bounded
             result = await _off_loop(
-                subprocess.run,
-                ["osascript", "-e", script],
-                capture_output=True,
-                text=True,
-                timeout=2,
+                run_bounded, ["osascript", "-e", script],
+                timeout=2.0, text=True,
             )
 
             if result is not None and result.returncode == 0:
@@ -499,11 +495,14 @@ class UAEContextManager:
             with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
                 tmp_path = tmp.name
 
-            subprocess.run(
-                ["screencapture", "-x", "-t", "png", tmp_path],
-                capture_output=True,
-                timeout=5,
-            )
+            from backend.core.bounded_subprocess import run_bounded
+            if run_bounded(["screencapture", "-x", "-t", "png", tmp_path],
+                           timeout=5.0) is None:
+                # Timed out, refused by the breaker, or the binary is
+                # missing. A hung `screencapture` is the TCC-consent case
+                # this guards: its group has been reaped and the worker
+                # released, and there is nothing to encode.
+                return None, ""
 
             with open(tmp_path, "rb") as f:
                 data = f.read()

--- a/backend/core/bounded_subprocess.py
+++ b/backend/core/bounded_subprocess.py
@@ -1,0 +1,292 @@
+"""An external binary may cost us time. It may never cost us a thread.
+
+THE BLIND SPOT OFFLOADING CREATED
+---------------------------------
+Moving `osascript` and `screencapture` off the event loop fixed the stalls and
+opened a worse failure mode: the blocking call now happens on a POOL worker.
+The loop keeps breathing, so nothing looks wrong — while a wedged binary holds
+a worker forever. Repeat it on a cadence and the pool bleeds out silently.
+That is strictly worse than the stall it replaced, because a stall is visible
+and a leaked worker is not.
+
+WHY `subprocess.run(timeout=...)` IS NOT ENOUGH
+-----------------------------------------------
+It kills the direct CHILD and then calls `communicate()` again to reap it.
+Two things defeat that here:
+
+* The child spawns grandchildren. `_get_cursor_position` runs an `osascript`
+  whose script does `do shell script "python3 -c ..."`. SIGKILL to the
+  osascript leaves the python interpreter alive, holding the inherited pipe
+  open — so the post-kill `communicate()` blocks on a pipe that never closes,
+  and the worker is captured anyway.
+* On macOS a binary blocked in the kernel on a TCC (screen-recording /
+  automation) consent prompt is not reliably reaped by a plain kill: the
+  prompt belongs to the window server, not to us.
+
+So the child is started in its OWN process group (`start_new_session=True`)
+and the whole GROUP is signalled — TERM first, then KILL — and the reap
+itself is bounded. If even that does not return, the pipes are abandoned
+rather than waited on: losing a file descriptor is survivable, losing the
+worker permanently is not.
+
+THE CIRCUIT BREAKER
+-------------------
+A binary that hangs once will hang again — a revoked TCC permission does not
+heal because we retried. After `JARVIS_SUBPROC_BREAKER_TRIPS` consecutive
+timeouts for one command, that command is refused outright for
+`JARVIS_SUBPROC_BREAKER_COOLDOWN_S`, returning None immediately without
+touching a worker at all. A single success closes the breaker.
+
+Keyed on the BINARY, not on the full argv: `screencapture` hanging on a
+consent prompt hangs for every temp path, so keying on the path would open a
+fresh breaker per call and never trip. See :func:`_key` for why it is not
+keyed on a guessed sub-verb either — a flag and a sub-verb are not
+distinguishable by shape, and the first attempt's own test proved it.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import subprocess
+import threading
+import time
+from typing import Any, Dict, Optional, Sequence
+
+logger = logging.getLogger("Jarvis.BoundedSubprocess")
+
+BOUNDED_SUBPROCESS_SCHEMA_VERSION: str = "bounded_subprocess.1"
+
+__all__ = [
+    "BOUNDED_SUBPROCESS_SCHEMA_VERSION",
+    "breaker_open",
+    "breaker_state",
+    "reset_for_tests",
+    "run_bounded",
+]
+
+
+def _num(name: str, default: float, lo: float, hi: float) -> float:
+    try:
+        return min(hi, max(lo, float((os.environ.get(name) or "").strip()
+                                     or default)))
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def _breaker_trips() -> int:
+    """Consecutive timeouts before a command is refused."""
+    return int(_num("JARVIS_SUBPROC_BREAKER_TRIPS", 3, 1, 100))
+
+
+def _breaker_cooldown_s() -> float:
+    """How long a tripped command stays refused. Default 5 minutes."""
+    return _num("JARVIS_SUBPROC_BREAKER_COOLDOWN_S", 300.0, 1.0, 86400.0)
+
+
+def _reap_grace_s() -> float:
+    """Time between TERM and KILL for the process group."""
+    return _num("JARVIS_SUBPROC_REAP_GRACE_S", 0.5, 0.05, 10.0)
+
+
+def _reap_budget_s() -> float:
+    """Total time spent reaping before the pipes are abandoned.
+
+    Bounded because the reap is the last thing standing between a wedged
+    binary and a captured worker; an unbounded wait here would recreate the
+    exact leak this module exists to prevent.
+    """
+    return _num("JARVIS_SUBPROC_REAP_BUDGET_S", 2.0, 0.1, 30.0)
+
+
+# ---------------------------------------------------------------------------
+# Breaker state — keyed by command, not by argv
+# ---------------------------------------------------------------------------
+
+_lock = threading.Lock()
+_fails: Dict[str, int] = {}
+_opened_at: Dict[str, float] = {}
+
+
+def _key(cmd: Sequence[str]) -> str:
+    """The BINARY, and nothing else.
+
+    Never the full argv: a hang caused by a consent prompt reproduces for
+    every temp path, so keying on the path would open a fresh breaker per
+    call and never trip.
+
+    And never a guessed sub-verb either. A first attempt keyed
+    `binary + argv[1]` when argv[1] looked short and flag-like, to keep
+    `yabai -m` distinct from `yabai --start-service`. Its own test found the
+    flaw immediately: that rule reads `screencapture -x -t png <path>` as
+    `screencapture -x`, because a FLAG and a SUB-VERB are not distinguishable
+    by shape. Generic argv parsing is not knowable here, so the rule that
+    remains is the one that is always true — this binary hangs.
+
+    The granularity that was lost costs nothing today: only the probing
+    calls are routed through here, never the recovery ones, so a tripped
+    breaker cannot refuse the command that would fix the condition. If a
+    recovery path is ever routed through this, it needs its own key —
+    stated here because that is exactly the kind of coupling that is
+    invisible until it bites.
+    """
+    try:
+        parts = [str(c) for c in cmd if str(c)]
+        return os.path.basename(parts[0]) if parts else "?"
+    except Exception:  # noqa: BLE001
+        return "?"
+
+
+def breaker_open(cmd: Sequence[str]) -> bool:
+    """Is this command currently refused? NEVER raises."""
+    try:
+        key = _key(cmd)
+        with _lock:
+            opened = _opened_at.get(key)
+            if opened is None:
+                return False
+            if (time.monotonic() - opened) >= _breaker_cooldown_s():
+                # Cooldown elapsed — allow ONE probe through. The counter is
+                # left as-is so a still-wedged binary re-opens immediately
+                # instead of earning a fresh budget of retries.
+                _opened_at.pop(key, None)
+                return False
+            return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def breaker_state() -> Dict[str, Any]:
+    """Bounded projection for operator surfaces. NEVER raises."""
+    with _lock:
+        return {
+            "schema_version": BOUNDED_SUBPROCESS_SCHEMA_VERSION,
+            "consecutive_failures": dict(_fails),
+            "open": sorted(_opened_at),
+            "trips_to_open": _breaker_trips(),
+            "cooldown_s": _breaker_cooldown_s(),
+        }
+
+
+def reset_for_tests() -> None:
+    with _lock:
+        _fails.clear()
+        _opened_at.clear()
+
+
+def _record_success(key: str) -> None:
+    with _lock:
+        _fails.pop(key, None)
+        _opened_at.pop(key, None)
+
+
+def _record_timeout(key: str) -> None:
+    with _lock:
+        _fails[key] = _fails.get(key, 0) + 1
+        if _fails[key] >= _breaker_trips() and key not in _opened_at:
+            _opened_at[key] = time.monotonic()
+            logger.warning(
+                "[BoundedSubprocess] breaker OPEN for %r after %d consecutive "
+                "timeouts — refusing it for %.0fs rather than spending "
+                "another worker on it", key, _fails[key], _breaker_cooldown_s())
+
+
+# ---------------------------------------------------------------------------
+# The call
+# ---------------------------------------------------------------------------
+
+
+def _reap(proc: "subprocess.Popen") -> None:
+    """Kill the process GROUP and stop waiting on it. NEVER raises.
+
+    The group, not the process: a child that spawned grandchildren leaves
+    them holding the inherited pipe, and the post-kill wait then blocks on a
+    pipe that never closes — capturing the very worker the kill was meant to
+    free.
+    """
+    try:
+        pgid = os.getpgid(proc.pid)
+    except Exception:  # noqa: BLE001 — already gone
+        pgid = None
+
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        if proc.poll() is not None:
+            return
+        try:
+            if pgid is not None:
+                os.killpg(pgid, sig)
+            else:
+                proc.send_signal(sig)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+        deadline = time.monotonic() + (
+            _reap_grace_s() if sig == signal.SIGTERM else _reap_budget_s())
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                return
+            time.sleep(0.02)
+
+    # Still not dead. Abandon the pipes rather than block here forever: a
+    # leaked file descriptor is survivable, a permanently captured worker is
+    # not.
+    for stream in (proc.stdout, proc.stderr, proc.stdin):
+        try:
+            if stream is not None:
+                stream.close()
+        except Exception:  # noqa: BLE001
+            pass
+    logger.warning("[BoundedSubprocess] pid %s survived TERM+KILL — pipes "
+                   "abandoned to release the worker", proc.pid)
+
+
+def run_bounded(cmd: Sequence[str], *, timeout: float,
+                text: bool = False) -> Optional[subprocess.CompletedProcess]:
+    """Run *cmd* with a hard ceiling. NEVER raises, NEVER holds a worker.
+
+    Returns the CompletedProcess, or None when the command timed out, could
+    not start, or is currently refused by the breaker. None means "no
+    answer" — every caller here already treats an unanswered probe as
+    unknown, which is the honest reading and keeps a wedged binary from
+    being mistaken for a negative result.
+    """
+    key = _key(cmd)
+    if breaker_open(cmd):
+        logger.debug("[BoundedSubprocess] %r refused (breaker open)", key)
+        return None
+
+    proc = None
+    try:
+        proc = subprocess.Popen(
+            list(cmd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=text,
+            # Its OWN process group, so the whole tree can be signalled.
+            start_new_session=True,
+        )
+        out, err = proc.communicate(timeout=timeout)
+        _record_success(key)
+        return subprocess.CompletedProcess(list(cmd), proc.returncode, out, err)
+    except subprocess.TimeoutExpired:
+        logger.warning("[BoundedSubprocess] %r exceeded %.2fs — reaping its "
+                       "process group", key, timeout)
+        if proc is not None:
+            _reap(proc)
+        _record_timeout(key)
+        return None
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        # A missing binary is a deterministic answer, not a hang: it must not
+        # count toward the breaker, or an uninstalled tool would look like a
+        # wedged one.
+        logger.debug("[BoundedSubprocess] %r unavailable: %s", key, exc)
+        if proc is not None:
+            _reap(proc)
+        return None
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[BoundedSubprocess] %r failed: %s", key, exc,
+                     exc_info=True)
+        if proc is not None:
+            _reap(proc)
+        return None

--- a/backend/core/experience_queue.py
+++ b/backend/core/experience_queue.py
@@ -872,8 +872,24 @@ class ExperienceQueueProcessor:
         if self.reactor_client is None:
             # Check via IPC
             try:
-                from backend.core.trinity_ipc import TrinityIPCBus
-                ipc = TrinityIPCBus()
+                # Constructed ONCE and cached. `TrinityIPCBus.__post_init__`
+                # mkdirs five directories, and this ran on every health check
+                # inside `_process_loop` — StallSampler caught the mkdir loop
+                # on the wedged main thread. Two defects, one line: repeated
+                # filesystem work, done on the event loop.
+                #
+                # The construction is also offloaded, because the FIRST one
+                # still touches the disk. Fail-open to inline so a missing
+                # helper cannot disable the health check.
+                ipc = getattr(self, "_trinity_ipc_bus", None)
+                if ipc is None:
+                    from backend.core.trinity_ipc import TrinityIPCBus
+                    try:
+                        from backend.core.async_offload import call_off_loop
+                        ipc = await call_off_loop(TrinityIPCBus)
+                    except Exception:  # noqa: BLE001
+                        ipc = TrinityIPCBus()
+                    self._trinity_ipc_bus = ipc
                 heartbeat = await ipc.read_heartbeat("reactor_core")
                 return heartbeat is not None and heartbeat.status == "ready"
             except Exception:

--- a/backend/core/ouroboros/governance/audit_ratchet.py
+++ b/backend/core/ouroboros/governance/audit_ratchet.py
@@ -361,7 +361,17 @@ async def run_registered_watchdogs() -> Dict[str, Drift]:
     """
     if not watchdogs_enabled():
         return {}
-    ratchets = registered_ratchets()
+    # `registered_ratchets` -> `prime_registry` -> `import_module` for every
+    # `*_repl` module in the package. StallSampler caught THIS call on the
+    # wedged main loop: a discovery walk is import work, and import work on
+    # the loop is a stall no `async def` around it can prevent. Offloaded to
+    # the house pool; fail-open to inline so a missing helper cannot silence
+    # every watchdog.
+    try:
+        from backend.core.async_offload import call_off_loop
+        ratchets = await call_off_loop(registered_ratchets)
+    except Exception:  # noqa: BLE001
+        ratchets = registered_ratchets()
     if not ratchets:
         return {}
     results = await asyncio.gather(

--- a/backend/core/parallel_initializer.py
+++ b/backend/core/parallel_initializer.py
@@ -2329,6 +2329,40 @@ class ParallelInitializer:
             logger.info("=" * 60)
 
             ai_manager = get_ai_manager()
+
+            # Warm engine discovery OFF the loop, once, before any
+            # `register_model` triggers it lazily.
+            #
+            # `OptimizationRouter.discover_engines` imports
+            # `voice_unlock.ml.quantized_models` and `safetensors.torch`
+            # (which pulls torch). It is correctly memoised — so it runs
+            # exactly once — but that once was happening inside
+            # `register_model` -> `select_engine`, ON the event loop:
+            # StallSampler caught `_probe_rust_engine` and `_probe_safetensors`
+            # on the wedged main thread. Paying it here, off-loop, leaves
+            # every later call hitting the cache.
+            try:
+                from backend.core.async_offload import call_off_loop
+                _router = getattr(ai_manager, "_router", None)
+                if _router is not None and hasattr(_router, "discover_engines"):
+                    await call_off_loop(_router.discover_engines)
+            except Exception as _warm_exc:  # noqa: BLE001 — never block boot
+                logger.debug(f"   engine discovery warm skipped: {_warm_exc}")
+
+            # Same treatment for the system voice catalogue. `say -v ?` is
+            # cached process-wide, but the FIRST call still shells out — and
+            # it was landing inside `RealtimeVoiceCommunicator.__init__`,
+            # constructed from a coroutine by `get_voice_communicator()`.
+            # StallSampler caught exactly that, as the last main-thread
+            # blocker of the boot. Paying it here, off-loop, means every
+            # constructor afterwards hits the cache.
+            try:
+                from backend.core.async_offload import call_off_loop
+                from backend.core.system_voices import voice_catalog_raw
+                await call_off_loop(voice_catalog_raw)
+            except Exception as _voice_exc:  # noqa: BLE001
+                logger.debug(f"   voice catalog warm skipped: {_voice_exc}")
+
             start_time = time.time()
 
             # =========================================================

--- a/backend/core/system_voices.py
+++ b/backend/core/system_voices.py
@@ -1,0 +1,111 @@
+"""`say -v ?` — asked once per process, bounded, never on the loop twice.
+
+TWO SUBSYSTEMS WERE ASKING THE SAME IMMUTABLE QUESTION
+------------------------------------------------------
+`realtime_voice_communicator._discover_voices` and
+`trinity_voice_coordinator._detect_best_voice` each ran
+`subprocess.run(['say', '-v', '?'])` — with 15s and 5s timeouts
+respectively — from their constructors. StallSampler caught BOTH on the
+wedged main loop; after the screen-context fixes landed they were the only
+two frames left.
+
+The installed voice list does not change during a process's life. Two
+subsystems shelling out for the same static answer is duplicated work whose
+cost is paid in event-loop latency, so the answer is fetched once and shared.
+
+WHY A RAW STRING AND NOT A PARSED MODEL
+----------------------------------------
+The two callers want different things from it: one builds a catalogue keyed
+by name, the other picks a single best voice. Parsing here would force both
+into a shape neither asked for and would put this module in the business of
+deciding what a "voice" is. It caches the bytes `say` produced; meaning stays
+with the caller.
+
+FAILURE IS A DISTINCT ANSWER FROM "NO VOICES"
+----------------------------------------------
+`None` means the query could not be answered — timed out, refused by the
+breaker, or `say` is absent (a Linux node). An empty string would say "this
+machine has no voices", which is a different claim and one that would make a
+caller fall back to a wrong default rather than to its own.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Optional
+
+logger = logging.getLogger("Jarvis.SystemVoices")
+
+SYSTEM_VOICES_SCHEMA_VERSION: str = "system_voices.1"
+
+__all__ = [
+    "SYSTEM_VOICES_SCHEMA_VERSION",
+    "reset_for_tests",
+    "voice_catalog_raw",
+]
+
+_lock = threading.Lock()
+_cached: Optional[str] = None
+_attempted = False
+
+
+def _timeout_s() -> float:
+    """``JARVIS_VOICE_CATALOG_TIMEOUT_S`` — default 3s.
+
+    Deliberately tighter than the 15s and 5s the two call sites carried.
+    `say -v ?` reads a local catalogue and returns in milliseconds; a
+    fifteen-second budget does not make a slow machine succeed, it makes a
+    wedged one expensive. The bound that matters is the reap, and
+    `run_bounded` owns that.
+    """
+    try:
+        return max(0.5, min(60.0, float(
+            (os.environ.get("JARVIS_VOICE_CATALOG_TIMEOUT_S") or "").strip()
+            or 3.0)))
+    except Exception:  # noqa: BLE001
+        return 3.0
+
+
+def voice_catalog_raw(force: bool = False) -> Optional[str]:
+    """The raw stdout of ``say -v ?``, cached per process. NEVER raises.
+
+    Returns None when the query could not be answered. A failure is cached
+    too: a machine without `say` will not grow one, and retrying per
+    constructor is how a missing binary turns into a recurring stall.
+    ``force=True`` re-asks (tests, and an operator who just installed a
+    voice).
+    """
+    global _cached, _attempted  # noqa: PLW0603
+    with _lock:
+        if _attempted and not force:
+            return _cached
+
+    result = None
+    try:
+        from backend.core.bounded_subprocess import run_bounded
+        completed = run_bounded(["say", "-v", "?"], timeout=_timeout_s(),
+                                text=True)
+        if completed is not None and completed.returncode == 0:
+            result = completed.stdout or ""
+        elif completed is None:
+            logger.debug("[SystemVoices] `say -v ?` unanswered "
+                         "(timeout, breaker, or absent)")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[SystemVoices] catalog query failed: %s", exc,
+                     exc_info=True)
+
+    with _lock:
+        _cached = result
+        _attempted = True
+    return result
+
+
+def reset_for_tests() -> None:
+    """Test-only."""
+    global _cached, _attempted  # noqa: PLW0603
+    with _lock:
+        _cached = None
+        _attempted = False

--- a/backend/core/trinity_voice_coordinator.py
+++ b/backend/core/trinity_voice_coordinator.py
@@ -2110,14 +2110,16 @@ class TrinityVoiceCoordinator:
 
         try:
             # v93.1: Increased timeout for heavily loaded systems
-            voice_timeout = float(os.getenv("JARVIS_VOICE_DETECT_TIMEOUT", "5.0"))
+            # Shared cached catalogue — see `core.system_voices`. This was
+            # the second of two subsystems shelling out for the same static
+            # list, both caught blocking the event loop.
+            from backend.core.system_voices import voice_catalog_raw
+            _catalog = voice_catalog_raw()
 
-            result = subprocess.run(
-                ["say", "-v", "?"],
-                capture_output=True,
-                text=True,
-                timeout=voice_timeout
-            )
+            class _R:                      # keep the parsing below unchanged
+                returncode = 0 if _catalog is not None else 1
+                stdout = _catalog or ""
+            result = _R()
 
             if result.returncode == 0:
                 voices = result.stdout.strip().split('\n')

--- a/backend/vision/yabai_space_detector.py
+++ b/backend/vision/yabai_space_detector.py
@@ -4306,12 +4306,16 @@ class YabaiSpaceDetector:
 
         try:
             # Quick query to verify yabai is responding
-            result = subprocess.run(
+            # Bounded + breaker: this runs on a POOL worker now, and a
+            # `yabai` blocked on a dead scripting-addition socket would hold
+            # that worker forever. The group is reaped on timeout, and a
+            # repeatedly-hanging binary is refused rather than retried.
+            from backend.core.bounded_subprocess import run_bounded
+            result = run_bounded(
                 [self._health.yabai_path, "-m", "query", "--spaces"],
-                capture_output=True,
-                text=True,
-                timeout=3,
-            )
+                timeout=3.0, text=True)
+            if result is None:
+                return False
             return result.returncode == 0 and "failed to connect" not in result.stderr.lower()
         except Exception:
             return False

--- a/tests/autonomy/test_uae_context_offload.py
+++ b/tests/autonomy/test_uae_context_offload.py
@@ -77,19 +77,33 @@ class TestBlockingWorkLeavesTheLoop:
             assert await uae._off_loop(_boom) is None
         assert any("failed" in r.message for r in caplog.records)
 
-    async def test_cancellation_is_propagated_not_swallowed(self):
-        """Swallowing CancelledError is how a task becomes unkillable."""
-        started = asyncio.Event()
+    async def test_cancellation_is_not_swallowed_by_the_wrapper(self, monkeypatch):
+        """Swallowing CancelledError is how a task becomes unkillable.
 
-        def _slow():
-            started.set()
-            time.sleep(2)
+        Asserted against OUR wrapper, not against thread-pool semantics: a
+        `run_in_executor` future whose work has already begun cannot be
+        cancelled, so a test that races the worker measures scheduling luck
+        rather than the contract. What is ours to guarantee is that
+        `_off_loop` re-raises CancelledError instead of folding it into the
+        `except Exception -> None` path that every other failure takes.
+        """
+        async def _cancelled(*_a, **_k):
+            raise asyncio.CancelledError()
 
-        task = asyncio.create_task(uae._off_loop(_slow))
-        await asyncio.wait_for(started.wait(), timeout=2)
-        task.cancel()
+        monkeypatch.setattr(
+            "backend.core.async_offload.call_off_loop", _cancelled)
         with pytest.raises(asyncio.CancelledError):
-            await task
+            await uae._off_loop(lambda: "never reached")
+
+    async def test_an_ordinary_error_is_still_absorbed(self, monkeypatch):
+        """The other half of the same contract: everything that is NOT a
+        cancellation becomes None, so a failed probe cannot kill the loop."""
+        async def _boom(*_a, **_k):
+            raise RuntimeError("worker exploded")
+
+        monkeypatch.setattr(
+            "backend.core.async_offload.call_off_loop", _boom)
+        assert await uae._off_loop(lambda: "x") is None
 
     async def test_it_degrades_to_inline_rather_than_failing(self, monkeypatch):
         """Fail-open: a missing offload helper must not break context
@@ -136,12 +150,12 @@ class TestTheScreenshotBodyIsOneUnitOfWork:
                             __import__("tempfile"), "NamedTemporaryFile",
                             lambda **k: _TmpFile())
 
-        def _explode(*a, **k):
-            raise RuntimeError("screencapture missing")
-
-        monkeypatch.setattr(__import__("subprocess"), "run", _explode)
-        with pytest.raises(RuntimeError):
-            uae.UAEContextManager._capture_screenshot_blocking()
+        # After the breaker landed, a failed capture no longer raises — it
+        # returns None (timed out, refused, or binary missing). The temp file
+        # must still be gone, which is the whole point of the `finally`.
+        import backend.core.bounded_subprocess as bsp
+        monkeypatch.setattr(bsp, "run_bounded", lambda *a, **k: None)
+        assert uae.UAEContextManager._capture_screenshot_blocking() == (None, "")
         import os
         assert not os.path.exists(seen["path"]), "temp PNG leaked"
 

--- a/tests/core/test_bounded_subprocess.py
+++ b/tests/core/test_bounded_subprocess.py
@@ -1,0 +1,226 @@
+"""An external binary may cost us time. It may never cost us a thread.
+
+Offloading `osascript` and `screencapture` off the event loop fixed the
+stalls and opened a worse failure mode: the blocking call now happens on a
+POOL worker, so the loop keeps breathing while a wedged binary holds that
+worker forever. A stall is visible; a leaked worker is not.
+
+The load-bearing case is `test_a_surviving_grandchild_cannot_capture_the_worker`:
+`subprocess.run(timeout=...)` kills the direct child and then reaps it — but
+`_get_cursor_position` runs an `osascript` whose script spawns a python
+interpreter, and that grandchild holds the inherited pipe open, so the
+post-kill wait blocks on a pipe that never closes.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from backend.core import bounded_subprocess as bs
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    bs.reset_for_tests()
+    monkeypatch.delenv("JARVIS_SUBPROC_BREAKER_TRIPS", raising=False)
+    monkeypatch.delenv("JARVIS_SUBPROC_BREAKER_COOLDOWN_S", raising=False)
+    yield
+    bs.reset_for_tests()
+
+
+class TestItReturnsRealResults:
+    def test_a_normal_command_comes_back(self):
+        r = bs.run_bounded([sys.executable, "-c", "print('hi')"],
+                           timeout=10, text=True)
+        assert r is not None and r.returncode == 0
+        assert "hi" in r.stdout
+
+    def test_a_nonzero_exit_is_a_result_not_a_failure(self):
+        r = bs.run_bounded([sys.executable, "-c", "raise SystemExit(3)"],
+                           timeout=10)
+        assert r is not None and r.returncode == 3
+
+    def test_a_missing_binary_is_None_and_does_NOT_trip_the_breaker(self):
+        """A binary that is not installed answers deterministically. Counting
+        it as a hang would make an uninstalled tool look like a wedged one."""
+        for _ in range(5):
+            assert bs.run_bounded(["definitely-not-a-real-binary-xyz"],
+                                  timeout=2) is None
+        assert bs.breaker_state()["open"] == []
+
+
+class TestATimeoutNeverHoldsTheWorker:
+    def test_a_hanging_command_returns_within_its_budget(self):
+        t0 = time.monotonic()
+        assert bs.run_bounded([sys.executable, "-c",
+                               "import time; time.sleep(30)"],
+                              timeout=0.5) is None
+        elapsed = time.monotonic() - t0
+        assert elapsed < 5, f"took {elapsed:.1f}s — the worker was held"
+
+    def test_a_surviving_grandchild_cannot_capture_the_worker(self):
+        """THE case `subprocess.run(timeout=...)` does not cover.
+
+        The child spawns a grandchild that outlives it and inherits the
+        pipe. Killing only the child leaves the post-kill reap blocking on a
+        pipe nothing will close. Signalling the process GROUP is what makes
+        this return.
+        """
+        script = (
+            "import subprocess, sys, time; "
+            # grandchild holds the inherited stdout pipe open, then sleeps
+            "subprocess.Popen([sys.executable, '-c', "
+            "'import time; time.sleep(30)']); "
+            "time.sleep(30)"
+        )
+        t0 = time.monotonic()
+        assert bs.run_bounded([sys.executable, "-c", script],
+                              timeout=0.5) is None
+        elapsed = time.monotonic() - t0
+        assert elapsed < 8, (
+            f"took {elapsed:.1f}s — a grandchild held the worker hostage")
+
+    def test_the_process_group_is_actually_dead_afterwards(self):
+        """Not merely 'we stopped waiting' — the tree is reaped, or the next
+        call inherits a machine full of zombies."""
+        marker = "bounded-subprocess-reap-probe"
+        script = f"import time; time.sleep(30)  # {marker}"
+        assert bs.run_bounded([sys.executable, "-c", script],
+                              timeout=0.5) is None
+        time.sleep(0.4)
+        out = subprocess.run(["ps", "-eo", "command"], capture_output=True,
+                             text=True, timeout=10).stdout
+        assert marker not in out, "the child survived the reap"
+
+
+class TestTheCircuitBreaker:
+    def test_it_opens_after_repeated_timeouts_and_then_refuses_instantly(
+            self, monkeypatch):
+        """A binary wedged on a revoked TCC permission does not heal because
+        we retried. Refusing costs no worker at all."""
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_TRIPS", "2")
+        cmd = [sys.executable, "-c", "import time; time.sleep(30)"]
+        for _ in range(2):
+            assert bs.run_bounded(cmd, timeout=0.3) is None
+        assert bs.breaker_open(cmd) is True
+
+        t0 = time.monotonic()
+        assert bs.run_bounded(cmd, timeout=5) is None
+        assert time.monotonic() - t0 < 0.2, "a refusal must not spawn anything"
+
+    def test_a_success_closes_it(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_TRIPS", "2")
+        hang = [sys.executable, "-c", "import time; time.sleep(30)"]
+        bs.run_bounded(hang, timeout=0.3)
+        assert bs.breaker_state()["consecutive_failures"]
+        bs.run_bounded([sys.executable, "-c", "print(1)"], timeout=10)
+        assert not bs.breaker_state()["consecutive_failures"]
+
+    def test_the_cooldown_lets_exactly_one_probe_through(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_TRIPS", "1")
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_COOLDOWN_S", "1")
+        cmd = [sys.executable, "-c", "import time; time.sleep(30)"]
+        bs.run_bounded(cmd, timeout=0.3)
+        assert bs.breaker_open(cmd) is True
+        time.sleep(1.1)
+        assert bs.breaker_open(cmd) is False, "cooldown must allow a retry"
+
+    def test_the_key_is_the_command_not_the_arguments(self):
+        """`screencapture` hanging on a consent prompt hangs for EVERY temp
+        path. Keying on the full argv would open a fresh breaker per call and
+        never trip."""
+        a = ["screencapture", "-x", "-t", "png", "/tmp/one.png"]
+        b = ["screencapture", "-x", "-t", "png", "/tmp/two.png"]
+        assert bs._key(a) == bs._key(b) == "screencapture"
+        # And NOT a guessed sub-verb: a flag and a sub-verb are not
+        # distinguishable by shape, so the key is the binary alone.
+        assert bs._key(["yabai", "-m", "query"]) == "yabai"
+        assert bs._key(["/usr/sbin/screencapture", "-x"]) == "screencapture"
+
+    def test_state_is_a_bounded_projection(self):
+        st = bs.breaker_state()
+        assert st["schema_version"].startswith("bounded_subprocess")
+        assert set(st) >= {"consecutive_failures", "open", "trips_to_open"}
+
+
+class TestItNeverRaises:
+    @pytest.mark.parametrize("cmd", [[], ["/"], ["", ""]])
+    def test_hostile_commands_return_None(self, cmd):
+        assert bs.run_bounded(cmd, timeout=1) is None
+
+    def test_breaker_helpers_never_raise(self):
+        assert bs.breaker_open([]) in (True, False)
+        assert isinstance(bs.breaker_state(), dict)
+
+
+class TestTheSharedVoiceCatalog:
+    """Two subsystems were each running `say -v ?` — 15s and 5s timeouts —
+    from their constructors, for the same immutable list. Both were caught on
+    the wedged main loop; after the screen-context fixes they were the only
+    two frames left."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh(self):
+        from backend.core import system_voices as sv
+        sv.reset_for_tests()
+        yield
+        sv.reset_for_tests()
+
+    def test_the_query_runs_once_and_is_shared(self, monkeypatch):
+        from backend.core import system_voices as sv
+        calls = {"n": 0}
+
+        def _fake(cmd, **kw):
+            calls["n"] += 1
+            return subprocess.CompletedProcess(cmd, 0, "Alex  en_US\n", "")
+
+        monkeypatch.setattr(bs, "run_bounded", _fake)
+        assert "Alex" in sv.voice_catalog_raw()
+        assert "Alex" in sv.voice_catalog_raw()
+        assert calls["n"] == 1, "the second caller must hit the cache"
+
+    def test_an_unanswered_query_is_None_not_empty(self, monkeypatch):
+        """None = 'could not ask'. '' would claim the machine has no voices,
+        which sends a caller to a wrong default instead of its own."""
+        from backend.core import system_voices as sv
+        monkeypatch.setattr(bs, "run_bounded", lambda *a, **k: None)
+        assert sv.voice_catalog_raw() is None
+
+    def test_a_failure_is_cached_too(self, monkeypatch):
+        """A machine without `say` will not grow one. Retrying per
+        constructor is how a missing binary becomes a recurring stall."""
+        from backend.core import system_voices as sv
+        calls = {"n": 0}
+
+        def _absent(*a, **k):
+            calls["n"] += 1
+            return None
+
+        monkeypatch.setattr(bs, "run_bounded", _absent)
+        sv.voice_catalog_raw()
+        sv.voice_catalog_raw()
+        assert calls["n"] == 1
+
+    def test_force_reasks(self, monkeypatch):
+        from backend.core import system_voices as sv
+        calls = {"n": 0}
+
+        def _fake(cmd, **kw):
+            calls["n"] += 1
+            return subprocess.CompletedProcess(cmd, 0, "Alex\n", "")
+
+        monkeypatch.setattr(bs, "run_bounded", _fake)
+        sv.voice_catalog_raw()
+        sv.voice_catalog_raw(force=True)
+        assert calls["n"] == 2
+
+    def test_the_timeout_is_seconds_not_a_fifteen_second_budget(self):
+        """`say -v ?` reads a local catalogue in milliseconds. A 15s budget
+        does not make a slow machine succeed; it makes a wedged one
+        expensive."""
+        from backend.core import system_voices as sv
+        assert sv._timeout_s() <= 5.0

--- a/unified_supervisor.py
+++ b/unified_supervisor.py
@@ -56528,8 +56528,19 @@ class HotReloadWatcher:
         if self.verbose:
             self.logger.info(self._type_registry.get_summary())
 
-        # Initialize file hashes
-        self._file_hashes = self._calculate_file_hashes_parallel()
+        # Initialize file hashes — OFF the loop.
+        #
+        # The monitor-loop twin of this call was offloaded first; StallSampler
+        # then caught THIS one, the initial baseline, as the last main-thread
+        # blocker of the boot. Same shape: a ThreadPoolExecutor fan-out whose
+        # `submit`/`as_completed` wait runs on the loop thread while every
+        # watched file is hashed.
+        try:
+            from backend.core.async_offload import call_off_loop
+            self._file_hashes = await call_off_loop(
+                self._calculate_file_hashes_parallel)
+        except Exception:  # noqa: BLE001 — fail-open to inline
+            self._file_hashes = self._calculate_file_hashes_parallel()
 
         # Count files by category
         backend_count = 0
@@ -56604,8 +56615,24 @@ class HotReloadWatcher:
                 if self._is_in_grace_period():
                     continue
 
-                # Check for changes
-                has_changes, changed_files, categorized = self._detect_changes()
+                # Check for changes — OFF the loop.
+                #
+                # `_detect_changes` -> `_calculate_file_hashes_parallel`
+                # blocks in `concurrent.futures.as_completed` while a pool
+                # hashes every watched file. Being inside a coroutine does
+                # not help: the loop thread sits in `threading.wait` for the
+                # whole fan-out. StallSampler caught this on the wedged main
+                # thread in 4 of 6 dumps once the screen-context and voice
+                # blockers were removed — it is the dominant remaining one,
+                # and it recurs every `check_interval`.
+                #
+                # The inner pool is untouched; only the WAIT moves.
+                try:
+                    from backend.core.async_offload import call_off_loop
+                    has_changes, changed_files, categorized = (
+                        await call_off_loop(self._detect_changes))
+                except Exception:  # noqa: BLE001 — fail-open to inline
+                    has_changes, changed_files, categorized = self._detect_changes()
 
                 if has_changes:
                     # Log changes by category


### PR DESCRIPTION
## Phase 1 — the boot stalls, found by stack not by guess

Every culprit came from a StallSampler dump taken while the loop was provably wedged. `import_off_loop` could not be applied *inside* the named functions — all three are **sync** — so the offload goes at the async boundary that reaches them, which is the same module's correct primitive for that shape.

| blocker | what it was doing on the loop |
|---|---|
| `audit_ratchet.run_registered_watchdogs` | `registered_ratchets` → `prime_registry` → `import_module` per `*_repl` — **my own sweep from this session** |
| `experience_queue._check_reactor_health` | rebuilt `TrinityIPCBus` **every** health check in `_process_loop`; its `__post_init__` mkdirs five dirs. Now built once, cached, off-loop |
| `parallel_initializer._init_optimized_voice_models` | → `register_model` → `select_engine` → `discover_engines`, importing `safetensors.torch`. Memoised, so it runs once — but that once was on the loop. Warmed off-loop instead |
| hot-reload `_monitor_loop` **and** `start()` | `_calculate_file_hashes_parallel` blocks in `as_completed` while a pool hashes every watched file. The pool is untouched; only the **wait** moved |
| `say -v ?` | run by **two** subsystems (15 s and 5 s timeouts) for the same immutable list → one cached bounded query in `core.system_voices`, warmed at boot |

## Phase 2 — the blind spot offloading created

Moving `osascript`/`screencapture` off the loop made a wedged binary hold a **pool worker** instead — invisible, and strictly worse than the stall it replaced.

`core.bounded_subprocess.run_bounded` is the answer, and it is not `subprocess.run(timeout=…)`:

- `_get_cursor_position` runs an `osascript` that **itself spawns a python interpreter**. SIGKILL to the osascript leaves the grandchild holding the inherited pipe, so the post-kill `communicate()` blocks on a pipe that never closes — capturing the worker anyway. The child now starts in its **own session** and the whole **group** is signalled, TERM then KILL.
- The reap is bounded; if the tree still won't die the pipes are abandoned. A leaked fd is survivable, a captured worker is not.
- A **circuit breaker** refuses a command after N consecutive timeouts — a revoked TCC permission does not heal because we retried. Keyed on the **binary**: the first version keyed `binary + argv[1]`, and its own test caught that reading `screencapture -x -t png <path>` as `screencapture -x`. A flag and a sub-verb are not distinguishable by shape.
- A missing binary is deterministic, not a hang, and never counts toward the breaker.

## Measured, comparable windows, same machine

| | before | after |
|---|---|---|
| main-thread stall dumps | 18 | **3** (none recurring) |
| worst stall (windowed) | 3.69 s | **2.70 s** (all-time high was 32.31 s) |
| every frame named above | present | **gone from the dumps** |

## Not proven, and I will not claim it

The boot is **not** "completely clean of stalls": 32 short stalls remain in a 3,845-line window, almost all below the sampler's dump threshold. The three dumps that did fire are three *different* one-off frames (a package import, a heartbeat validator, a supervisor init), not a recurring blocker. The dominant repeating culprits are eliminated; a long tail of first-import costs is not.

38 tests — 20 for the breaker (including a grandchild-survives-the-kill case and a process-group-actually-dead assertion), 10 for the offload contract, 8 for the shared voice catalogue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates recurring boot stalls by offloading sync work from the event loop and ensures OS binaries cannot capture worker threads. Previously, imports, file‑hash waits, and `say`/`osascript`/`screencapture` could wedge the loop or leak pool workers; now these calls run off‑loop, are bounded with process‑group reaping, and repeated hangs are refused by a per‑binary circuit breaker.

- Adds `backend/core/bounded_subprocess.py`: `run_bounded(cmd, timeout, text=False)` runs the child in its own session, signals the process group (TERM→KILL), bounds the reap, and returns `None` on timeout/refusal/missing binary; breaker keyed by binary with `JARVIS_SUBPROC_BREAKER_TRIPS` and `JARVIS_SUBPROC_BREAKER_COOLDOWN_S`.
- Replaces direct `subprocess.run` in `backend/autonomy/uae_context_manager.py` (`osascript`, `screencapture`) and `backend/vision/yabai_space_detector.py` with `run_bounded`; screenshot capture now returns `(None, "")` on timeout/refusal/missing instead of raising.
- Adds `backend/core/system_voices.py`: single cached `say -v ?` via `voice_catalog_raw()` with `JARVIS_VOICE_CATALOG_TIMEOUT_S`; consumed by `backend/agi_os/realtime_voice_communicator.py` and `backend/core/trinity_voice_coordinator.py`; warmed in `backend/core/parallel_initializer.py`.
- Offloads remaining boot blockers at async boundaries: cache and offload `TrinityIPCBus` construction in `backend/core/experience_queue.py`; offload `registered_ratchets()` in `backend/core/ouroboros/governance/audit_ratchet.py`; warm engine discovery off‑loop in `backend/core/parallel_initializer.py`; move waits for `_calculate_file_hashes_parallel` off the loop in `unified_supervisor.py` for both `start()` and `_monitor_loop` (inner pool unchanged).
- Adds `tests/core/test_bounded_subprocess.py`; updates `tests/autonomy/test_uae_context_offload.py` to reflect non‑raising screenshot behavior and cancellation contract.

**Review and rollout**
- No required config changes. Optional tuning: `JARVIS_SUBPROC_BREAKER_TRIPS` (default 3), `JARVIS_SUBPROC_BREAKER_COOLDOWN_S` (default 300s), `JARVIS_SUBPROC_REAP_GRACE_S`, `JARVIS_SUBPROC_REAP_BUDGET_S`, `JARVIS_VOICE_CATALOG_TIMEOUT_S` (default 3s).
- If any external code relied on `_capture_screenshot_blocking` raising, handle a `None` image instead. Logs include breaker openings; `breaker_state()` exposes a bounded status projection.

<sup>Written for commit 532945b182b514ffdae14d1eb9e6fc372f86d772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

