### PR TITLE
fix(workspace): an autonomous poll was foregrounding Chrome every 60 seconds

### DIFF
--- a/backend/autonomy/email_triage/runner.py
+++ b/backend/autonomy/email_triage/runner.py
@@ -1050,6 +1050,18 @@ class EmailTriageRunner:
         if agent:
             payload: Dict[str, Any] = {
                 "limit": self._config.max_emails_per_cycle,
+                # A poll never consents to the visual tier. The provenance
+                # gate (execution_context.is_unattended_request → the agent's
+                # _visual_surface_refused) already refuses it when this cycle
+                # runs inside execution_budget(request_kind=AUTONOMOUS) — but
+                # agent_runtime degrades to running the cycle UNSTAMPED when
+                # that import fails, and an unstamped context reads as
+                # attended. This key closes that one hole at the one caller
+                # that knows, structurally, that no human asked: without it,
+                # the degraded path re-inherits the config default and the
+                # 60s poll goes back to foregrounding Chrome and switching
+                # the operator's Spaces (measured: 84 hijacks in one boot).
+                "allow_visual_fallback": False,
             }
             # v291.2: Propagate deadline so the workspace agent → Google client
             # chain uses budget-aware timeouts instead of the fixed 15s default.

--- a/backend/core/execution_context.py
+++ b/backend/core/execution_context.py
@@ -55,6 +55,9 @@ __all__ = [
     "RootReason",
     "RequestKind",
     "Criticality",
+    # Attendance
+    "UNATTENDED_REQUEST_KINDS",
+    "is_unattended_request",
     # Errors
     "BudgetExhaustedError",
     "LocalCapExceededError",
@@ -380,6 +383,50 @@ def remaining_budget() -> Optional[float]:
     if ctx is None:
         return None
     return max(0.0, ctx.remaining)
+
+
+#: Request kinds during which NO HUMAN IS WATCHING the screen. The set lives
+#: here, beside the enum it interprets, so a new ``RequestKind`` member is
+#: added in the same diff that decides its attendance — not discovered later
+#: by whichever consumer guessed wrong.
+#:
+#: ``RUNTIME`` is deliberately absent: it is the kind interactive command
+#: paths run under (or they run with no context at all), and the consumers of
+#: this predicate use it to REFUSE things — a wrong ``True`` here silently
+#: degrades a human's "Iron Man" visual flow, which is the regression this
+#: comment exists to prevent.
+UNATTENDED_REQUEST_KINDS = frozenset({
+    RequestKind.STARTUP,
+    RequestKind.RECOVERY,
+    RequestKind.BACKGROUND,
+    RequestKind.AUTONOMOUS,
+})
+
+
+def is_unattended_request() -> bool:
+    """True iff the CURRENT task declared a request kind no human attends.
+
+    This is the canonical answer to "may this code path seize the user's
+    desktop / speak / otherwise commandeer an interactive surface?" — the
+    question v284.0's trusted-provenance work made answerable but nothing
+    yet asked. The first consumer is the workspace agent's visual tier,
+    which was observed foregrounding Chrome and switching macOS Spaces
+    every 60 seconds from an ``AUTONOMOUS``-stamped email-triage poll: the
+    stamp was present the whole time; no seam consulted it.
+
+    ``None`` context reads as ATTENDED. That polarity is load-bearing:
+    interactive command paths largely run outside any execution budget, so
+    fail-closed-on-None would break every human-initiated visual flow to
+    guard against callers that already carry the stamp. Unattended callers
+    that skip ``execution_budget`` (e.g. an ImportError degradation) must
+    declare themselves at their own seam instead — see
+    ``email_triage.runner._fetch_unread``. NEVER raises.
+    """
+    try:
+        ctx = _current_ctx.get()
+        return ctx is not None and ctx.request_kind in UNATTENDED_REQUEST_KINDS
+    except Exception:  # noqa: BLE001 — a telemetry predicate must not throw
+        return False
 
 
 # ---------------------------------------------------------------------------

--- a/backend/neural_mesh/agents/google_workspace_agent.py
+++ b/backend/neural_mesh/agents/google_workspace_agent.py
@@ -1086,6 +1086,10 @@ class UnifiedWorkspaceExecutor:
         self._calendar_bridge: Optional[CalendarBridge] = None
         self._computer_use: Optional[ComputerUseTool] = None
         self._spatial_awareness = None  # v6.2: SpatialAwarenessAgent integration
+        # Doors that already logged an unattended-refusal at INFO — the
+        # refusal fires on every autonomous poll tick, and only the first
+        # occurrence per door is a diagnostic (see _visual_surface_refused).
+        self._visual_refusals_logged: set = set()
         self._initialized = False
         self._lock = asyncio.Lock()
 
@@ -1148,8 +1152,53 @@ class UnifiedWorkspaceExecutor:
                 logger.exception(f"Error initializing unified executor: {e}")
                 return False
 
+    def _visual_surface_refused(self, door: str) -> bool:
+        """True when the CURRENT request may not seize the user's desktop.
+
+        The visual tier does not render into a sandbox — it foregrounds a
+        real browser via Yabai (``SwitchResult.LAUNCHED_APP``: it will OPEN
+        one if none exists), yanks the user across macOS Spaces, and
+        screenshots whatever is now frontmost. For a human who just said
+        "check my email" that is the product. For an unattended caller it is
+        a desktop hijack: the 60s email-triage poll, running with
+        ``RequestKind.AUTONOMOUS`` correctly stamped, was measured switching
+        the operator's Space every minute for an entire session (84 switches
+        in one boot) because the stamp existed and NO SEAM CONSULTED IT.
+
+        The decision is provenance-driven (``core.execution_context``), not
+        caller-discipline-driven: a payload flag can be authored by an LLM;
+        the contextvar cannot. Consulted at every door into the visual tier
+        — ``_ensure_spatial_awareness``, ``_ensure_visual_tooling``, and the
+        switch seam itself — BEFORE their cached fast paths, because an
+        interactive command warming the cache must not open the door for
+        the next autonomous poll. Fail-open to ATTENDED on any fault: the
+        predicate guards a convenience surface, and breaking the human flow
+        to guard it harder inverts the priorities. NEVER raises.
+        """
+        try:
+            from core.execution_context import is_unattended_request
+            refused = is_unattended_request()
+        except Exception:  # noqa: BLE001 — predicate unavailable ⇒ attended
+            return False
+        if refused:
+            # INFO once per door, then DEBUG — this fires on every poll tick
+            # and the first occurrence is the diagnostic, not the 500th.
+            if door not in self._visual_refusals_logged:
+                self._visual_refusals_logged.add(door)
+                logger.info(
+                    "[VisualTier] REFUSED (%s): unattended request kind — an "
+                    "autonomous caller may not foreground apps or switch "
+                    "Spaces; falling through to non-visual failure handling",
+                    door,
+                )
+            else:
+                logger.debug("[VisualTier] refused (%s): unattended", door)
+        return refused
+
     async def _ensure_spatial_awareness(self) -> bool:
         """Load spatial awareness only when a visual workflow actually needs it."""
+        if self._visual_surface_refused("spatial_awareness"):
+            return False
         if self._spatial_awareness is not None:
             return True
 
@@ -1174,6 +1223,8 @@ class UnifiedWorkspaceExecutor:
 
     async def _ensure_visual_tooling(self) -> bool:
         """Load Computer Use only for commands that explicitly need a visual tier."""
+        if self._visual_surface_refused("visual_tooling"):
+            return False
         if self._computer_use is not None:
             return True
 
@@ -1578,6 +1629,13 @@ class UnifiedWorkspaceExecutor:
         Returns:
             True if switch succeeded, False otherwise
         """
+        # Structural backstop at the ONE seam every visual path crosses to
+        # touch the desktop — including future callers that reach switching
+        # without passing either _ensure_* door first. Redundant with those
+        # doors by design: the doors give clean tier fallthrough; this line
+        # guarantees the hijack is impossible even if a door is bypassed.
+        if self._visual_surface_refused("app_switch"):
+            return False
         if not await self._ensure_spatial_awareness():
             logger.debug("Spatial Awareness not available, skipping app switch")
             return False
@@ -3731,7 +3789,21 @@ class GoogleWorkspaceAgent(BaseNeuralMeshAgent):
         self._fallback_uses = 0
 
     async def _narrate(self, text: str) -> None:
-        """Fire-and-forget voice narration for real-time feedback."""
+        """Fire-and-forget voice narration for real-time feedback.
+
+        Real-time feedback presumes someone is there to receive it. The
+        same 60s email-triage poll that was foregrounding Chrome was also
+        speaking "Checking your inbox now." into an empty room on every
+        tick — narration is a seizure of the audio surface exactly as the
+        visual tier is of the desktop, so it consults the same provenance
+        predicate at its own one door. Unattended ⇒ silent, not queued.
+        """
+        try:
+            from core.execution_context import is_unattended_request
+            if is_unattended_request():
+                return
+        except Exception:  # noqa: BLE001 — predicate unavailable ⇒ legacy
+            pass
         try:
             from backend.core.supervisor.unified_voice_orchestrator import safe_say
             await safe_say(text)

--- a/tests/unit/backend/neural_mesh/test_unattended_visual_tier.py
+++ b/tests/unit/backend/neural_mesh/test_unattended_visual_tier.py
@@ -1,0 +1,210 @@
+"""An autonomous poll may not seize the operator's desktop — or their ears.
+
+WHAT WAS MEASURED
+-----------------
+The 60-second email-triage poll, with its Google API tier dead on this
+machine, escalated to the Computer Use visual tier on every tick:
+`google_workspace_agent` foregrounded Chrome via Yabai (LAUNCHED_APP — it
+OPENS one when none exists), switched the operator's macOS Space (4 -> 5,
+84 times in one boot), screenshotted Gmail, and spoke "Checking your inbox
+now." into an empty room. The operator experienced it as "a Chrome window
+keeps opening".
+
+The provenance was PRESENT the entire time: agent_runtime wraps the cycle
+in `execution_budget(request_kind=RequestKind.AUTONOMOUS)` (v284.0, built
+exactly so payload flags need not be trusted). No seam consulted it. The
+fix is one canonical predicate — `execution_context.is_unattended_request`
+— consulted at every door into the visual tier, before the cached fast
+paths, plus one declared-consent key at the one caller that can run
+UNSTAMPED (agent_runtime's ImportError degradation).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+# The agent reads the SHORT module identity (`core.execution_context`) —
+# matching its stamper, agent_runtime. These tests stamp through the same
+# identity the production pairing uses; the dual-root hazard is pinned
+# explicitly below.
+import sys
+from pathlib import Path
+
+_BACKEND = str(Path(__file__).resolve().parents[4] / "backend")
+if _BACKEND not in sys.path:
+    sys.path.insert(0, _BACKEND)
+
+from core.execution_context import (  # noqa: E402
+    UNATTENDED_REQUEST_KINDS,
+    RequestKind,
+    execution_budget,
+    is_unattended_request,
+)
+from backend.neural_mesh.agents.google_workspace_agent import (  # noqa: E402
+    UnifiedWorkspaceExecutor,
+)
+
+
+# ---------------------------------------------------------------------------
+# The canonical predicate
+# ---------------------------------------------------------------------------
+
+class TestTheAttendancePredicate:
+
+    def test_no_context_reads_as_attended(self):
+        """Load-bearing polarity: interactive command paths mostly run
+        OUTSIDE any budget. Fail-closed-on-None would break every human
+        visual flow to guard callers that already carry the stamp."""
+        assert is_unattended_request() is False
+
+    @pytest.mark.asyncio
+    async def test_the_autonomous_stamp_reads_as_unattended(self):
+        """The exact stamp the email-triage poll carries."""
+        async with execution_budget(
+            owner="test", timeout=5.0, request_kind=RequestKind.AUTONOMOUS,
+        ):
+            assert is_unattended_request() is True
+        assert is_unattended_request() is False, "stamp leaked past the budget"
+
+    @pytest.mark.asyncio
+    async def test_runtime_reads_as_attended(self):
+        """RUNTIME is what interactive paths run under when they DO carry a
+        budget — refusing it would degrade the human's flow."""
+        async with execution_budget(
+            owner="test", timeout=5.0, request_kind=RequestKind.RUNTIME,
+        ):
+            assert is_unattended_request() is False
+
+    def test_every_request_kind_has_a_declared_attendance(self):
+        """A new RequestKind member must be classified in the same diff that
+        creates it — this is the assertion that forces the conversation."""
+        for kind in RequestKind:
+            assert (kind in UNATTENDED_REQUEST_KINDS) == (
+                kind is not RequestKind.RUNTIME
+            ), (
+                f"{kind} attendance changed or was never declared — decide "
+                f"it in UNATTENDED_REQUEST_KINDS, next to the enum"
+            )
+
+    def test_the_dual_root_pairing_is_pinned(self):
+        """`core.execution_context` and `backend.core.execution_context` are
+        TWO module instances with TWO contextvars. The stamper this fix
+        pairs with (agent_runtime) and the readers (workspace agent) both
+        use the SHORT identity; this test documents the hazard so a future
+        'cleanup' normalizing the agent's import to the long form doesn't
+        silently disconnect it from its stamper."""
+        import core.execution_context as short
+        import backend.core.execution_context as long_form
+        # Both exist and both expose the predicate...
+        assert hasattr(short, "is_unattended_request")
+        assert hasattr(long_form, "is_unattended_request")
+        # ...and the agent's source binds the short identity, like its stamper.
+        import inspect
+        import backend.neural_mesh.agents.google_workspace_agent as gwa
+        src = inspect.getsource(gwa)
+        assert "from core.execution_context import is_unattended_request" in src
+
+
+# ---------------------------------------------------------------------------
+# The doors
+# ---------------------------------------------------------------------------
+
+def _executor() -> UnifiedWorkspaceExecutor:
+    ex = UnifiedWorkspaceExecutor.__new__(UnifiedWorkspaceExecutor)
+    ex._spatial_awareness = None
+    ex._computer_use = None
+    ex._visual_refusals_logged = set()
+    ex._lock = asyncio.Lock()
+    return ex
+
+
+class TestTheVisualTierRefusesUnattendedRequests:
+
+    @pytest.mark.asyncio
+    async def test_visual_tooling_door_refuses_before_the_cache(self):
+        """The cache check must come SECOND: an interactive command warming
+        `_computer_use` must not open the door for the next poll."""
+        ex = _executor()
+        ex._computer_use = object()      # cache warm — the dangerous state
+        async with execution_budget(
+            owner="test", timeout=5.0, request_kind=RequestKind.AUTONOMOUS,
+        ):
+            assert await ex._ensure_visual_tooling() is False
+
+    @pytest.mark.asyncio
+    async def test_spatial_awareness_door_refuses_before_the_cache(self):
+        ex = _executor()
+        ex._spatial_awareness = {"switch_to_app": object()}
+        async with execution_budget(
+            owner="test", timeout=5.0, request_kind=RequestKind.AUTONOMOUS,
+        ):
+            assert await ex._ensure_spatial_awareness() is False
+
+    @pytest.mark.asyncio
+    async def test_the_switch_seam_backstop_never_reaches_yabai(self):
+        """The one seam every visual path crosses. Even a caller that
+        bypasses both _ensure_* doors cannot move the operator's Space."""
+        ex = _executor()
+        called = {"n": 0}
+
+        async def _switch(app, narrate=True):
+            called["n"] += 1
+
+        ex._spatial_awareness = {"switch_to_app": _switch}
+        async with execution_budget(
+            owner="test", timeout=5.0, request_kind=RequestKind.AUTONOMOUS,
+        ):
+            ok = await ex._switch_to_app_with_spatial_awareness("Google Chrome")
+        assert ok is False
+        assert called["n"] == 0, "an unattended request reached the desktop"
+
+    @pytest.mark.asyncio
+    async def test_attended_requests_pass_the_doors_unchanged(self):
+        """The gate must be invisible to the human path — cache-warm tooling
+        stays available with no context and under RUNTIME."""
+        ex = _executor()
+        ex._computer_use = object()
+        assert await ex._ensure_visual_tooling() is True
+        async with execution_budget(
+            owner="test", timeout=5.0, request_kind=RequestKind.RUNTIME,
+        ):
+            assert await ex._ensure_visual_tooling() is True
+
+    @pytest.mark.asyncio
+    async def test_refusal_logs_INFO_once_per_door_then_debug(self, caplog):
+        """This fires on every 60s poll tick; only the first occurrence per
+        door is a diagnostic."""
+        import logging
+        ex = _executor()
+        ex._computer_use = object()
+        with caplog.at_level(logging.INFO):
+            async with execution_budget(
+                owner="test", timeout=5.0,
+                request_kind=RequestKind.AUTONOMOUS,
+            ):
+                await ex._ensure_visual_tooling()
+                await ex._ensure_visual_tooling()
+        infos = [r for r in caplog.records
+                 if r.levelno == logging.INFO and "REFUSED" in r.getMessage()]
+        assert len(infos) == 1, f"expected exactly one INFO refusal, got {len(infos)}"
+
+
+# ---------------------------------------------------------------------------
+# The caller that can run unstamped
+# ---------------------------------------------------------------------------
+
+class TestTheTriagePollDeclaresItself:
+
+    def test_fetch_unread_payload_carries_explicit_no_visual_consent(self):
+        """agent_runtime degrades to running the cycle UNSTAMPED when the
+        execution_context import fails — and an unstamped context reads as
+        attended. The runner is the one caller that knows structurally that
+        no human asked, so it declares it in the payload, covering the
+        degraded path under ANY module identity."""
+        import inspect
+        from backend.autonomy.email_triage import runner as triage_runner
+        src = inspect.getsource(triage_runner.EmailTriageRunner._fetch_unread)
+        assert '"allow_visual_fallback": False' in src, (
+            "the poll's payload no longer refuses the visual tier — the "
+            "ImportError degradation path is unguarded again")


### PR DESCRIPTION
## The Chrome window

The operator reported "a Chrome window keeps opening." The log named the mechanism:

```
[Spatial Awareness] Switching to Google Chrome...
[Spatial Awareness] Successfully switched to Google Chrome (Space 4 -> 5)
```

**Every ~60 seconds. 84 times in one boot.** And `SwitchResult.LAUNCHED_APP` means the switch *opens* a Chrome window when none exists.

The chain: `EMAIL_TRIAGE` polls every 60s → the Google API tier is dead on this machine ("Google API libraries not available") → the waterfall escalates to **Tier 3 Computer Use** → Yabai foregrounds the browser, switches the operator's macOS Space, screenshots Gmail — and `_narrate()` speaks *"Checking your inbox now."* into an empty room on every tick.

## Root cause

The visual tier's precondition was **"is visual fallback enabled in general"** (`JARVIS_WORKSPACE_EMAIL_VISUAL_FALLBACK` — a global, origin-blind config default) when it must be **"did an attended interaction ask for this."**

The provenance was present the entire time: `agent_runtime` wraps the triage cycle in `execution_budget(request_kind=RequestKind.AUTONOMOUS)` — v284.0 built trusted provenance precisely so payload flags need not be believed. **The stamp existed; no seam consulted it.**

## The fix is the consultation, not a new mechanism

- **`core/execution_context.py`** gains the canonical predicate: `UNATTENDED_REQUEST_KINDS` (beside the enum it interprets, so a new member is classified in the diff that creates it) + `is_unattended_request()`. None-context reads **attended** — load-bearing polarity: interactive command paths mostly run outside any budget, and this predicate is used to *refuse* things.
- **The workspace executor consults it at every door** into the visual tier — `_ensure_spatial_awareness`, `_ensure_visual_tooling`, and the switch seam itself — **before the cached fast paths**, because an interactive command warming the cache must not open the door for the next poll. The switch seam is a deliberate structural backstop: even a caller bypassing both doors cannot move the operator's Space.
- **`_narrate()` consults the same predicate** — narration seizes the audio surface exactly as the visual tier seizes the desktop.
- **`email_triage/runner._fetch_unread` declares `"allow_visual_fallback": False`** — `agent_runtime` degrades to running the cycle *unstamped* when the `execution_context` import fails, and an unstamped context reads attended; the one caller that knows structurally that no human asked closes that hole under any module identity.

The human "Iron Man" flow is untouched: no-context and `RUNTIME` requests pass every door unchanged, pinned by test.

## Flagged, not fixed here

`core.execution_context` and `backend.core.execution_context` are **two module instances with two contextvars** (verified: `a is b` → `False`). The triage stamper and these readers both use the short identity — coherent pairing — but `unified_supervisor.py:2172` stamps through the long identity into a second ledger. Pinned by test so a future import "cleanup" cannot silently disconnect reader from stamper; unifying the aliasing in the 102K-line monolith is its own change.

## The posture blocks: innocent, verdict by the instrument's own rule

This hunt began as "take the posture blocks." Measured first: **every** LoopSink line in the O+V session reads `loop_stalled_ms=0.00`, and LoopSentinel recorded **zero** stalls. `loop_sink.py`'s own decision rule — written after a prior hours-long chase of this exact callsite — says *"elapsed high, stall ~0 → off-loop and healthy — IGNORE."* Their elapsed time is worker-pool wall clock during boot contention, not loop blockage. **No posture code was changed, deliberately** — Slices 24/33/257/258 already did that work, and it held.

## Tests

11 new, all green. Pre-existing reds confirmed at clean HEAD `b0980fb3d7` in a worktree (not this change): `test_shell_action_blocked`, `test_handle_security_alert_unresolved_high_risk_is_info`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Chrome from being foregrounded every 60 seconds by the autonomous email triage poll. Unattended requests now refuse visual and narration paths; attended commands behave unchanged.

- Adds `UNATTENDED_REQUEST_KINDS` and `is_unattended_request` to `core/execution_context` to classify unattended request kinds and guard desktop/audio seizure.
- The workspace executor consults the predicate at `_ensure_spatial_awareness`, `_ensure_visual_tooling`, and the app-switch seam, before cache checks; logs one INFO per door, then DEBUG.
- `_narrate()` checks the same predicate and stays silent when unattended.
- `backend/autonomy/email_triage/runner._fetch_unread` sets `"allow_visual_fallback": False` to cover the unstamped degradation path.
- Attended flows (no context or `RequestKind.RUNTIME`) still pass all doors; tests added in `tests/unit/backend/neural_mesh/test_unattended_visual_tier.py`.
- Known but not fixed: dual import roots `core.execution_context` vs `backend.core.execution_context`; pairing is pinned by test, import unification is out of scope.

<sup>Written for commit 04aab5e057d9240cb54396dc7268e611cf03f9af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

