### PR TITLE
fix(hud): the 1.44s stall was not anonymous — the dumper was set above it

### DIFF
--- a/backend/core/prewarm.py
+++ b/backend/core/prewarm.py
@@ -75,6 +75,16 @@ DEFAULT_PREWARM: Tuple[str, ...] = (
     "backend.core.trinity_ipc",
     # The registry walk `audit_ratchet.registered_ratchets` triggers.
     "backend.core.ouroboros.battle_test.repl_dispatch_registry",
+    # Caught at `coding_council/orchestrator.py:273 <module>`, reached from
+    # `main.health_check` -> `get_coding_council_health` ->
+    # `get_coding_council`, which does a LAZY `from .orchestrator import ...`
+    # inside an async function. The dump's innermost frame was
+    # `importlib._bootstrap_external._write_atomic` -- the loop was writing a
+    # .pyc while an HTTP health request waited. Cold import measured at
+    # 325ms. Same shape as `backend.system` above, found the same way: by
+    # lowering JARVIS_STALL_SAMPLER_TRIGGER_S below the stall and reading
+    # the stack, rather than by adding another instrument.
+    "backend.core.coding_council.orchestrator",
 )
 
 __all__ = [

--- a/backend/hud/stall_sampler.py
+++ b/backend/hud/stall_sampler.py
@@ -94,7 +94,27 @@ def _f(name: str, default: float, minimum: float) -> float:
 
 
 def trigger_s() -> float:
-    return _f(ENV_TRIGGER_S, 2.0, 0.25)
+    """How stale the heartbeat must be before a dump is worth taking.
+
+    Was 2.0s. Lowered because a STATIC definition of "pathological" goes
+    blind as the system improves, and this one did: it was calibrated when
+    the worst stall was 32.31s, and by the time the worst was 1.44s it could
+    no longer fire at all. Five rounds of fixes had made the instrument that
+    found them incapable of finding the next one -- the ratchet only ever
+    tightens against the tool.
+
+    1.0s is still 4x the sentinel's own stall threshold, so this stays what
+    the comment above promises: the pathological windows, not every
+    scheduling hiccup. The cost of being wrong is bounded elsewhere and
+    cheaply -- `min_gap_s` (10s) and `max_dumps` (8 per process) cap the
+    total spend at eight stack dumps no matter how often the loop hitches.
+
+    Setting this to 0.60 is what unmasked the 0.63s stall whose innermost
+    frame was `importlib._bootstrap_external._write_atomic`: a .pyc being
+    written on the event loop while a FastAPI health request waited on a
+    first-time import of `coding_council.orchestrator`.
+    """
+    return _f(ENV_TRIGGER_S, 1.0, 0.25)
 
 
 def min_gap_s() -> float:

--- a/tests/hud/test_stall_visibility_ratchet.py
+++ b/tests/hud/test_stall_visibility_ratchet.py
@@ -1,0 +1,79 @@
+"""The instrument must be able to see the era it is in.
+
+WHAT HAPPENED
+-------------
+`StallSampler.trigger_s` was 2.0s, chosen when the worst observed stall was
+32.31s. Five rounds of fixes brought the worst to 1.44s -- at which point the
+dumper could no longer fire at all, and a real stall was reported by
+`LoopSentinel` (threshold 0.25s) with no stack behind it. The stall looked
+anonymous. It was not: it was sub-threshold, and the threshold was the bug.
+
+Lowering the trigger to 0.60s produced a dump on the first occurrence, whose
+innermost frame was `importlib._bootstrap_external._write_atomic` -- the loop
+writing a .pyc during a first-time import of `coding_council.orchestrator`,
+reached from a FastAPI health endpoint. Cold import measured at 325ms.
+
+These tests pin both halves: the dumper can see stalls of the size this
+system now produces, and the import it caught is pre-warmed so it stops
+landing on the loop.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.hud import stall_sampler
+from backend.hud import loop_sentinel
+from backend.core import prewarm
+
+
+class TestTheDumperCanSeeTheCurrentEra:
+
+    def test_the_trigger_is_below_the_stalls_this_system_actually_produces(self):
+        """The measured worst stall was 1.44s. A 2.0s trigger cannot fire on
+        that, which is how a real stall came to look like a ghost."""
+        assert stall_sampler.trigger_s() <= 1.44, (
+            f"trigger is {stall_sampler.trigger_s()}s — blind to the 1.44s "
+            f"class this system currently produces")
+
+    def test_it_still_sits_well_above_the_sentinel_so_dumps_stay_rare(self):
+        """A dump per scheduling hiccup would be noise, and the sampler's
+        whole value is that its output is worth reading."""
+        assert stall_sampler.trigger_s() >= loop_sentinel.stall_threshold_s() * 2, (
+            "the dumper is now close enough to the sentinel to dump on "
+            "ordinary hiccups")
+
+    def test_the_cost_of_a_lower_trigger_is_bounded(self):
+        """Lowering a diagnostic's threshold is only safe because the spend
+        is capped somewhere else. If these caps go, the trigger must be
+        re-examined -- that is why they are asserted here and not assumed."""
+        assert stall_sampler.max_dumps() <= 32, "unbounded dump count"
+        assert stall_sampler.min_gap_s() >= 1.0, "dumps could tail-chase"
+
+    def test_a_typo_in_the_knob_cannot_turn_it_into_a_spin(self, monkeypatch):
+        monkeypatch.setenv(stall_sampler.ENV_TRIGGER_S, "0.0001")
+        assert stall_sampler.trigger_s() >= 0.25, "clamp floor lost"
+        monkeypatch.setenv(stall_sampler.ENV_TRIGGER_S, "not-a-number")
+        assert stall_sampler.trigger_s() > 0, "a bad value must not raise"
+
+
+class TestTheImportItCaughtIsWarmed:
+
+    def test_the_health_endpoint_import_is_in_the_prewarm_list(self):
+        """`main.health_check` -> `get_coding_council_health` ->
+        `get_coding_council` does a LAZY `from .orchestrator import ...`
+        inside an async function. Warming it moves that cost off the request
+        path without changing a line of the subsystem."""
+        assert "backend.core.coding_council.orchestrator" in prewarm.DEFAULT_PREWARM
+
+    def test_every_prewarm_entry_is_importable_or_absent_not_a_typo(self):
+        """A misspelled entry warms nothing and fails silently -- the list
+        would still 'work' while the stall it targets kept happening."""
+        import importlib.util
+        for name in prewarm.DEFAULT_PREWARM:
+            top = name.split(".")[0]
+            assert importlib.util.find_spec(top) is not None or top not in (
+                "backend",), f"{name}: top-level package {top} not found"
+
+    def test_the_list_stays_deduplicated(self):
+        names = prewarm.prewarm_modules()
+        assert len(names) == len(set(names))


### PR DESCRIPTION
## There was no ghost

The stall that "left no dump" was **1.44s**. `StallSampler.trigger_s` was **2.0s**.

| instrument | threshold | what it does |
|---|---|---|
| `LoopSentinel` | 0.25s | reports the lag — this is where 1.44s came from |
| `StallSampler` | **2.0s** | dumps the stack — deliberately above the sentinel |

`1.44 < 2.0`. The instrument that could unmask it already existed and already had the knob.

## What it was

`JARVIS_STALL_SAMPLER_TRIGGER_S=0.60` + restart produced a dump on the first occurrence:

```
importlib._bootstrap_external._write_atomic     <- writing a .pyc
_cache_bytecode / get_code / exec_module
coding_council/orchestrator.py:273  <module>
coding_council/__init__.py:94       get_coding_council
integration.py:3200                 get_coding_council_health
main.py:7690                        health_check   <- a FastAPI endpoint
```

A **first-time import of `coding_council.orchestrator` executing on the event loop while an HTTP health request waited** — including the bytecode cache write. Cold import **measured at 325ms**. `get_coding_council` does a lazy `from .orchestrator import ...` inside an async function.

Known class, existing remedy. `prewarm.py`'s own docstring records the twin:

> Caught at `backend/system/__init__.py:21 <module>`, reached from `main._collect_bridge_health` inside a FastAPI health endpoint — an import executing while a request was being served.

So the fix is **one entry in the evidence-derived `DEFAULT_PREWARM` list**, not a new mechanism.

## The larger finding

**A static definition of "pathological" goes blind as the system improves** — and this one did. 2.0s was calibrated when the worst stall was 32.31s. By the time the worst was 1.44s, the dumper could not fire at all. Five rounds of fixes had made the instrument that found them incapable of finding the next one. The ratchet only ever tightens against the tool.

Default **2.0s → 1.0s**. Still 4× the sentinel's 0.25s, so it stays "pathological windows, not every hiccup" — and the cost of being wrong was *already* bounded: `min_gap_s` (10s) and `max_dumps` (8/process) cap total spend at eight dumps however often the loop hitches. Those caps are now asserted by tests rather than assumed, because they are what makes the lower trigger safe.

## Deliberately not built

**The per-task duration wrapper and `_run_once` tracing.**

- A task-duration wrapper names the **task**; this dump named the **line**. The culprit is a synchronous call *inside* a coroutine — a wrapper would have said `health_check` and stopped there.
- It allocates a wrapper **per task**, the opposite of zero-overhead on the normal path. The sampler costs one float read per interval, from a separate thread.
- asyncio's own `slow_callback_duration` exists (default 0.1s) but only fires in **debug mode**, whose overhead is real.
- `_run_once` is a **private API that does not exist on uvloop** — installed in this env, currently disabled for speechbrain/torch compatibility, so a future re-enable would silently blind the tracer.

## Tests

7 new, pinning both halves. 452 passed across everything touching prewarm/stall_sampler.

⚠️ 8 unrelated failures **verified pre-existing at clean HEAD `b6536231eb`** (baselined in a worktree): `test_startup_orchestrator` (3), `test_disease10_acceptance` (2), `test_default_components`, `test_disease10_wiring`, `test_failover_lifecycle_mesh_gaps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes 1.44s event-loop stalls visible and removes their cause during health checks by lowering the stall dump trigger and prewarming the offending import.

- Default `backend.hud.stall_sampler.trigger_s` is now 1.0s (was 2.0s), so stalls below 2.0s produce stack dumps. Cost remains bounded by `min_gap_s` (10s) and `max_dumps` (8/process). `JARVIS_STALL_SAMPLER_TRIGGER_S` still overrides and is clamped to a 0.25s floor.
- Adds `backend.core.coding_council.orchestrator` to `backend.core.prewarm.DEFAULT_PREWARM` to avoid first-time import work on the request path of the health endpoint.
- Tests pin the new trigger behavior, the safety caps, env parsing/clamp, and the correctness/deduplication of the prewarm list.

<sup>Written for commit 552d8ef8795fb661d10cf6962f6133759e18361e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

