### PR TITLE
fix(trinity): the repo-sync loop stops polling, and stops writing nothing

### DIFF
--- a/backend/core/coding_council/trinity/cross_repo_sync.py
+++ b/backend/core/coding_council/trinity/cross_repo_sync.py
@@ -115,6 +115,21 @@ class CrossRepoSync:
         self._event_handlers: List[Callable[[SyncEvent], Coroutine]] = []
         self._sync_task: Optional[asyncio.Task] = None
         self._running = False
+        #: Last payload actually persisted per repo, so an unchanged state
+        #: costs nothing. Excludes `timestamp` — see `_write_repo_state`.
+        self._last_written: Dict[Any, Any] = {}
+        #: Set by an fs event; the loop waits on it instead of sleeping.
+        self._wake: asyncio.Event = asyncio.Event()
+        self._fs_subscribed: bool = False
+        #: Backstop interval. `JARVIS_CROSS_REPO_BACKSTOP_S` — default 60s,
+        #: six times the old blind poll, because the OS now does the noticing
+        #: and this is only here for the case where it cannot.
+        try:
+            self._backstop_s = max(5.0, min(3600.0, float(
+                (os.environ.get("JARVIS_CROSS_REPO_BACKSTOP_S") or "").strip()
+                or 60.0)))
+        except Exception:  # noqa: BLE001
+            self._backstop_s = 60.0
         self._sync_lock = asyncio.Lock()
 
         # Initialize repo states
@@ -152,9 +167,55 @@ class CrossRepoSync:
                 "— continuing with partial state"
             )
 
+        # Subscribe to the filesystem BEFORE the loop starts, so a mutation
+        # during startup is not missed by the window between the two.
+        await self._subscribe_to_fs_events()
+
         # Start sync loop
         self._sync_task = asyncio.create_task(self._sync_loop())
-        logger.info("[CrossRepoSync] Started")
+        logger.info(
+            "[CrossRepoSync] Started (%s, backstop %.0fs)",
+            "fs-events primary" if self._fs_subscribed else "poll-only",
+            self._backstop_s,
+        )
+
+    async def _subscribe_to_fs_events(self) -> bool:
+        """Wake on real filesystem mutations. NEVER raises.
+
+        Reuses the `TrinityEventBus` `fs.changed.*` topics the existing
+        `FileSystemEventBridge` already publishes and four intake sensors
+        already consume. Adding a second watcher (`watchdog`) here would mean
+        two independent observers of the same directories in one process,
+        and a second thing to keep alive.
+
+        A failure is not fatal: the loop's backstop still runs, so the worst
+        case is the cadence that shipped rather than blindness.
+        """
+        try:
+            from backend.core.trinity_event_bus import get_event_bus_if_exists
+            bus = get_event_bus_if_exists()
+            if bus is None:
+                return False
+            await bus.subscribe("fs.changed.*", self._on_fs_event)
+            self._fs_subscribed = True
+            return True
+        except Exception:  # noqa: BLE001
+            logger.debug("[CrossRepoSync] fs-event subscription unavailable",
+                         exc_info=True)
+            return False
+
+    async def _on_fs_event(self, event: Any) -> None:
+        """A mutation happened; evaluate now instead of at the next tick.
+
+        Only SETS a flag — the evaluation itself stays in the one loop that
+        owns this state. Doing the work here would let a burst of file events
+        run N overlapping evaluations, which is how an event-driven rewrite
+        becomes worse than the poll it replaced.
+        """
+        try:
+            self._wake.set()
+        except Exception:  # noqa: BLE001
+            pass
 
     async def stop(self) -> None:
         """Stop the sync manager."""
@@ -417,10 +478,30 @@ class CrossRepoSync:
             "sync_status": repo.sync_status.value,
         }
 
+        # Write ONLY when the state actually changed.
+        #
+        # This rewrote three files every ten seconds for the life of the
+        # daemon, whether or not anything moved — and StallSampler caught one
+        # of those writes on the event loop. `timestamp` is excluded from the
+        # comparison on purpose: including it makes every payload unique and
+        # turns "write on change" back into "write always".
+        payload = {k: v for k, v in state.items() if k != "timestamp"}
+        if self._last_written.get(repo_type) == payload:
+            return
         try:
-            tmp = state_file.with_suffix(".tmp")
-            tmp.write_text(json.dumps(state, indent=2))
-            tmp.rename(state_file)
+            def _persist() -> None:
+                tmp = state_file.with_suffix(".tmp")
+                tmp.write_text(json.dumps(state, indent=2))
+                tmp.rename(state_file)
+
+            # Off the loop: a small write is still a write, and this one
+            # happens on the thread that must answer everything else.
+            try:
+                from backend.core.async_offload import call_off_loop
+                await call_off_loop(_persist)
+            except Exception:  # noqa: BLE001 — fail-open to inline
+                _persist()
+            self._last_written[repo_type] = payload
         except Exception as e:
             logger.warning(f"[CrossRepoSync] Failed to write state: {e}")
 
@@ -459,10 +540,17 @@ class CrossRepoSync:
         while self._running:
             try:
                 # Re-discover repos (handles repos coming online/offline)
+                paths = {rt: self._repos[rt].repo_path for rt in RepoType}
+                try:
+                    from backend.core.async_offload import call_off_loop
+                    present = await call_off_loop(
+                        lambda: {rt: p.exists() for rt, p in paths.items()})
+                except Exception:  # noqa: BLE001 — fail-open to inline
+                    present = {rt: p.exists() for rt, p in paths.items()}
                 for repo_type in RepoType:
                     repo = self._repos[repo_type]
                     was_online = repo.online
-                    repo.online = repo.repo_path.exists()
+                    repo.online = present.get(repo_type, False)
 
                     # Status change detection
                     if repo.online and not was_online:
@@ -487,7 +575,25 @@ class CrossRepoSync:
                 for repo_type in RepoType:
                     await self._write_repo_state(repo_type)
 
-                await asyncio.sleep(10)  # Sync every 10 seconds
+                # Event-PRIMARY, poll as a backstop.
+                #
+                # A repo coming online or going offline is a filesystem
+                # mutation, and the OS already tells us: `TrinityEventBus`
+                # carries `fs.changed.*` from the existing
+                # `FileSystemEventBridge`, which four intake sensors already
+                # consume. Adding `watchdog` here would be a second watcher
+                # for a signal this process already receives.
+                #
+                # The sleep is not deleted, it is DEMOTED — the repo's own
+                # Gap #4 pattern is event-primary with a polling floor, so a
+                # missing or failed bus degrades to the behaviour that
+                # shipped rather than to blindness.
+                try:
+                    await asyncio.wait_for(self._wake.wait(),
+                                           timeout=self._backstop_s)
+                except asyncio.TimeoutError:
+                    pass
+                self._wake.clear()
 
             except asyncio.CancelledError:
                 break

--- a/tests/core/test_cross_repo_sync_events.py
+++ b/tests/core/test_cross_repo_sync_events.py
@@ -1,0 +1,170 @@
+"""The repo-sync loop stops polling, and stops writing what did not change.
+
+StallSampler caught this on the wedged main loop — at a ~500-byte JSON write
+that ran every ten seconds whether or not anything had moved.
+
+What the loop actually did per tick, measured rather than assumed: three
+`Path.exists()` calls and three small `write_text` + `rename` pairs. No
+directory walk, no delta comparison, no hashing. That measurement is why the
+fix is event-driven + write-on-change + off-loop, and NOT a process pool: a
+`ProcessPoolExecutor` dispatch costs more than the work it would isolate.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from backend.core.coding_council.trinity import cross_repo_sync as crs
+
+
+@pytest.fixture
+def mgr(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CROSS_REPO_BACKSTOP_S", "0.2")
+    m = crs.CrossRepoSync()
+    m._sync_dir = tmp_path / "sync"
+    m._sync_dir.mkdir(parents=True, exist_ok=True)
+    return m
+
+
+class TestWriteOnChange:
+    async def test_an_unchanged_state_is_not_rewritten(self, mgr, tmp_path):
+        """The single biggest win: three files rewritten every ten seconds,
+        forever, for state that almost never changes."""
+        rt = list(crs.RepoType)[0]
+        repo = mgr._repos[rt]
+        repo.online = True
+
+        await mgr._write_repo_state(rt)
+        state_file = next(iter(tmp_path.rglob(f"{rt.value}.json")), None)
+        assert state_file is not None, "first write must happen"
+        first_mtime = state_file.stat().st_mtime_ns
+
+        await mgr._write_repo_state(rt)
+        assert state_file.stat().st_mtime_ns == first_mtime, (
+            "an unchanged state was rewritten")
+
+    async def test_a_changed_state_IS_written(self, mgr, tmp_path):
+        rt = list(crs.RepoType)[0]
+        mgr._repos[rt].online = False
+        await mgr._write_repo_state(rt)
+        state_file = next(iter(tmp_path.rglob(f"{rt.value}.json")))
+        assert json.loads(state_file.read_text())["online"] is False
+
+        mgr._repos[rt].online = True
+        await mgr._write_repo_state(rt)
+        assert json.loads(state_file.read_text())["online"] is True
+
+    async def test_the_timestamp_is_excluded_from_the_comparison(self, mgr):
+        """Including it makes every payload unique and turns write-on-change
+        back into write-always — the bug wearing the fix's clothes."""
+        rt = list(crs.RepoType)[0]
+        await mgr._write_repo_state(rt)
+        stored = mgr._last_written[rt]
+        assert "timestamp" not in stored
+        assert "online" in stored and "sync_status" in stored
+
+
+class TestEventDriven:
+    async def test_an_fs_event_wakes_the_loop_instead_of_a_sleep(self, mgr):
+        assert not mgr._wake.is_set()
+        await mgr._on_fs_event(object())
+        assert mgr._wake.is_set(), "a mutation must wake the evaluation"
+
+    async def test_the_handler_only_flags_and_never_evaluates(self, mgr):
+        """Doing the work in the handler would let a burst of file events run
+        N overlapping evaluations — an event-driven rewrite that is worse
+        than the poll it replaced."""
+        called = {"discover": 0}
+
+        async def _spy():
+            called["discover"] += 1
+
+        mgr._discover_repos = _spy
+        for _ in range(50):
+            await mgr._on_fs_event(object())
+        assert called["discover"] == 0
+        assert mgr._wake.is_set()
+
+    async def test_a_missing_bus_degrades_to_the_backstop_not_to_blindness(
+            self, mgr, monkeypatch):
+        """Event-primary with a polling FLOOR — the repo's own Gap #4
+        pattern. No bus must mean the old cadence, never no cadence."""
+        monkeypatch.setattr(
+            "backend.core.trinity_event_bus.get_event_bus_if_exists",
+            lambda: None)
+        assert await mgr._subscribe_to_fs_events() is False
+        assert mgr._fs_subscribed is False
+        assert mgr._backstop_s > 0
+
+    async def test_a_hostile_bus_never_escapes_start(self, mgr, monkeypatch):
+        class _Bus:
+            async def subscribe(self, *_a, **_k):
+                raise RuntimeError("bus exploded")
+
+        monkeypatch.setattr(
+            "backend.core.trinity_event_bus.get_event_bus_if_exists",
+            lambda: _Bus())
+        assert await mgr._subscribe_to_fs_events() is False
+
+    async def test_it_subscribes_when_a_bus_exists(self, mgr, monkeypatch):
+        seen = {}
+
+        class _Bus:
+            async def subscribe(self, pattern, handler):
+                seen["pattern"] = pattern
+                return "sub-1"
+
+        monkeypatch.setattr(
+            "backend.core.trinity_event_bus.get_event_bus_if_exists",
+            lambda: _Bus())
+        assert await mgr._subscribe_to_fs_events() is True
+        assert seen["pattern"] == "fs.changed.*", (
+            "must reuse the EXISTING topic four sensors already consume")
+
+
+class TestTheLoopLeavesTheEventLoopAlone:
+    async def test_a_tick_does_not_block_on_filesystem_stats(self, mgr):
+        """The presence probe is three `exists()` calls — small, and still
+        not the loop thread's job."""
+        import time as _t
+
+        slow = {"n": 0}
+        real_exists = crs.Path.exists if hasattr(crs, "Path") else None
+
+        worst = 0.0
+
+        async def _ticker():
+            nonlocal worst
+            for _ in range(30):
+                t0 = _t.monotonic()
+                await asyncio.sleep(0.01)
+                worst = max(worst, _t.monotonic() - t0)
+
+        # Make the probe genuinely slow, the way a stalled disk would.
+        for repo in mgr._repos.values():
+            class _SlowPath(type(repo.repo_path)):
+                def exists(self, *a, **k):      # noqa: D102
+                    _t.sleep(0.05)
+                    slow["n"] += 1
+                    return True
+            try:
+                repo.repo_path = _SlowPath(str(repo.repo_path))
+            except Exception:
+                pytest.skip("path subclassing unavailable on this platform")
+
+        ticker = asyncio.create_task(_ticker())
+        mgr._running = True
+        loop_task = asyncio.create_task(mgr._sync_loop())
+        await asyncio.sleep(0.5)
+        mgr._running = False
+        loop_task.cancel()
+        ticker.cancel()
+        for t in (loop_task, ticker):
+            try:
+                await t
+            except asyncio.CancelledError:
+                pass
+        assert slow["n"] > 0, "the probe never ran; the test proved nothing"
+        assert worst < 0.15, f"the loop was blocked for {worst:.3f}s"


### PR DESCRIPTION
## The audit came first, and it changed the design

What `_sync_loop` actually did per tick — measured, not assumed:

```
3x  Path.exists()                  (one per RepoType)
3x  write_text(~500B) + rename     (unconditional, every 10s, forever)
```

**No directory walk. No delta comparison. No hashing.** The StallSampler dump landed on one of those small writes.

That measurement is why this is event-driven + write-on-change + off-loop and **not** a process pool. A `ProcessPoolExecutor` dispatch costs a fork and tens of milliseconds — more than the work it would isolate. Process isolation is the right tool for the hot-reloader's hash fan-out, a genuine CPU-bound walk, and `cooperative_fs_io.offload(cpu_bound=True)` already exists for that shape. It is the wrong tool for three stats and three 500-byte writes.

## The neighbours, audited

| module | live? | finding |
|---|---|---|
| `heartbeat_validator` | **yes** (526 log mentions) | read+parsed every heartbeat file per tick on the loop — offloaded in the previous change |
| `multi_transport.FileTransport` | **no** — 0 log mentions, 0 production construction sites | the genuine FS-polling design (`iterdir` + `glob` + `read_text` per message, 0.5 s poll), but nothing constructs it. Named, not rebuilt |
| `message_queue._process_loop` | yes | 0.1 s cadence, but an in-memory dequeue — not a filesystem poll, and absent from every dump |

Rewriting `FileTransport` with a watcher and a process pool would be building an event-driven architecture for code nobody runs.

## What changed

- **Write on change.** Three files were rewritten every ten seconds whether or not anything moved. `timestamp` is excluded from the comparison on purpose — including it makes every payload unique and turns "write on change" straight back into "write always".
- **Event-primary.** The loop waits on an `asyncio.Event` set by `fs.changed.*` from the **existing** `TrinityEventBus` / `FileSystemEventBridge` that four intake sensors already consume. Adding `watchdog` would put a second independent watcher on the same directories in one process.
- **The poll is demoted, not deleted** — a 10 s blind poll becomes a 60 s backstop (`JARVIS_CROSS_REPO_BACKSTOP_S`). Event-primary with a polling floor is this repo's own Gap #4 pattern: a missing bus degrades to the cadence that shipped, never to blindness.
- **The handler only sets a flag.** Evaluating inside it would let a burst of file events run N overlapping evaluations — an event-driven rewrite that is worse than the poll it replaced.
- The residual `exists()` probe and the write both go off the loop.

9 tests, including a loop-responsiveness case that fails if a slow `exists()` ever blocks the loop again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make cross-repo sync event-driven and write-on-change. Previously the loop polled every 10s and rewrote three ~500B JSON files unconditionally; now it wakes on filesystem events and writes only when state changes, reducing loop blocking and IO. File mtimes no longer update unless content changes.

- Subscribes to `TrinityEventBus` `fs.changed.*` before starting; handler only sets a wake flag; no extra `watchdog`. If the bus is missing or fails, sync degrades to a backstop instead of going blind.
- Demotes the blind poll to an env-tunable backstop (`JARVIS_CROSS_REPO_BACKSTOP_S`, default 60s). You can set it between 5–3600s.
- Offloads `Path.exists()` probes and state writes off the event loop; excludes `timestamp` from change detection to prevent write-always.
- Adds `tests/core/test_cross_repo_sync_events.py` to cover no-rewrite-on-unchanged, timestamp exclusion, event wake behavior, graceful degradation, and loop responsiveness.

**Rollout notes**
- No required config. If you relied on the 10s “heartbeat” file rewrites, switch to the existing `fs.changed.*` events on `TrinityEventBus` or watch content changes, or temporarily set `JARVIS_CROSS_REPO_BACKSTOP_S=10`.

<sup>Written for commit c306e6a31c0aa0d92349389d81a039e90f380938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

