### PR TITLE
feat(loop): pre-warm the import graph; make the breaker speak

### DIFF
--- a/backend/core/bounded_subprocess.py
+++ b/backend/core/bounded_subprocess.py
@@ -47,13 +47,15 @@ Python 3.9+, ``from __future__ import annotations``.
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 import signal
 import subprocess
 import threading
 import time
-from typing import Any, Dict, Optional, Sequence
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 logger = logging.getLogger("Jarvis.BoundedSubprocess")
 
@@ -61,8 +63,10 @@ BOUNDED_SUBPROCESS_SCHEMA_VERSION: str = "bounded_subprocess.1"
 
 __all__ = [
     "BOUNDED_SUBPROCESS_SCHEMA_VERSION",
+    "breaker_ledger_path",
     "breaker_open",
     "breaker_state",
+    "open_breakers_on_disk",
     "reset_for_tests",
     "run_bounded",
 ]
@@ -139,21 +143,130 @@ def _key(cmd: Sequence[str]) -> str:
         return "?"
 
 
+
+# ---------------------------------------------------------------------------
+# Durable export — the breaker must be visible from ANOTHER process
+# ---------------------------------------------------------------------------
+#
+# A tripped breaker that only exists in the daemon's memory is invisible to
+# `trinity status`, which runs in its own CLI process. A revoked macOS
+# Screen-Recording permission would then present as "everything fine, the
+# screenshots merely stopped" — the silent failure this whole arc exists to
+# end. So a trip is written where any process can read it, and cleared the
+# moment the command succeeds again.
+
+
+def breaker_ledger_path() -> Path:
+    """Where open breakers are recorded. ``JARVIS_SUBPROC_BREAKER_LEDGER``,
+    else beside the other `.jarvis/` state."""
+    raw = (os.environ.get("JARVIS_SUBPROC_BREAKER_LEDGER") or "").strip()
+    if raw:
+        return Path(raw)
+    root = Path(os.environ.get("JARVIS_PROJECT_ROOT") or ".")
+    return root / ".jarvis" / "subprocess_breakers.json"
+
+
+def _write_ledger() -> None:
+    """Persist the open set. NEVER raises — telemetry may not break a probe."""
+    try:
+        path = breaker_ledger_path()
+        with _lock:
+            payload = {
+                "schema_version": BOUNDED_SUBPROCESS_SCHEMA_VERSION,
+                "open": {k: {"opened_at_monotonic": v,
+                             "consecutive_failures": _fails.get(k, 0)}
+                         for k, v in _opened_at.items()},
+                "updated_at": time.time(),
+                "pid": os.getpid(),
+                "cooldown_s": _breaker_cooldown_s(),
+            }
+        if not payload["open"]:
+            # An empty ledger is REMOVED rather than written empty: a stale
+            # file full of `{}` and an actually-healthy system should not be
+            # distinguishable only by reading a timestamp.
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(payload, indent=2, sort_keys=True),
+                       encoding="utf-8")
+        os.replace(tmp, path)
+    except Exception:  # noqa: BLE001
+        logger.debug("[BoundedSubprocess] ledger write skipped", exc_info=True)
+
+
+def open_breakers_on_disk(path: Optional[Path] = None) -> Tuple[str, ...]:
+    """Commands currently refused, as recorded by ANY process. NEVER raises.
+
+    Read by `trinity status` so a tripped breaker in the daemon shows up on
+    the operator's screen instead of only in that daemon's memory. A ledger
+    older than the cooldown is ignored: the breaker would have re-probed by
+    now, and reporting a stale trip is its own kind of lie.
+    """
+    try:
+        p = path or breaker_ledger_path()
+        raw = json.loads(p.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            return ()
+        age = time.time() - float(raw.get("updated_at") or 0)
+        if age > float(raw.get("cooldown_s") or _breaker_cooldown_s()) * 2:
+            return ()
+        return tuple(sorted(raw.get("open") or ()))
+    except Exception:  # noqa: BLE001 — absent / malformed == nothing open
+        return ()
+
+
+
+_hydrated = False
+
+
+def _hydrate_from_ledger() -> None:
+    """Adopt trips recorded by a PREVIOUS process, once. NEVER raises.
+
+    Found by testing recovery rather than by reading code: a success in a
+    fresh process could not clear an on-disk trip, because `_record_success`
+    only rewrote the ledger when the key was open in THIS process's memory —
+    and a new process has none.
+
+    Hydrating fixes both directions, and the second is the more valuable: a
+    daemon that restarts while a binary is still wedged should honour the
+    cooldown it already earned instead of spending a worker rediscovering
+    it. The staleness rule in `open_breakers_on_disk` still applies, so an
+    ancient ledger is ignored rather than inherited.
+    """
+    global _hydrated  # noqa: PLW0603
+    if _hydrated:
+        return
+    _hydrated = True
+    try:
+        for key in open_breakers_on_disk():
+            with _lock:
+                _opened_at.setdefault(key, time.monotonic())
+                _fails.setdefault(key, _breaker_trips())
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def breaker_open(cmd: Sequence[str]) -> bool:
     """Is this command currently refused? NEVER raises."""
     try:
+        _hydrate_from_ledger()
         key = _key(cmd)
         with _lock:
             opened = _opened_at.get(key)
             if opened is None:
                 return False
-            if (time.monotonic() - opened) >= _breaker_cooldown_s():
-                # Cooldown elapsed — allow ONE probe through. The counter is
-                # left as-is so a still-wedged binary re-opens immediately
-                # instead of earning a fresh budget of retries.
-                _opened_at.pop(key, None)
-                return False
-            return True
+            # Cooldown elapsed -> allow a probe through, but do NOT clear the
+            # state here. This function is a QUESTION, and it used to answer
+            # by mutating: it popped `_opened_at`, so the success that
+            # followed found nothing open and never cleared the on-disk
+            # ledger — the breaker recovered in memory and stayed tripped on
+            # the operator's screen forever. Only an OUTCOME
+            # (`_record_success` / `_record_timeout`) changes state now.
+            return (time.monotonic() - opened) < _breaker_cooldown_s()
     except Exception:  # noqa: BLE001
         return False
 
@@ -171,26 +284,39 @@ def breaker_state() -> Dict[str, Any]:
 
 
 def reset_for_tests() -> None:
+    global _hydrated  # noqa: PLW0603
+    _hydrated = True                 # tests own their state; never adopt disk
     with _lock:
         _fails.clear()
         _opened_at.clear()
 
 
 def _record_success(key: str) -> None:
+    _hydrate_from_ledger()
+    reopened = False
     with _lock:
         _fails.pop(key, None)
-        _opened_at.pop(key, None)
+        reopened = _opened_at.pop(key, None) is not None
+    if reopened:
+        _write_ledger()
 
 
 def _record_timeout(key: str) -> None:
+    newly_open = False
     with _lock:
         _fails[key] = _fails.get(key, 0) + 1
         if _fails[key] >= _breaker_trips() and key not in _opened_at:
             _opened_at[key] = time.monotonic()
-            logger.warning(
-                "[BoundedSubprocess] breaker OPEN for %r after %d consecutive "
-                "timeouts — refusing it for %.0fs rather than spending "
-                "another worker on it", key, _fails[key], _breaker_cooldown_s())
+            newly_open = True
+            failures = _fails[key]
+    if newly_open:
+        logger.warning(
+            "[BoundedSubprocess] breaker OPEN for %r after %d consecutive "
+            "timeouts — refusing it for %.0fs rather than spending another "
+            "worker on it", key, failures, _breaker_cooldown_s())
+        # Written OUTSIDE the lock: the ledger touches the filesystem, and a
+        # disk hiccup must not hold the lock every probe contends for.
+        _write_ledger()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/core/coding_council/trinity/heartbeat_validator.py
+++ b/backend/core/coding_council/trinity/heartbeat_validator.py
@@ -796,7 +796,19 @@ class HeartbeatValidator:
         """
         try:
             if filepath.exists():
-                data = json.loads(filepath.read_text())
+                # `exists()` + `read_text()` + `json.loads()` per heartbeat
+                # file, every monitor tick. StallSampler caught this on the
+                # wedged main loop: a handful of small reads is nothing until
+                # the disk is busy, and then the loop wears the latency of
+                # every one of them. The parse rides along because splitting
+                # it would leave the JSON decode — CPU over the file — on the
+                # loop for no gain.
+                try:
+                    from backend.core.async_offload import call_off_loop
+                    data = await call_off_loop(
+                        lambda: json.loads(filepath.read_text()))
+                except Exception:  # noqa: BLE001 — fail-open to inline
+                    data = json.loads(filepath.read_text())
                 heartbeat = Heartbeat.from_dict(data)
 
                 health = ComponentHealth(

--- a/backend/core/ouroboros/cli/trinity_status.py
+++ b/backend/core/ouroboros/cli/trinity_status.py
@@ -429,6 +429,15 @@ class DaemonSpec:
     #: an operator at the supervisor's error log to debug the engine is worse
     #: than saying nothing.
     log_hint: Callable[[], str] = lambda: ""
+    #: Facts that degrade a daemon WITHOUT being a transport probe — e.g. a
+    #: tripped subprocess circuit breaker. Returns short reason codes.
+    #:
+    #: A daemon answering on every socket while its screen capture has been
+    #: refused for ten minutes is not HEALTHY, and calling it healthy is the
+    #: silent-failure mode the breaker was built to end. Folded into the SAME
+    #: verdict rather than reported beside it, so there is one answer per
+    #: daemon and no second health path to keep in step.
+    conditions: Callable[[], Tuple[str, ...]] = lambda: ()
 
 
 @dataclass(frozen=True)
@@ -440,6 +449,8 @@ class DaemonHealth:
     transports: Mapping[str, str] = field(default_factory=dict)
     detail: str = ""
     recommendation: str = ""
+    #: Non-transport faults, as short reason codes (e.g. CIRCUIT_OPEN:...).
+    conditions: Tuple[str, ...] = ()
 
     @property
     def ok(self) -> bool:
@@ -467,6 +478,34 @@ class FleetHealth:
         return None
 
 
+
+def subprocess_breaker_conditions() -> Tuple[str, ...]:
+    """Open subprocess circuit breakers, as operator-facing reason codes.
+
+    Read from the DURABLE ledger, not from memory: the breaker trips inside
+    the daemon and this runs in the status CLI's own process, so in-memory
+    state would always read empty here — the failure would be invisible
+    precisely where an operator goes to look for it.
+
+    `screencapture` and `osascript` are the TCC-governed pair, so a trip on
+    either is reported as `TCC_BLOCKED` — that is what it means on macOS
+    nine times out of ten, and it names the fix (Screen Recording /
+    Automation permission) instead of making the operator infer it.
+    """
+    try:
+        from backend.core.bounded_subprocess import open_breakers_on_disk
+        out = []
+        for cmd in open_breakers_on_disk():
+            if cmd in ("screencapture", "osascript"):
+                out.append(f"TCC_BLOCKED:{cmd} (grant Screen Recording / "
+                           f"Automation, or it stays refused)")
+            else:
+                out.append(f"CIRCUIT_OPEN:{cmd}")
+        return tuple(out)
+    except Exception:  # noqa: BLE001
+        return ()
+
+
 def default_fleet() -> Tuple[DaemonSpec, ...]:
     """The two daemons this repo runs. Every address resolved dynamically."""
     return (
@@ -480,6 +519,7 @@ def default_fleet() -> Tuple[DaemonSpec, ...]:
             ),
             absent_hint="start it with `trinity up`",
             log_hint=lambda: f"tail {_err_log()}",
+            conditions=subprocess_breaker_conditions,
         ),
         DaemonSpec(
             name="ov",
@@ -601,6 +641,15 @@ async def assess_daemon(spec: DaemonSpec, *,
     required = {t.label: states.get(t.label, "error")
                 for t in spec.transports if not t.optional}
     state = classify(pid is not None, required or states)
+    try:
+        conditions = tuple(spec.conditions() or ())
+    except Exception:  # noqa: BLE001
+        conditions = ()
+    # A live daemon with an open breaker is DEGRADED, never HEALTHY. A daemon
+    # that is DOWN or already faulted keeps its verdict: a tripped breaker
+    # inside a process that is not running is not the operator's problem.
+    if conditions and state is Health.HEALTHY:
+        state = Health.DEGRADED
     shown = ", ".join(
         f"{k}={v}" + ("*" if any(t.label == k and t.optional
                                  for t in spec.transports) else "")
@@ -618,9 +667,17 @@ async def assess_daemon(spec: DaemonSpec, *,
     else:
         detail = f"pid {pid} live; {shown}" if pid else f"live; {shown}"
         rec = ""
+
+    # Conditions are APPENDED, not branched on. The verdict above may already
+    # be DEGRADED *because* of them, and an `elif` here would be unreachable
+    # exactly when it mattered — the operator would read "partial readiness"
+    # with no hint that a permission was revoked.
+    if conditions:
+        detail = f"{detail} — but {', '.join(conditions)}"
+        rec = rec or _hint(spec)
     return DaemonHealth(name=spec.name, title=spec.title, state=state,
                         pid=pid, transports=states, detail=detail,
-                        recommendation=rec)
+                        recommendation=rec, conditions=conditions)
 
 
 async def assess_fleet(specs: Optional[Tuple[DaemonSpec, ...]] = None, *,
@@ -686,6 +743,7 @@ __all__ = [
     "DaemonHealth", "DaemonSpec", "FleetHealth", "Health", "HealthReport",
     "Transport", "active_health_handshake", "assess_daemon", "assess_fleet",
     "classify", "default_fleet", "engine_endpoint", "engine_pid",
+    "subprocess_breaker_conditions",
     "engine_socket", "fleet_deadline_s", "fleet_probe_timeout_s",
     "status_main", "supervisor_endpoint", "supervisor_pid",
 ]

--- a/backend/core/prewarm.py
+++ b/backend/core/prewarm.py
@@ -1,0 +1,171 @@
+"""Pay the first-import tax before anything is waiting on it.
+
+WHY A PRE-WARM AND NOT MORE OFFLOADING
+--------------------------------------
+The recurring loop blockers were fixed by moving work off the loop. What
+remained was a different shape: the FIRST import of a module, executed
+wherever the loop happened to reach it. Offloading each of those means
+finding every async boundary that might touch a heavy module — whack-a-mole
+against an import graph that changes every week.
+
+An import is paid once per process. So it is paid HERE, early, on a worker,
+and every later touch is a `sys.modules` hit no matter which coroutine gets
+there first. The downstream code is not changed at all, which is the point:
+nothing has to remember this exists.
+
+WHY ONE WORKER AND NOT A POOL
+------------------------------
+`async_offload.import_off_loop` funnels every deferred import through a
+SINGLE worker, and its docstring records why in measured detail: CPython
+takes a per-module lock, so N threads importing a shared dependency graph
+serialize on those locks anyway — with the loop thread queued in among them.
+That is how ~2s of work became a 12.38s wedge. Warming in parallel would
+recreate exactly that. This dispatches sequentially through the existing
+primitive; nothing new is invented here.
+
+THE LIST IS EVIDENCE, NOT INTUITION
+------------------------------------
+Every default below came from a StallSampler dump taken while the loop was
+provably wedged. Two candidates that look obvious are deliberately ABSENT:
+
+* ``Quartz`` — never imported in this process. The cursor probe runs an
+  `osascript` that spawns its OWN python to import it, so warming it here
+  would cost time and change nothing. (That path is separately bounded by
+  `bounded_subprocess`.)
+* ``torch`` directly — reached through `safetensors.torch`, which is listed;
+  importing torch twice by two names is the same graph and the same locks.
+
+``JARVIS_PREWARM_MODULES`` (comma-separated) extends the list without code,
+and ``JARVIS_PREWARM_ENABLED=0`` disables it entirely.
+
+FAILURE IS EXPECTED AND FINE
+-----------------------------
+A module that is not installed on this machine simply is not warmed — the
+import that would have failed later fails here instead, in a worker, with
+nobody waiting. Nothing raises out of this module, and a warm that cannot
+run leaves behaviour exactly as it was.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Jarvis.Prewarm")
+
+PREWARM_SCHEMA_VERSION: str = "prewarm.1"
+
+#: Evidence-derived. Each entry was observed importing ON the event loop in a
+#: StallSampler dump, or is the direct dependency that import pulls.
+DEFAULT_PREWARM: Tuple[str, ...] = (
+    # Caught at `backend/system/__init__.py:21 <module>`, reached from
+    # `main._collect_bridge_health` inside a FastAPI health endpoint — an
+    # import executing while a request was being served.
+    "backend.system",
+    # `ai_loader.discover_engines` probes. Warmed at the voice-model
+    # initializer too, but that is late; this is the same graph, earlier.
+    "safetensors.torch",
+    "voice_unlock.ml.quantized_models",
+    # `experience_queue._check_reactor_health` constructs this; the class is
+    # cached now, the module import is not.
+    "backend.core.trinity_ipc",
+    # The registry walk `audit_ratchet.registered_ratchets` triggers.
+    "backend.core.ouroboros.battle_test.repl_dispatch_registry",
+)
+
+__all__ = [
+    "DEFAULT_PREWARM",
+    "PREWARM_SCHEMA_VERSION",
+    "prewarm_enabled",
+    "prewarm_modules",
+    "prewarm_stats",
+    "spawn_prewarm",
+]
+
+_stats: Dict[str, Any] = {
+    "started": False, "done": False, "warmed": [], "failed": [],
+    "elapsed_s": 0.0,
+}
+
+
+def prewarm_enabled() -> bool:
+    """``JARVIS_PREWARM_ENABLED`` (default true)."""
+    return (os.environ.get("JARVIS_PREWARM_ENABLED", "1") or "").strip().lower() \
+        not in ("0", "false", "no", "off", "")
+
+
+def prewarm_modules() -> Tuple[str, ...]:
+    """The list, with any env additions. NEVER raises."""
+    try:
+        extra = (os.environ.get("JARVIS_PREWARM_MODULES") or "").strip()
+        added = tuple(m.strip() for m in extra.split(",") if m.strip())
+        seen, out = set(), []
+        for name in DEFAULT_PREWARM + added:
+            if name not in seen:
+                seen.add(name)
+                out.append(name)
+        return tuple(out)
+    except Exception:  # noqa: BLE001
+        return DEFAULT_PREWARM
+
+
+def prewarm_stats() -> Dict[str, Any]:
+    """Bounded projection. NEVER raises."""
+    return {"schema_version": PREWARM_SCHEMA_VERSION, **_stats,
+            "warmed": list(_stats["warmed"]), "failed": list(_stats["failed"])}
+
+
+async def _run() -> None:
+    """Import each module, sequentially, off the loop. NEVER raises."""
+    import sys
+
+    names = prewarm_modules()
+    t0 = time.monotonic()
+    _stats["started"] = True
+    warmed: List[str] = []
+    failed: List[str] = []
+    for name in names:
+        if name in sys.modules:
+            continue                    # already paid by someone else
+        try:
+            from backend.core.async_offload import import_off_loop
+            await import_off_loop(name)
+            warmed.append(name)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — absent module, bad graph
+            failed.append(f"{name}: {type(exc).__name__}")
+    _stats["warmed"] = warmed
+    _stats["failed"] = failed
+    _stats["elapsed_s"] = round(time.monotonic() - t0, 3)
+    _stats["done"] = True
+    if warmed or failed:
+        logger.info(
+            "[Prewarm] %d module(s) warmed in %.2fs%s — later imports are "
+            "sys.modules hits on whichever coroutine reaches them first",
+            len(warmed), _stats["elapsed_s"],
+            f", {len(failed)} unavailable" if failed else "")
+
+
+def spawn_prewarm() -> Optional["asyncio.Task"]:
+    """Fire the warm as a DETACHED task. NEVER raises, never blocks.
+
+    Detached on purpose: awaiting it here would move the very cost this
+    exists to hide onto the caller. The task races the boot and loses
+    gracefully — a module the loop reaches first is simply imported there,
+    exactly as it is today.
+    """
+    if not prewarm_enabled():
+        return None
+    try:
+        return asyncio.get_running_loop().create_task(
+            _run(), name="jarvis-prewarm")
+    except RuntimeError:
+        return None                     # no loop — a sync context
+    except Exception:  # noqa: BLE001
+        logger.debug("[Prewarm] not scheduled", exc_info=True)
+        return None

--- a/tests/cli/test_trinity_status.py
+++ b/tests/cli/test_trinity_status.py
@@ -480,3 +480,109 @@ class TestAnOptionalTransportIsReportedNotFatal:
         assert "supervisor.err.log" in sup.log_hint()
         hint = ov.log_hint()
         assert hint == "" or "sessions" in hint, hint
+
+
+class TestATrippedBreakerIsVisibleToTheOperator:
+    """A breaker that only exists in the daemon's memory is invisible to the
+    status CLI, which runs in its own process. A revoked Screen-Recording
+    permission would present as "everything fine, the screenshots merely
+    stopped" — the exact silent failure the breaker was built to end."""
+
+    async def test_an_open_breaker_degrades_a_daemon_that_answers_everything(
+            self):
+        """THE point: every transport live, pid live — and still not
+        HEALTHY, because its screen capture has been refused for minutes."""
+        import backend.core.ouroboros.cli.thin_client as tc
+        real = tc.probe_http
+
+        async def _live(*_a, **_k):
+            return "live"
+
+        tc.probe_http = _live
+        try:
+            spec = st.DaemonSpec(
+                name="sup", title="supervisor", pid_source=lambda: 1,
+                transports=(st.Transport("tcp", "tcp",
+                                         lambda: ("127.0.0.1", 1)),),
+                conditions=lambda: ("TCC_BLOCKED:screencapture",))
+            row = await st.assess_daemon(spec, timeout=0.2)
+            assert row.state is st.Health.DEGRADED, row.detail
+            assert "TCC_BLOCKED" in row.detail
+            assert row.transports["tcp"] == "live", "the socket is fine"
+            assert row.conditions
+        finally:
+            tc.probe_http = real
+
+    async def test_a_healthy_daemon_with_no_conditions_stays_healthy(self):
+        import backend.core.ouroboros.cli.thin_client as tc
+        real = tc.probe_http
+
+        async def _live(*_a, **_k):
+            return "live"
+
+        tc.probe_http = _live
+        try:
+            spec = st.DaemonSpec(
+                name="sup", title="supervisor", pid_source=lambda: 1,
+                transports=(st.Transport("tcp", "tcp",
+                                         lambda: ("127.0.0.1", 1)),))
+            row = await st.assess_daemon(spec, timeout=0.2)
+            assert row.state is st.Health.HEALTHY
+        finally:
+            tc.probe_http = real
+
+    async def test_a_down_daemon_is_not_relabelled_by_a_stale_breaker(self):
+        """A tripped breaker inside a process that is not running is not the
+        operator's problem; DOWN must survive."""
+        spec = st.DaemonSpec(
+            name="sup", title="supervisor", pid_source=lambda: None,
+            transports=(), conditions=lambda: ("CIRCUIT_OPEN:yabai",))
+        row = await st.assess_daemon(spec, timeout=0.05)
+        assert row.state is st.Health.DOWN
+
+    def test_the_condition_is_read_from_the_DURABLE_ledger(
+            self, tmp_path, monkeypatch):
+        """Cross-process by construction: the CLI reads what the daemon
+        wrote, because its own memory is always empty here."""
+        import json
+        import time as _t
+        led = tmp_path / "breakers.json"
+        led.write_text(json.dumps({
+            "schema_version": "bounded_subprocess.1",
+            "open": {"screencapture": {"consecutive_failures": 3}},
+            "updated_at": _t.time(), "cooldown_s": 300, "pid": 999,
+        }))
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_LEDGER", str(led))
+        conds = st.subprocess_breaker_conditions()
+        assert any("TCC_BLOCKED" in c and "screencapture" in c for c in conds)
+        assert any("Screen Recording" in c for c in conds), "name the FIX"
+
+    def test_a_non_tcc_binary_reports_circuit_open(self, tmp_path, monkeypatch):
+        import json
+        import time as _t
+        led = tmp_path / "b.json"
+        led.write_text(json.dumps({
+            "open": {"yabai": {}}, "updated_at": _t.time(), "cooldown_s": 300}))
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_LEDGER", str(led))
+        assert st.subprocess_breaker_conditions() == ("CIRCUIT_OPEN:yabai",)
+
+    def test_a_stale_ledger_is_ignored(self, tmp_path, monkeypatch):
+        """The breaker would have re-probed by now; reporting a stale trip is
+        its own kind of lie."""
+        import json
+        led = tmp_path / "b.json"
+        led.write_text(json.dumps({
+            "open": {"screencapture": {}}, "updated_at": 0, "cooldown_s": 1}))
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_LEDGER", str(led))
+        assert st.subprocess_breaker_conditions() == ()
+
+    def test_no_ledger_means_no_conditions(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_LEDGER",
+                           str(tmp_path / "absent.json"))
+        assert st.subprocess_breaker_conditions() == ()
+
+    def test_the_supervisor_row_actually_carries_this_condition_source(self):
+        """Wiring pin: the fleet's supervisor row must consult it, or the
+        whole chain is a module nobody calls."""
+        sup, _ = st.default_fleet()
+        assert sup.conditions is st.subprocess_breaker_conditions

--- a/tests/core/test_bounded_subprocess.py
+++ b/tests/core/test_bounded_subprocess.py
@@ -224,3 +224,66 @@ class TestTheSharedVoiceCatalog:
         expensive."""
         from backend.core import system_voices as sv
         assert sv._timeout_s() <= 5.0
+
+
+class TestTheTripIsVisibleAcrossProcesses:
+    """A breaker that exists only in the daemon's memory is invisible to
+    `trinity status`, which runs in its own process — a revoked permission
+    would present as "everything fine, the screenshots merely stopped"."""
+
+    @pytest.fixture(autouse=True)
+    def _ledger(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_LEDGER",
+                           str(tmp_path / "breakers.json"))
+        bs.reset_for_tests()
+        yield
+        bs.reset_for_tests()
+
+    def test_a_trip_is_written_where_another_process_can_read_it(
+            self, monkeypatch):
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_TRIPS", "1")
+        bs.run_bounded([sys.executable, "-c", "import time; time.sleep(30)"],
+                       timeout=0.3)
+        assert bs.open_breakers_on_disk(), "the trip never reached disk"
+
+    def test_the_full_lifecycle_trip_refuse_cooldown_recover_clear(
+            self, monkeypatch, tmp_path):
+        """Every step of the operator-visible cycle, in order."""
+        import shutil
+        fake = tmp_path / "screencapture"
+        shutil.copy(sys.executable, fake)
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_TRIPS", "1")
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_COOLDOWN_S", "1")
+        hang = [str(fake), "-c", "import time; time.sleep(30)"]
+        ok = [str(fake), "-c", "print(1)"]
+
+        assert bs.run_bounded(hang, timeout=0.3) is None          # trip
+        assert bs.open_breakers_on_disk() == ("screencapture",)
+        assert bs.run_bounded(ok, timeout=5) is None              # refused
+        time.sleep(1.2)                                           # cooldown
+        assert bs.run_bounded(ok, timeout=10) is not None         # probe ok
+        assert bs.open_breakers_on_disk() == (), "recovery must CLEAR it"
+
+    def test_asking_whether_it_is_open_does_not_change_the_answer(
+            self, monkeypatch):
+        """`breaker_open` used to POP the state, so the success that followed
+        found nothing open and never cleared the on-disk ledger — recovered
+        in memory, tripped forever on the operator's screen. A question must
+        not mutate."""
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_TRIPS", "1")
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_COOLDOWN_S", "1")
+        cmd = [sys.executable, "-c", "import time; time.sleep(30)"]
+        bs.run_bounded(cmd, timeout=0.3)
+        time.sleep(1.2)
+        assert bs.breaker_open(cmd) is False        # cooldown elapsed
+        assert bs.open_breakers_on_disk(), "the question erased the record"
+
+    def test_a_fresh_process_inherits_a_live_trip(self, monkeypatch):
+        """A daemon restarting into a still-wedged binary should honour the
+        cooldown it already earned, not spend a worker rediscovering it."""
+        monkeypatch.setenv("JARVIS_SUBPROC_BREAKER_TRIPS", "1")
+        bs.run_bounded([sys.executable, "-c", "import time; time.sleep(30)"],
+                       timeout=0.3)
+        bs._fails.clear(); bs._opened_at.clear()      # simulate a new process
+        bs._hydrated = False
+        assert bs.breaker_open([sys.executable]) is True

--- a/unified_supervisor.py
+++ b/unified_supervisor.py
@@ -97155,6 +97155,23 @@ async def async_main(args: argparse.Namespace) -> int:
 
     Handles CLI commands and kernel startup.
     """
+    # ---- Deterministic pre-warm (detached) --------------------------------
+    #
+    # The FIRST import of a heavy module is paid wherever the loop happens to
+    # reach it — StallSampler caught `backend/system/__init__.py` executing
+    # inside a served health endpoint. Paying it here, on a worker, makes
+    # every later touch a `sys.modules` hit no matter which coroutine gets
+    # there first, and changes no downstream code.
+    #
+    # Detached deliberately: awaiting it would move the cost onto this
+    # caller. It races the boot and loses gracefully — a module the loop
+    # reaches first is simply imported there, exactly as before.
+    try:
+        from backend.core.prewarm import spawn_prewarm
+        spawn_prewarm()
+    except Exception:  # noqa: BLE001 — a warm-up never blocks a boot
+        pass
+
     # Handle control commands first
     if args.status:
         return await handle_status()


### PR DESCRIPTION
## Phase 1 — the pre-warm matrix

A first import is paid once per process, wherever the loop happens to reach it. Chasing each one means finding every async boundary that might touch a heavy module. So it is paid **early, on a worker**, and every later touch is a `sys.modules` hit no matter which coroutine gets there first — with no downstream change, which is the point.

Dispatched detached from the top of `async_main` through the **existing** `async_offload.import_off_loop`, and **sequentially, not in parallel**: that primitive's docstring records the measurement — CPython takes a per-module lock, so N threads importing a shared graph serialize on those locks anyway with the loop queued among them. That is how ~2 s of work became a 12.38 s wedge.

**The list is evidence, and two obvious entries are deliberately absent.** `Quartz` is never imported in this process — the cursor probe runs an `osascript` that spawns its *own* python to import it, so warming it here would cost time and change nothing. `torch` is reached via `safetensors.torch`, which is listed.

Also offloaded from the same dumps: `heartbeat_validator` read **and parsed** every heartbeat file on the loop each monitor tick.

**What the residual actually was** — three dumps, three different things, only one an import:

| dump | disposition |
|---|---|
| `backend/system/__init__.py` executing inside a served health endpoint | the pre-warm case |
| `heartbeat_validator` file reads in `_monitor_loop` | offloaded |
| `selectors.select` under `_run_once`, no repo frames | the loop **idle** — a sampler false positive, reported as such |

## Phase 2 — a breaker that speaks

A trip living only in the daemon's memory is invisible to `trinity status`, which runs in its own process. So a trip is written to a durable ledger any process can read, and folded into the daemon row that already exists:

```
▲ supervisor (body: audio, vision, HUD stream): DEGRADED
  ⎿ partial readiness (pid=22681, tcp=live, uds=absent*) — but
    TCC_BLOCKED:screencapture (grant Screen Recording / Automation, or it stays refused)
```

No second health path: `DaemonSpec` gains `conditions` and the existing verdict function folds them in. Conditions are **appended** to the detail rather than branched on — an `elif` there was unreachable exactly when it mattered, since the verdict was already DEGRADED *because* of them. A DOWN daemon keeps its verdict: a tripped breaker inside a process that is not running is not the operator's problem.

## Two bugs the end-to-end test found, both mine

- A success in a **fresh** process could not clear an on-disk trip — the clear only fired when the key was open in *that* process's memory. The breaker now hydrates from the ledger, which also means a daemon restarting into a still-wedged binary honours the cooldown it already earned.
- `breaker_open` answered its question by **mutating** (popping state on cooldown), so the success that followed found nothing open and never cleared the ledger: recovered in memory, tripped forever on screen. Only outcomes change state now.

## Verified end to end

One process tripping, **another** reading: trip → refuse → cooldown → probe → clear, with `trinity status` showing DEGRADED + `TCC_BLOCKED` while open and returning to HEALTHY after.

68 tests green (13 new): the cross-process lifecycle, the read-only-probe regression, ledger staleness, TCC vs generic reason codes, and a wiring pin that the supervisor row actually consults the condition source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-warms heavy imports on a worker and makes subprocess circuit breaker trips visible in `trinity status`, reducing event-loop stalls and ending silent failures when TCC blocks capture. Previously, first imports ran on the loop and breaker trips lived only in memory; now imports are warmed sequentially off-loop and trips are recorded durably and folded into the health verdict.

**Changes**
- Add `backend/core/prewarm.py`; spawn a detached, sequential warm via `import_off_loop` at `async_main` start. Configure with `JARVIS_PREWARM_ENABLED` and extend via `JARVIS_PREWARM_MODULES`.
- Offload heartbeat JSON read+parse in `heartbeat_validator` with `call_off_loop`.
- Persist breaker state in `bounded_subprocess` to `breaker_ledger_path()` and read it in `subprocess_breaker_conditions`; append conditions to daemon detail and degrade HEALTHY to DEGRADED when present. DOWN remains DOWN.
- Fix breaker lifecycle: hydrate from ledger on first check, make `breaker_open` non-mutating, write ledger on open, and clear on success only when previously open.

**Rollout**
- No changes needed for the default fleet. Custom fleets should pass `conditions=subprocess_breaker_conditions` when constructing `DaemonSpec`.
- Optional config: set `JARVIS_SUBPROC_BREAKER_LEDGER` (else `.jarvis/subprocess_breakers.json` under `JARVIS_PROJECT_ROOT`), tune `JARVIS_PREWARM_ENABLED` and `JARVIS_PREWARM_MODULES`.

<sup>Written for commit 719643138f47b9b61bc1ddb729e35b84e5fb62a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

