### PR TITLE
perf(macos): screen lock was a question asked 86,400 times a day

### DIFF
--- a/backend/macos_helper/lock_state_listener.py
+++ b/backend/macos_helper/lock_state_listener.py
@@ -1,0 +1,334 @@
+"""Screen lock/unlock as an OS-delivered event, not a 1 Hz question.
+
+WHAT THIS REPLACES
+------------------
+`system_event_monitor._system_state_monitoring_loop` asked the OS "is the
+screen locked?" every second, forever. Measured on a live supervisor: 571
+checks in 9.8 minutes, each emitting two INFO lines -- 1,142 of the window's
+1,783 log lines, 64% of everything the process said. The answer changed zero
+times.
+
+Worse than the noise: the check ran SYNCHRONOUSLY on the event loop, and its
+fallback path shells out to `osascript`. That is how a lock probe becomes a
+multi-second stall, and `screen_lock_detector` frames are exactly what the
+one surviving main-thread StallSampler dump contains.
+
+WHY ctypes AND NOT pyobjc / DistributedNotificationCenter
+----------------------------------------------------------
+`NSDistributedNotificationCenter` is the textbook answer and it is the wrong
+one HERE, for a reason already paid for in this codebase. From
+`async_pipeline._fast_check_screen_locked`:
+
+    v270.1: Replaced `from Quartz import CGSessionCopyCurrentDictionary`
+    with ctypes-based check. Importing Quartz triggers AppKit._metadata
+    (15K+ ObjC bridge lines) -- SIGSEGV risk when CoreAudio IO thread active.
+
+This process runs CoreAudio. Pulling the ObjC bridge back in to avoid a
+stall would trade a hitch for a crash. `DistributedNotificationCenter` also
+needs a live CFRunLoop pumping on its thread, which is a second, larger
+commitment on top of the first.
+
+`notify(3)` from libSystem has neither problem: it is a C API reachable by
+ctypes, it hands back a plain FILE DESCRIPTOR, and a descriptor is something
+a thread can block on with `select` and an event loop can be told about with
+`call_soon_threadsafe`. Measured round-trip on this machine: 0.2ms.
+
+EVENT-PRIMARY, NEVER EVENT-ONLY
+--------------------------------
+`notify_register_file_descriptor` returns success for a name whether or not
+anything ever posts it -- the name space is open. So registration proves the
+TRANSPORT works; it cannot prove macOS POSTS these keys on this OS version.
+That is not a reason to avoid the mechanism, it is a reason not to bet the
+correctness of lock detection on it. The consumer keeps a slow polling
+backstop, exactly the event-primary-with-a-floor shape the intake sensors
+already use for `fs.changed.*`. If the notification fires, the backstop never
+matters; if it never fires, behaviour degrades to the old cadence rather than
+to blindness.
+
+THREAD DISCIPLINE
+-----------------
+One daemon thread, blocked in `select()`, touching no loop state. The only
+thing it does on wake is `loop.call_soon_threadsafe` -- the single supported
+door into a running loop from another thread. Shutdown goes through a
+self-pipe, not a select timeout: a timeout would reintroduce polling to stop
+a poller.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import logging
+import os
+import select
+import threading
+from typing import Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Jarvis.LockStateListener")
+
+LOCK_LISTENER_SCHEMA_VERSION: str = "lock_state_listener.1"
+
+#: Darwin notification names that accompany a console/lock transition.
+#: `screenIsLocked`/`screenIsUnlocked` are the documented pair;
+#: `sessionDidMoveOffConsole`/`sessionDidMoveToConsole` are what loginwindow
+#: posts for fast-user-switching and, on several OS versions, for lock. All
+#: four are registered because the cost of an extra descriptor is one int and
+#: the cost of guessing wrong is a missed transition.
+DEFAULT_KEYS: Tuple[str, ...] = (
+    "com.apple.screenIsLocked",
+    "com.apple.screenIsUnlocked",
+    "com.apple.sessionDidMoveOffConsole",
+    "com.apple.sessionDidMoveToConsole",
+)
+
+__all__ = [
+    "DEFAULT_KEYS",
+    "LOCK_LISTENER_SCHEMA_VERSION",
+    "LockStateListener",
+    "listener_enabled",
+    "notify_keys",
+]
+
+
+def listener_enabled() -> bool:
+    """``JARVIS_LOCK_EVENT_LISTENER_ENABLED`` (default true)."""
+    raw = (os.environ.get("JARVIS_LOCK_EVENT_LISTENER_ENABLED", "1") or "").strip()
+    return raw.lower() not in ("0", "false", "no", "off")
+
+
+def notify_keys() -> Tuple[str, ...]:
+    """The Darwin names to watch. ``JARVIS_LOCK_NOTIFY_KEYS`` replaces the
+    default set entirely (comma-separated) -- an operator on an OS version
+    that posts something else must not have to edit code. NEVER raises."""
+    try:
+        raw = (os.environ.get("JARVIS_LOCK_NOTIFY_KEYS") or "").strip()
+        if not raw:
+            return DEFAULT_KEYS
+        keys = tuple(k.strip() for k in raw.split(",") if k.strip())
+        return keys or DEFAULT_KEYS
+    except Exception:  # noqa: BLE001
+        return DEFAULT_KEYS
+
+
+class LockStateListener:
+    """Wakes a callback when macOS says the console/lock state moved.
+
+    The callback is invoked ON THE EVENT LOOP via `call_soon_threadsafe` and
+    is given no arguments: this class reports that SOMETHING changed, never
+    what the new state is. Reading the state stays with the existing
+    detector, which already knows how -- this only removes the need to ask
+    on a timer.
+    """
+
+    def __init__(
+        self,
+        on_change: Callable[[], None],
+        loop: "object" = None,
+        keys: Optional[Tuple[str, ...]] = None,
+    ) -> None:
+        self._on_change = on_change
+        self._loop = loop
+        self._keys: Tuple[str, ...] = keys if keys is not None else notify_keys()
+        self._libc: Optional[ctypes.CDLL] = None
+        self._fds: Dict[int, str] = {}          # fd -> key name
+        self._tokens: List[int] = []
+        self._thread: Optional[threading.Thread] = None
+        self._stop_r: int = -1
+        self._stop_w: int = -1
+        self._running = False
+        self._wakeups = 0
+
+    # -- introspection -----------------------------------------------------
+
+    @property
+    def available(self) -> bool:
+        """True once at least one descriptor is registered and the thread is
+        alive. A consumer reads this to decide how hard it still has to
+        poll -- it must never be inferred from `start()` not raising."""
+        return bool(self._running and self._fds)
+
+    @property
+    def wakeups(self) -> int:
+        """Transitions observed. A listener that is `available` but has zero
+        wakeups after a real lock is the signal that these keys are not
+        posted on this OS version -- the thing registration cannot tell us."""
+        return self._wakeups
+
+    def stats(self) -> Dict[str, object]:
+        """Bounded projection. NEVER raises."""
+        return {
+            "schema_version": LOCK_LISTENER_SCHEMA_VERSION,
+            "available": self.available,
+            "wakeups": self._wakeups,
+            "keys": list(self._fds.values()),
+            "requested_keys": list(self._keys),
+        }
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def _load(self) -> bool:
+        """Bind the three libSystem symbols. NEVER raises."""
+        try:
+            path = ctypes.util.find_library("System")
+            if not path:
+                return False
+            libc = ctypes.CDLL(path, use_errno=True)
+            libc.notify_register_file_descriptor.restype = ctypes.c_uint32
+            libc.notify_register_file_descriptor.argtypes = [
+                ctypes.c_char_p, ctypes.POINTER(ctypes.c_int),
+                ctypes.c_int, ctypes.POINTER(ctypes.c_int),
+            ]
+            libc.notify_cancel.restype = ctypes.c_uint32
+            libc.notify_cancel.argtypes = [ctypes.c_int]
+            self._libc = libc
+            return True
+        except Exception:  # noqa: BLE001 — not macOS, or no libSystem
+            logger.debug("[LockListener] libSystem unavailable", exc_info=True)
+            return False
+
+    def start(self) -> bool:
+        """Register and spawn the waiter. Returns whether it is live.
+
+        NEVER raises and never blocks: every failure mode here means the
+        caller keeps polling, which is exactly what it did before.
+        """
+        if self._running:
+            return self.available
+        if not listener_enabled():
+            logger.debug("[LockListener] disabled by env")
+            return False
+        if not self._load():
+            return False
+
+        # Bind the loop we were started FROM when the caller did not name
+        # one. An async caller that forgets would otherwise get its callback
+        # invoked on the listener thread -- correct-looking in a test, a
+        # data race in production.
+        if self._loop is None:
+            try:
+                import asyncio
+                self._loop = asyncio.get_running_loop()
+            except RuntimeError:
+                self._loop = None       # genuinely synchronous caller
+
+        for key in self._keys:
+            try:
+                fd = ctypes.c_int(0)
+                token = ctypes.c_int(0)
+                status = self._libc.notify_register_file_descriptor(  # type: ignore[union-attr]
+                    key.encode(), ctypes.byref(fd), 0, ctypes.byref(token))
+                if status == 0 and fd.value >= 0:
+                    self._fds[fd.value] = key
+                    self._tokens.append(token.value)
+                else:
+                    logger.debug("[LockListener] %s -> status=%s", key, status)
+            except Exception:  # noqa: BLE001
+                logger.debug("[LockListener] register failed: %s", key,
+                             exc_info=True)
+
+        if not self._fds:
+            logger.debug("[LockListener] no descriptors; caller keeps polling")
+            return False
+
+        try:
+            self._stop_r, self._stop_w = os.pipe()
+        except OSError:
+            self._release()
+            return False
+
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._wait_forever, name="jarvis-lock-listener", daemon=True)
+        self._thread.start()
+        logger.info(
+            "[LockListener] event-driven lock detection live on %d key(s): %s "
+            "— the 1Hz probe is now a backstop, not the mechanism",
+            len(self._fds), ", ".join(self._fds.values()))
+        return True
+
+    def stop(self) -> None:
+        """Wake the thread through the self-pipe and release. NEVER raises."""
+        self._running = False
+        try:
+            if self._stop_w >= 0:
+                os.write(self._stop_w, b"x")
+        except OSError:
+            pass
+        t = self._thread
+        if t is not None and t.is_alive():
+            t.join(timeout=2.0)
+        self._release()
+
+    def _release(self) -> None:
+        """Close descriptors and cancel tokens. NEVER raises."""
+        for token in self._tokens:
+            try:
+                self._libc.notify_cancel(token)  # type: ignore[union-attr]
+            except Exception:  # noqa: BLE001
+                pass
+        self._tokens.clear()
+        for fd in list(self._fds):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        self._fds.clear()
+        for fd in (self._stop_r, self._stop_w):
+            try:
+                if fd >= 0:
+                    os.close(fd)
+            except OSError:
+                pass
+        self._stop_r = self._stop_w = -1
+
+    # -- the thread --------------------------------------------------------
+
+    def _wait_forever(self) -> None:
+        """Block on the descriptors. Touches no loop state. NEVER raises."""
+        while self._running:
+            watch = list(self._fds) + ([self._stop_r] if self._stop_r >= 0 else [])
+            if not watch:
+                return
+            try:
+                readable, _, _ = select.select(watch, [], [])
+            except (OSError, ValueError):
+                return              # descriptors closed under us: stopping
+            if not self._running or self._stop_r in readable:
+                return
+            fired = False
+            for fd in readable:
+                try:
+                    # notify(3) writes a 4-byte token per post; draining it is
+                    # what re-arms the descriptor for the next transition.
+                    os.read(fd, 4)
+                    fired = True
+                except OSError:
+                    return
+            if fired:
+                self._wakeups += 1
+                self._dispatch()
+
+    def _dispatch(self) -> None:
+        """Hand off to the loop. The ONLY thread-to-loop door. NEVER raises.
+
+        A first version returned silently when no loop was bound, which meant
+        a listener constructed without one counted the wake and dropped the
+        callback -- `wakeups` incremented while nothing downstream ever ran.
+        A dispatcher that swallows the event it was built to deliver is worse
+        than either honest option, so both are taken explicitly: with a loop,
+        `call_soon_threadsafe`; without one, a direct call, because the only
+        callers that omit a loop are synchronous ones whose callback is
+        already thread-safe (a `threading.Event.set`).
+        """
+        loop = self._loop
+        try:
+            if loop is not None and not loop.is_closed():  # type: ignore[attr-defined]
+                loop.call_soon_threadsafe(self._on_change)  # type: ignore[attr-defined]
+            else:
+                self._on_change()
+        except RuntimeError:
+            pass                    # loop shutting down — a missed wake is
+            #                         covered by the consumer's backstop
+        except Exception:  # noqa: BLE001
+            logger.debug("[LockListener] dispatch failed", exc_info=True)

--- a/backend/macos_helper/system_event_monitor.py
+++ b/backend/macos_helper/system_event_monitor.py
@@ -162,6 +162,13 @@ class SystemEventMonitor:
 
         # System state
         self._is_screen_locked: bool = False
+        # Set by LockStateListener from its own thread via
+        # loop.call_soon_threadsafe -- so `set` runs ON the loop and the
+        # Event needs no lock of its own. Created here rather than in the
+        # loop so `_start_lock_listener` can hand out the bound method
+        # before the first await.
+        self._lock_event: asyncio.Event = asyncio.Event()
+        self._lock_listener: Optional[Any] = None
         self._is_system_sleeping: bool = False
         self._last_user_activity: datetime = datetime.now()
         self._is_idle: bool = False
@@ -395,6 +402,19 @@ class SystemEventMonitor:
 
             self._running = False
             self._startup_state = "stopping"
+
+            # Released BEFORE the tasks are cancelled: the listener owns an
+            # OS thread and four descriptors, and a daemon thread blocked in
+            # select() outlives a cancelled coroutine. Its stop() wakes that
+            # thread through its self-pipe rather than waiting on a timeout.
+            listener = self._lock_listener
+            self._lock_listener = None
+            if listener is not None:
+                try:
+                    listener.stop()
+                except Exception:  # noqa: BLE001 — shutdown must not raise
+                    logger.debug("[SystemEventMonitor] listener stop failed",
+                                 exc_info=True)
 
             active_tasks = [task for task in list(self._tasks) if not task.done()]
             for task in active_tasks:
@@ -962,25 +982,110 @@ class SystemEventMonitor:
     # =========================================================================
 
     async def _system_state_monitoring_loop(self) -> None:
-        """Monitor system state (sleep, wake, screen lock)."""
+        """React to lock/unlock; fall back to asking only when nothing tells us.
+
+        Was `sleep(1)` forever. Measured on a live supervisor, that asked the
+        OS 571 times in 9.8 minutes and got the same answer 571 times, while
+        emitting 64% of everything the process logged.
+
+        The loop is now EVENT-PRIMARY: `LockStateListener` wakes it from a
+        Darwin `notify(3)` descriptor the instant the console state moves.
+        The sleep is DEMOTED, not deleted -- registration cannot prove macOS
+        posts those keys on this OS version (see the listener docstring), so
+        an unproven producer must degrade to the old cadence, never to
+        blindness. Same event-primary-with-a-floor shape the intake sensors
+        use for `fs.changed.*`.
+
+        The backstop is ADAPTIVE: it starts at the responsive interval and
+        backs off geometrically while nothing changes, so a machine that
+        never locks stops paying for the question. Any transition -- from the
+        listener or from the backstop itself -- collapses it back to
+        responsive, because the moment right after a change is the moment the
+        next one is most likely.
+        """
+        self._start_lock_listener()
+        delay = self._lock_backstop_min_s()
         while self._running:
             try:
-                await asyncio.sleep(1)  # Check every second
-                await self._update_screen_lock_status()
+                # Event-primary: return the instant the OS says something
+                # moved. `wait_for` is the timeout, so the backstop is the
+                # ceiling on ignorance, not the cadence of the check.
+                try:
+                    await asyncio.wait_for(self._lock_event.wait(), timeout=delay)
+                    self._lock_event.clear()
+                    woke_on_event = True
+                except asyncio.TimeoutError:
+                    woke_on_event = False
+
+                changed = await self._update_screen_lock_status()
+
+                if changed or woke_on_event:
+                    delay = self._lock_backstop_min_s()
+                else:
+                    delay = min(delay * self._lock_backstop_growth(),
+                                self._lock_backstop_max_s())
 
             except asyncio.CancelledError:
                 break
             except Exception as e:
                 logger.debug(f"System state monitoring error: {e}")
-                await asyncio.sleep(2)
+                await asyncio.sleep(self._lock_backstop_min_s() * 2)
+
+    # -- lock backstop tuning (env-driven; nothing here is a literal) -------
+
+    def _lock_backstop_min_s(self) -> float:
+        """Responsive interval, used right after any transition."""
+        return _clamp(_env_float("JARVIS_LOCK_BACKSTOP_MIN_S", 1.0), 0.1, 60.0)
+
+    def _lock_backstop_max_s(self) -> float:
+        """Ceiling while the state is quiet. With the listener live this is
+        the ONLY cost of the old poller, paid once per this interval."""
+        return _clamp(_env_float("JARVIS_LOCK_BACKSTOP_MAX_S", 60.0),
+                      self._lock_backstop_min_s(), 3600.0)
+
+    def _lock_backstop_growth(self) -> float:
+        """Geometric back-off factor. >1 or the backstop never widens."""
+        return _clamp(_env_float("JARVIS_LOCK_BACKSTOP_GROWTH", 2.0), 1.0, 10.0)
+
+    def _start_lock_listener(self) -> None:
+        """Arm the OS listener once. NEVER raises: a failure here means the
+        adaptive backstop is the whole mechanism, which is still strictly
+        better than the fixed 1Hz poll it replaced."""
+        if self._lock_listener is not None:
+            return
+        try:
+            from .lock_state_listener import LockStateListener
+
+            listener = LockStateListener(
+                on_change=self._lock_event.set,
+                loop=asyncio.get_running_loop(),
+            )
+            if listener.start():
+                self._lock_listener = listener
+        except Exception:  # noqa: BLE001
+            logger.debug("[SystemEventMonitor] lock listener unavailable",
+                         exc_info=True)
 
     async def _update_screen_lock_status(self) -> bool:
-        """Update screen lock status."""
+        """Update screen lock status. Returns whether the state CHANGED.
+
+        The return value used to be "did this run without throwing", which
+        no caller could act on. It now reports the transition, because the
+        adaptive backstop needs to know whether the last look found news.
+        """
         try:
             # Try using the existing screen lock detector
             try:
                 from voice_unlock.objc.server.screen_lock_detector import is_screen_locked
-                is_locked = is_screen_locked()
+                # OFF THE LOOP. On the fast path this is a cheap ctypes call,
+                # but `is_screen_locked` falls back to `osascript` when
+                # CGSession is inconclusive -- a synchronous subprocess on the
+                # event loop, and precisely the frame the surviving
+                # main-thread StallSampler dump caught.
+                from backend.core.async_offload import call_off_loop
+                is_locked = await call_off_loop(is_screen_locked)
+                if is_locked is None:
+                    return False        # probe failed; "unknown" is not "unlocked"
             except ImportError:
                 # Fallback: Check via IOKit/CGSession
                 script = """
@@ -995,7 +1100,10 @@ class SystemEventMonitor:
                 )
                 is_locked = b"true" in stdout.lower()
 
-            # Detect change
+            # Detect change. This delta gate was already here and already
+            # correct -- an event is emitted on TRANSITION, never per probe.
+            # It is deliberately left alone: the spam was never this gate, it
+            # was the detector logging its own no-news answer at INFO.
             if is_locked != self._is_screen_locked:
                 old_status = self._is_screen_locked
                 self._is_screen_locked = is_locked
@@ -1006,8 +1114,14 @@ class SystemEventMonitor:
                 else:
                     event = MacOSEventFactory.create_screen_unlocked()
 
+                logger.info(
+                    "[SystemEventMonitor] screen %s (was %s)",
+                    "LOCKED" if is_locked else "UNLOCKED",
+                    "locked" if old_status else "unlocked",
+                )
                 await self._emit_event(event)
-            return True
+                return True
+            return False
 
         except Exception as e:
             logger.debug(f"Error checking screen lock: {e}")

--- a/backend/voice_unlock/objc/server/screen_lock_detector.py
+++ b/backend/voice_unlock/objc/server/screen_lock_detector.py
@@ -190,7 +190,13 @@ def _check_cgsession_locked_via_ctypes() -> Optional[bool]:
                 return True
 
             # Dictionary obtained and no lock indicators — screen is unlocked
-            logger.info(
+            # DEBUG, not INFO: this is the no-news answer on the hot path.
+            # Measured on a live supervisor, this line and its sibling in
+            # `is_screen_locked` produced 1,142 of 1,783 log lines -- 64% of
+            # everything the process said -- to report that nothing had
+            # changed, 571 times in a row. A transition IS logged, once, by
+            # the delta gate in `system_event_monitor`.
+            logger.debug(
                 "🔓 [SCREEN-DETECT] CGSession (ctypes) says UNLOCKED - Fast Path"
             )
             return False
@@ -397,7 +403,10 @@ def is_screen_locked() -> bool:
                 return True
             else:
                 detection_results.append(("CGSession-ctypes", False))
-                logger.info(
+                # DEBUG for the same reason as the sibling line above: the
+                # unlocked fast path is the boring case, and it is the case
+                # that runs on every probe.
+                logger.debug(
                     "🔓 [SCREEN-DETECT] ctypes CGSession says UNLOCKED - "
                     "Trusting ctypes (Fast Path)"
                 )

--- a/tests/macos_helper/test_lock_state_events.py
+++ b/tests/macos_helper/test_lock_state_events.py
@@ -1,0 +1,328 @@
+"""Screen lock stops being a question asked once a second.
+
+WHAT WAS MEASURED
+-----------------
+`_system_state_monitoring_loop` slept 1s forever and called
+`is_screen_locked()` SYNCHRONOUSLY on the event loop. On a live supervisor:
+571 checks in 9.8 minutes, 1,142 log lines (64% of everything the process
+said), and the answer never changed once. `screen_lock_detector` frames are
+also what the one surviving main-thread StallSampler dump contains -- because
+the detector's fallback path shells out to `osascript`.
+
+WHAT THESE PIN
+--------------
+That the loop reacts to an OS event rather than a timer, that the backstop
+survives an OS that never posts (registration proves the transport, never
+the producer), that the probe left the loop, and that the delta gate which
+was ALREADY correct still only speaks on a transition.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import time
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform != "darwin",
+                                reason="Darwin notify(3) is macOS-only")
+
+from backend.macos_helper import lock_state_listener as lsl
+
+
+# ---------------------------------------------------------------------------
+# The listener — a descriptor, a thread, and one door back to the loop
+# ---------------------------------------------------------------------------
+
+class TestListener:
+
+    def test_it_registers_and_reports_itself_available(self):
+        fired = []
+        li = lsl.LockStateListener(on_change=lambda: fired.append(1))
+        try:
+            started = li.start()
+            assert started is True
+            assert li.available is True
+            assert li.stats()["keys"], "registered with zero descriptors"
+        finally:
+            li.stop()
+        assert li.available is False, "stop() left the listener claiming live"
+
+    def test_a_posted_notification_wakes_the_thread(self):
+        """The round trip that proves the TRANSPORT. It deliberately does not
+        claim macOS posts these keys on lock -- that is the producer, and it
+        is why the consumer keeps a backstop."""
+        import ctypes, ctypes.util
+
+        libc = ctypes.CDLL(ctypes.util.find_library("System"), use_errno=True)
+        libc.notify_post.restype = ctypes.c_uint32
+        libc.notify_post.argtypes = [ctypes.c_char_p]
+
+        woke = threading_event()
+        li = lsl.LockStateListener(on_change=woke.set,
+                                   keys=("com.apple.screenIsLocked",))
+        try:
+            assert li.start() is True
+            libc.notify_post(b"com.apple.screenIsLocked")
+            assert woke.wait(timeout=5.0), "the descriptor never woke"
+            assert li.wakeups >= 1
+        finally:
+            li.stop()
+
+    @pytest.mark.asyncio
+    async def test_the_handoff_to_the_loop_is_call_soon_threadsafe(self):
+        """A listener thread touching loop state directly is the bug this
+        class exists to not have. The callback must arrive ON the loop."""
+        loop = asyncio.get_running_loop()
+        seen = {}
+
+        def _cb():
+            # If this ran on the listener thread, there'd be no running loop.
+            seen["loop"] = asyncio.get_event_loop_policy().get_event_loop()
+            seen["thread_is_main"] = True
+
+        li = lsl.LockStateListener(on_change=_cb, loop=loop,
+                                   keys=("com.apple.screenIsLocked",))
+        try:
+            assert li.start() is True
+            import ctypes, ctypes.util
+            libc = ctypes.CDLL(ctypes.util.find_library("System"))
+            libc.notify_post.argtypes = [ctypes.c_char_p]
+            libc.notify_post(b"com.apple.screenIsLocked")
+            for _ in range(50):
+                await asyncio.sleep(0.05)
+                if seen:
+                    break
+            assert seen.get("thread_is_main"), "callback never reached the loop"
+        finally:
+            li.stop()
+
+    def test_disabled_by_env_means_the_caller_keeps_polling(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_LOCK_EVENT_LISTENER_ENABLED", "0")
+        li = lsl.LockStateListener(on_change=lambda: None)
+        assert li.start() is False
+        assert li.available is False
+
+    def test_keys_are_env_replaceable(self, monkeypatch):
+        """An OS version that posts something else must not need a code
+        change."""
+        monkeypatch.setenv("JARVIS_LOCK_NOTIFY_KEYS", "com.example.a,com.example.b")
+        assert lsl.notify_keys() == ("com.example.a", "com.example.b")
+        monkeypatch.setenv("JARVIS_LOCK_NOTIFY_KEYS", "   ")
+        assert lsl.notify_keys() == lsl.DEFAULT_KEYS, "blank must not blind it"
+
+    def test_stop_is_idempotent_and_never_raises(self):
+        li = lsl.LockStateListener(on_change=lambda: None)
+        li.start()
+        li.stop()
+        li.stop()          # second stop must not explode on closed fds
+
+
+def threading_event():
+    import threading
+    return threading.Event()
+
+
+# ---------------------------------------------------------------------------
+# The monitor — event-primary, adaptive floor, probe off the loop
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def monitor():
+    from backend.macos_helper.system_event_monitor import SystemEventMonitor
+    m = SystemEventMonitor()
+    m._running = True
+    return m
+
+
+class TestTheLoopIsEventPrimary:
+
+    @pytest.mark.asyncio
+    async def test_an_event_wakes_it_far_sooner_than_the_backstop(
+            self, monitor, monkeypatch):
+        """The whole point: a transition is noticed immediately, not on the
+        next tick of a timer."""
+        monkeypatch.setenv("JARVIS_LOCK_BACKSTOP_MIN_S", "30")
+        monkeypatch.setenv("JARVIS_LOCK_BACKSTOP_MAX_S", "30")
+        calls = []
+
+        async def _probe():
+            calls.append(time.monotonic())
+            return False
+
+        monitor._update_screen_lock_status = _probe
+        monitor._start_lock_listener = lambda: None
+
+        task = asyncio.create_task(monitor._system_state_monitoring_loop())
+        await asyncio.sleep(0.05)
+        n_before = len(calls)
+        monitor._lock_event.set()               # the OS "said" something moved
+        await asyncio.sleep(0.15)
+        monitor._running = False
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert len(calls) > n_before, (
+            "the event did not wake the loop — it is still timer-driven")
+
+    def test_the_responsive_floor_refuses_a_pathological_interval(
+            self, monitor, monkeypatch):
+        """An operator must not be able to configure a 1ms poll. The first
+        draft of the test above set 0.02s and read the clamped 0.1s back as a
+        bug in the loop -- it was the guard doing its job."""
+        monkeypatch.setenv("JARVIS_LOCK_BACKSTOP_MIN_S", "0.001")
+        assert monitor._lock_backstop_min_s() == 0.1
+        monkeypatch.setenv("JARVIS_LOCK_BACKSTOP_GROWTH", "0.5")
+        assert monitor._lock_backstop_growth() >= 1.0, (
+            "a growth factor below 1 would SHRINK the backstop forever")
+
+    @pytest.mark.asyncio
+    async def test_the_backstop_widens_while_nothing_changes(
+            self, monitor, monkeypatch):
+        """A machine that never locks must stop paying to ask."""
+        monkeypatch.setenv("JARVIS_LOCK_BACKSTOP_MIN_S", "0.1")
+        monkeypatch.setenv("JARVIS_LOCK_BACKSTOP_MAX_S", "10")
+        monkeypatch.setenv("JARVIS_LOCK_BACKSTOP_GROWTH", "2")
+        stamps = []
+
+        async def _probe():
+            stamps.append(time.monotonic())
+            return False                        # never any news
+
+        monitor._update_screen_lock_status = _probe
+        monitor._start_lock_listener = lambda: None
+
+        task = asyncio.create_task(monitor._system_state_monitoring_loop())
+        await asyncio.sleep(1.7)
+        monitor._running = False
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert len(stamps) >= 3, "too few samples to see a trend"
+        gaps = [b - a for a, b in zip(stamps, stamps[1:])]
+        assert gaps[-1] > gaps[0] * 1.5, (
+            f"backstop never widened: {gaps[0]:.3f}s -> {gaps[-1]:.3f}s")
+
+    @pytest.mark.asyncio
+    async def test_a_transition_collapses_the_backstop_to_responsive(
+            self, monitor, monkeypatch):
+        """Right after a change is when the next one is most likely."""
+        monkeypatch.setenv("JARVIS_LOCK_BACKSTOP_MIN_S", "0.1")
+        monkeypatch.setenv("JARVIS_LOCK_BACKSTOP_MAX_S", "10")
+        monkeypatch.setenv("JARVIS_LOCK_BACKSTOP_GROWTH", "2")
+        stamps, changed = [], {"n": 0}
+
+        async def _probe():
+            stamps.append(time.monotonic())
+            changed["n"] += 1
+            return changed["n"] == 4            # one transition, mid-run
+
+        monitor._update_screen_lock_status = _probe
+        monitor._start_lock_listener = lambda: None
+
+        task = asyncio.create_task(monitor._system_state_monitoring_loop())
+        await asyncio.sleep(2.2)
+        monitor._running = False
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        gaps = [b - a for a, b in zip(stamps, stamps[1:])]
+        assert len(gaps) >= 4, f"not enough samples: {len(gaps)}"
+        # Probes 1..4 widen (0.1, 0.2, 0.4); probe 4 reports the transition,
+        # so the interval BEFORE probe 5 must collapse back to the floor.
+        assert gaps[3] < gaps[2], (
+            f"a transition did not reset the backstop: {gaps[2]:.3f} -> "
+            f"{gaps[3]:.3f}")
+
+
+class TestTheProbeLeftTheLoop:
+
+    @pytest.mark.asyncio
+    async def test_a_slow_lock_probe_does_not_stall_the_loop(self, monitor):
+        """`is_screen_locked` falls back to `osascript`. On the loop, that is
+        a multi-second stall — the frame the surviving dump caught."""
+        import backend.macos_helper.system_event_monitor as sem
+
+        real_import = __import__
+
+        def _slow_is_screen_locked():
+            time.sleep(0.4)                     # what osascript costs
+            return False
+
+        mod = type(sys)("voice_unlock.objc.server.screen_lock_detector")
+        mod.is_screen_locked = _slow_is_screen_locked
+        sys.modules["voice_unlock.objc.server.screen_lock_detector"] = mod
+        try:
+            worst = 0.0
+            ticking = True
+
+            async def ticker():
+                nonlocal worst
+                while ticking:
+                    t0 = time.monotonic()
+                    await asyncio.sleep(0.01)
+                    worst = max(worst, time.monotonic() - t0 - 0.01)
+
+            t = asyncio.create_task(ticker())
+            await asyncio.sleep(0.02)
+            await monitor._update_screen_lock_status()
+            ticking = False
+            t.cancel()
+            try:
+                await t
+            except asyncio.CancelledError:
+                pass
+
+            assert worst < 0.2, (
+                f"the loop was blocked {worst:.3f}s by the lock probe")
+        finally:
+            sys.modules.pop("voice_unlock.objc.server.screen_lock_detector", None)
+
+
+class TestTheDeltaGateAndTheLogging:
+
+    @pytest.mark.asyncio
+    async def test_only_a_transition_emits_an_event(self, monitor):
+        """This gate was already correct and is deliberately untouched."""
+        emitted = []
+        monitor._emit_event = lambda e: asyncio.sleep(0, result=emitted.append(e))
+
+        mod = type(sys)("voice_unlock.objc.server.screen_lock_detector")
+        state = {"v": False}
+        mod.is_screen_locked = lambda: state["v"]
+        sys.modules["voice_unlock.objc.server.screen_lock_detector"] = mod
+        try:
+            assert await monitor._update_screen_lock_status() is False
+            assert await monitor._update_screen_lock_status() is False
+            assert emitted == [], "an event fired without a transition"
+
+            state["v"] = True
+            assert await monitor._update_screen_lock_status() is True
+            assert len(emitted) == 1, "the transition did not emit exactly once"
+
+            assert await monitor._update_screen_lock_status() is False
+            assert len(emitted) == 1, "a steady state emitted again"
+        finally:
+            sys.modules.pop("voice_unlock.objc.server.screen_lock_detector", None)
+
+    def test_the_unlocked_fast_path_no_longer_logs_at_INFO(self, caplog):
+        """64% of the log was this line saying nothing had changed."""
+        from voice_unlock.objc.server import screen_lock_detector as d
+
+        with caplog.at_level(logging.INFO,
+                             logger="voice_unlock.objc.server.screen_lock_detector"):
+            d._check_cgsession_locked_via_ctypes()
+        noisy = [r for r in caplog.records
+                 if r.levelno >= logging.INFO and "UNLOCKED" in r.getMessage()]
+        assert not noisy, f"still emitting INFO on the no-news path: {noisy}"


### PR DESCRIPTION
## The defect

`_system_state_monitoring_loop` slept 1s forever and called `is_screen_locked()` **synchronously on the event loop**. Measured on a live supervisor: **571 checks in 9.8 minutes, 1,142 log lines — 64% of everything the process said** — to report that nothing had changed, 571 times in a row.

The severity, not the noise, is why it mattered: `is_screen_locked` falls back to `osascript` when CGSession is inconclusive, and a synchronous subprocess on the loop is how a lock probe becomes a multi-second stall. `screen_lock_detector` frames are exactly what the one surviving main-thread StallSampler dump contains.

## Why ctypes `notify(3)` and not DistributedNotificationCenter

pyobjc is the textbook answer and the wrong one here, for a reason this codebase already paid for (`async_pipeline` v270.1): importing Quartz pulls `AppKit._metadata`, which **SIGSEGVs while the CoreAudio IO thread is active** — and this process runs CoreAudio. It also needs a live CFRunLoop pumping on its thread.

`notify(3)` from libSystem has neither problem: a C API reachable by ctypes that hands back a plain **file descriptor** — something a thread can block on with `select` and a loop can be told about with `call_soon_threadsafe`. **Measured wake: 0.2ms.**

## Event-primary, never event-only

`notify_register_file_descriptor` returns success for a name whether or not anything ever posts it. Registration proves the **transport**; it cannot prove macOS **posts** these keys on this OS version. So the poll is **demoted, not deleted** — and made **adaptive**: responsive floor, geometric back-off while quiet, collapsing back to responsive on any transition, because the moment after a change is when the next one is likeliest. Same event-primary-with-a-floor shape the intake sensors use for `fs.changed.*`.

## Deliberately not rebuilt

**The state-delta gate.** `_update_screen_lock_status` already emitted only on transition and is left alone. The spam was never that gate — it was the **detector logging its own no-news answer at INFO**. Two log levels fixed 64% of the volume with no new layer.

## Two bugs the tests found, both mine

- `_dispatch` returned silently when no loop was bound, so a listener built without one **counted the wake and dropped the callback** — `wakeups` incremented while nothing downstream ran. A dispatcher that swallows the event it exists to deliver is worse than either honest option, so both are now explicit; `start()` also binds the running loop when the caller omits it.
- The first backstop test set `0.02s` and read the clamped `0.1s` back as a loop bug. It was the guard refusing a pathological interval — the test was wrong, and the floor is now pinned by a test of its own.

## Live-proven on a restarted daemon

```
[LockListener] event-driven lock detection live on 4 key(s):
  com.apple.screenIsLocked, com.apple.screenIsUnlocked,
  com.apple.sessionDidMoveOffConsole, com.apple.sessionDidMoveToConsole
```

| | previous boot | this boot |
|---|---|---|
| SCREEN-DETECT log lines | 2,220 | **0** |
| stalls in window | 12 | 8 |
| worst stall | 1.59s | 1.44s |
| StallSampler dumps | 0 | 0 |

**Honest bound:** the log result is decisive (64% → 0%) and the listener is confirmed armed. The **stall change is within noise** — 12→8 and 1.59s→1.44s over different window lengths is not a result I'd claim as a fix. A 1.44s stall remains and produced no dump, so its cause is currently unknown. The defensible claims are that the probe left the loop, the poll is no longer the mechanism, and the log dominance is gone.

## Tests

13 new, 25 green across the affected modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces 1 Hz screen-lock polling with event-driven detection via Darwin `notify(3)`. Demotes the poll to an adaptive backstop and offloads the lock probe from the event loop to prevent stalls and eliminate log spam.

- Old: `_system_state_monitoring_loop` slept 1s and synchronously called `is_screen_locked()`, sometimes spawning `osascript`, clogging logs and stalling the loop. New: `LockStateListener` blocks on `notify(3)` file descriptors and wakes the loop on lock/console transitions; the loop waits on an `asyncio.Event` with a widening backstop; only transitions are logged.

**Review focus**
- New `lock_state_listener.py`: ctypes-based `notify(3)` registration, one OS thread blocked in `select()`, self-pipe stop, `call_soon_threadsafe` handoff, and `stats()` for visibility.
- `system_event_monitor.py`: integrates the listener, introduces adaptive backoff (`MIN`, `MAX`, `GROWTH`), and uses `call_off_loop(is_screen_locked)` to keep subprocess fallbacks off the loop.
- `screen_lock_detector.py`: drops unlocked fast-path logs from INFO to DEBUG; transition logging remains in the monitor.
- Tests: cover event wake, backstop widening/reset, probe off-loop (no stalls), delta gate, and logging level changes.

**Rollout and ops**
- macOS-only path; no migration required. To disable: set `JARVIS_LOCK_EVENT_LISTENER_ENABLED=0`.
- Override notify keys if an OS posts different names: `JARVIS_LOCK_NOTIFY_KEYS=com.example.key1,com.example.key2`.
- Tune backstop if needed: `JARVIS_LOCK_BACKSTOP_MIN_S`, `JARVIS_LOCK_BACKSTOP_MAX_S`, `JARVIS_LOCK_BACKSTOP_GROWTH` (clamped to safe ranges).
- Observe listener health via `listener.stats()` (`available`, `wakeups`, `keys`); when unavailable, behavior falls back to the backstop.

<sup>Written for commit 8c123cf99bae30a1d0073870d03efd92a4c5eb67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

