### PR TITLE
feat(local): the guard measured how much RAM was left, not what was breaking

### DIFF
--- a/backend/core/ouroboros/governance/audio_contention_probe.py
+++ b/backend/core/ouroboros/governance/audio_contention_probe.py
@@ -1,0 +1,282 @@
+"""Ask the audio hardware whether it is already suffering.
+
+WHY THIS EXISTS
+---------------
+``local_model_admission``'s docstring names the hazard exactly:
+
+    the audio tap runs on a real-time thread, `HALC_ProxyIOContext ::
+    skipping cycle due to overload` is already in the boot log at idle, and
+    a swap storm during model load is exactly the condition that turns a
+    dropped buffer into a severed sentence.
+
+That sentence was PROSE. Nothing read it. The guard inferred audio risk
+from a memory number, which is a proxy for the thing we actually care
+about — and a proxy that says "22.8% free" while `coreaudiod` is, at that
+same moment, logging a real overload with a safety violation.
+
+macOS publishes the ground truth. `coreaudiod` emits an audioanalytics IO
+error per overload, and it carries the causal chain in one record:
+
+    overload_type: Overload          safety_violation: 1
+    multi_cycle_io_page_faults_duration: 3141689      <- PAGING, mid-cycle
+    lateness: 271   deadline: 2151   scheduler_latency: 31083
+
+`multi_cycle_io_page_faults_duration` is the mechanism the admission
+docstring describes, measured by the OS rather than guessed by us: the
+real-time thread took page faults inside its IO deadline. That is a swap
+storm severing a sentence, in one field.
+
+COST, MEASURED
+--------------
+`/usr/bin/log show` costs ~1.4-2.7s and the cost is dominated by process
+startup, NOT by window length (30s window: 2.70s; 120s: 1.46s). Two
+consequences, both structural:
+
+  * it can never run on the event loop, and never per token — it is
+    TTL-cached and single-flight;
+  * the window may be generous for free, so it is, which makes the signal
+    less spiky than a tight window would.
+
+UNKNOWN IS NOT CONTENTION
+-------------------------
+When the probe cannot answer — binary missing, timeout, breaker open, a
+future macOS that renames the subsystem — it returns ``ok=False`` and
+callers fall back to the memory-only decision. Reading "could not measure"
+as "audio is suffering" would refuse local inference forever the first
+time Apple changes a log predicate, which is how a safety guard becomes
+the reason a tier is permanently dark. The memory gate still guards; this
+sharpens it when it can.
+
+Python 3.9+, ``from __future__ import annotations``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("Jarvis.AudioContention")
+
+AUDIO_CONTENTION_SCHEMA_VERSION: str = "audio_contention.1"
+
+#: The subsystem coreaudiod reports IO errors through.
+_PREDICATE = (
+    'subsystem == "com.apple.audioanalytics" '
+    'AND eventMessage CONTAINS "overload_type"'
+)
+
+_INT_FIELD = r'"{field}":\s*Optional\((-?\d+)\)'
+
+__all__ = [
+    "AUDIO_CONTENTION_SCHEMA_VERSION",
+    "AudioContention",
+    "probe",
+    "probe_async",
+    "reset_for_tests",
+    "window_s",
+]
+
+
+def enabled() -> bool:
+    """``JARVIS_AUDIO_CONTENTION_PROBE_ENABLED`` (default true)."""
+    raw = (os.environ.get("JARVIS_AUDIO_CONTENTION_PROBE_ENABLED", "1") or "").strip()
+    return raw.lower() not in ("0", "false", "no", "off")
+
+
+def _f(name: str, default: float, lo: float, hi: float) -> float:
+    """Env float, clamped. NEVER raises — a typo in a guard's timing must
+    not be able to turn the guard into the outage."""
+    try:
+        raw = (os.environ.get(name) or "").strip()
+        return max(lo, min(hi, float(raw))) if raw else default
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def window_s() -> float:
+    """How far back to look. Generous because it is nearly free (see COST)."""
+    return _f("JARVIS_AUDIO_CONTENTION_WINDOW_S", 120.0, 10.0, 3600.0)
+
+
+def ttl_s() -> float:
+    """Cache lifetime. Must exceed the probe's own ~1.4-2.7s cost by a wide
+    margin or the probe becomes the contention it measures."""
+    return _f("JARVIS_AUDIO_CONTENTION_TTL_S", 45.0, 5.0, 900.0)
+
+
+def timeout_s() -> float:
+    return _f("JARVIS_AUDIO_CONTENTION_TIMEOUT_S", 8.0, 1.0, 60.0)
+
+
+@dataclass(frozen=True)
+class AudioContention:
+    """One reading. ``ok=False`` means UNMEASURED, never "healthy"."""
+
+    ok: bool
+    overloads: int = 0
+    safety_violations: int = 0
+    worst_lateness: int = 0
+    page_fault_ns: int = 0
+    window_s: float = 0.0
+    age_s: float = 0.0
+    error: Optional[str] = None
+
+    @property
+    def contended(self) -> bool:
+        """Did the audio graph actually miss its deadline in the window?
+
+        A single overload counts. There is no "acceptable rate" of severed
+        audio to tune here — the caller decides what to DO about it, and
+        the caller has cheaper options than refusing (slow down first).
+        """
+        return self.ok and self.overloads > 0
+
+    @property
+    def paging_implicated(self) -> bool:
+        """True when the overloads took page faults inside the IO cycle.
+
+        This is the distinction that makes the signal actionable for a
+        MEMORY guard: audio can overload for reasons a local model cannot
+        cause (a USB interface, a hostile plugin). Page faults mid-cycle
+        are memory pressure, which is exactly what loading weights makes
+        worse — so this is the field that should move an ADMISSION
+        decision, while bare `contended` should only move a SPEED one.
+        """
+        return self.contended and self.page_fault_ns > 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": AUDIO_CONTENTION_SCHEMA_VERSION,
+            "ok": self.ok, "overloads": self.overloads,
+            "safety_violations": self.safety_violations,
+            "worst_lateness": self.worst_lateness,
+            "page_fault_ns": self.page_fault_ns,
+            "contended": self.contended,
+            "paging_implicated": self.paging_implicated,
+            "window_s": self.window_s, "age_s": round(self.age_s, 1),
+            "error": self.error,
+        }
+
+
+_lock = threading.Lock()
+_cached: Optional[AudioContention] = None
+_cached_at: float = 0.0
+_inflight = threading.Lock()
+
+
+def _parse(out: str, window: float) -> AudioContention:
+    """Count overloads and extract the worst numbers. NEVER raises."""
+    try:
+        lines = [ln for ln in out.splitlines() if "overload_type" in ln]
+        if not lines:
+            return AudioContention(ok=True, overloads=0, window_s=window)
+
+        def _max_field(field: str) -> int:
+            best = 0
+            for m in re.finditer(_INT_FIELD.format(field=field), out):
+                try:
+                    best = max(best, int(m.group(1)))
+                except ValueError:
+                    continue
+            return best
+
+        # safety_violation is 0/1 per record — count records, not the max.
+        violations = sum(
+            1 for m in re.finditer(_INT_FIELD.format(field="safety_violation"), out)
+            if m.group(1) not in ("0",)
+        )
+        return AudioContention(
+            ok=True,
+            overloads=len(lines),
+            safety_violations=violations,
+            worst_lateness=_max_field("lateness"),
+            page_fault_ns=_max_field("multi_cycle_io_page_faults_duration"),
+            window_s=window,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return AudioContention(ok=False, window_s=window,
+                               error=f"parse:{type(exc).__name__}")
+
+
+def probe(force: bool = False) -> AudioContention:
+    """A cached reading. SYNCHRONOUS and ~1.4-2.7s on a miss — callers on
+    the event loop MUST use :func:`probe_async`. NEVER raises.
+    """
+    global _cached, _cached_at  # noqa: PLW0603
+
+    if not enabled():
+        return AudioContention(ok=False, error="disabled")
+
+    now = time.monotonic()
+    with _lock:
+        if _cached is not None and not force and (now - _cached_at) < ttl_s():
+            age = now - _cached_at
+            return AudioContention(**{**_cached.__dict__, "age_s": age})
+
+    # Single-flight: a burst of callers must not each spawn `log show`.
+    # Non-blocking acquire — a caller that loses the race takes the stale
+    # reading rather than queueing behind a 2s subprocess.
+    if not _inflight.acquire(blocking=False):
+        with _lock:
+            if _cached is not None:
+                return AudioContention(
+                    **{**_cached.__dict__, "age_s": now - _cached_at})
+        return AudioContention(ok=False, error="probe_in_flight")
+
+    try:
+        window = window_s()
+        try:
+            from backend.core.bounded_subprocess import run_bounded
+        except Exception:  # noqa: BLE001
+            return AudioContention(ok=False, window_s=window,
+                                   error="bounded_subprocess_unavailable")
+
+        completed = run_bounded(
+            ["/usr/bin/log", "show", "--last", f"{int(window)}s",
+             "--predicate", _PREDICATE, "--style", "compact"],
+            timeout=timeout_s(), text=True,
+        )
+        if completed is None:
+            reading = AudioContention(ok=False, window_s=window,
+                                      error="unanswered")
+        elif completed.returncode != 0:
+            reading = AudioContention(ok=False, window_s=window,
+                                      error=f"rc={completed.returncode}")
+        else:
+            reading = _parse(completed.stdout or "", window)
+
+        with _lock:
+            _cached = reading
+            _cached_at = time.monotonic()
+        return reading
+    finally:
+        _inflight.release()
+
+
+async def probe_async(force: bool = False) -> AudioContention:
+    """:func:`probe` off the event loop. NEVER raises.
+
+    Uses the house offload primitive, whose pool is separate from the
+    default executor precisely so a 2s subprocess cannot contend with the
+    200+ ``to_thread`` sites in this process.
+    """
+    try:
+        from backend.core.async_offload import call_off_loop
+        result = await call_off_loop(probe, force)
+        if result is None:                      # offload failed, fail-open
+            return AudioContention(ok=False, error="offload_failed")
+        return result
+    except Exception:  # noqa: BLE001
+        return AudioContention(ok=False, error="offload_error")
+
+
+def reset_for_tests() -> None:
+    """Test-only."""
+    global _cached, _cached_at  # noqa: PLW0603
+    with _lock:
+        _cached = None
+        _cached_at = 0.0

--- a/backend/core/ouroboros/governance/local_model_admission.py
+++ b/backend/core/ouroboros/governance/local_model_admission.py
@@ -68,10 +68,11 @@ from __future__ import annotations
 import enum
 import logging
 import os
+import re
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger("Ouroboros.LocalModelAdmission")
 
@@ -575,6 +576,260 @@ def _read_host_pressure() -> Tuple[str, float, str]:
         return ("unknown", -1.0, "unavailable")
 
 
+# ---------------------------------------------------------------------------
+# Contention dimension — the machine is not "fine below critical"
+# ---------------------------------------------------------------------------
+#
+# `free_pct` is a LEVEL. It answers "how much is left", and on unified memory
+# that is a lagging, compressed, and frankly optimistic number: measured on
+# this host at the moment of writing, the canonical gate said `warn` (22.8%
+# free) while the machine was swapping in at 3.6 MB/s and `coreaudiod` had
+# logged a real overload — `safety_violation: 1`, and page faults taken INSIDE
+# the IO cycle — four minutes earlier.
+#
+# So the level says "room to spare" at the exact moment the audio graph is
+# being severed by paging. What is missing is a RATE and a VICTIM:
+#
+#   * paging rate  — swap-in bytes per second. A level cannot distinguish a
+#     machine sitting still at 11 GB of swap (survivable) from one actively
+#     paging (not), and it is the paging that costs the real-time thread its
+#     deadline.
+#   * audio contention — `audio_contention_probe`, which reads the overload
+#     records coreaudiod already publishes. Its `paging_implicated` flag is
+#     the causal join: audio missed its deadline AND took page faults doing
+#     it. That is this module's docstring, finally measured instead of feared.
+#
+# Each independent signal escalates the host level ONE rung through the
+# EXISTING ladder (admit → prune → defer). No new action vocabulary, no
+# second decision path: strictest-wins composition, the same discipline this
+# module already applies across its accelerator and host bounds.
+
+
+def paging_rate_threshold_bps() -> float:
+    """Swap-in bytes/sec above which the machine counts as actively paging.
+
+    Default 1 MiB/s. Not a capacity figure — a *sustained transfer* figure:
+    below it, paging is incidental; above it, the machine is moving working
+    set through swap continuously, which is the condition that costs a
+    real-time audio thread its deadline.
+    """
+    return _envf("JARVIS_LOCAL_PAGING_RATE_BPS", 1_048_576.0, 0.0, 1e12)
+
+
+def contention_enabled() -> bool:
+    """``JARVIS_LOCAL_CONTENTION_GATE_ENABLED`` (default true).
+
+    Off restores the v2 ladder byte-for-byte: level-only, no rate, no audio.
+    """
+    raw = (os.environ.get("JARVIS_LOCAL_CONTENTION_GATE_ENABLED", "1") or "").strip()
+    return raw.lower() not in ("0", "false", "no", "off")
+
+
+def _envf(name: str, default: float, lo: float, hi: float) -> float:
+    """Env float, clamped. NEVER raises."""
+    try:
+        raw = (os.environ.get(name) or "").strip()
+        return max(lo, min(hi, float(raw))) if raw else default
+    except Exception:  # noqa: BLE001
+        return default
+
+
+class _PagingSampler:
+    """Swap-in RATE, from two samples. Thread-safe. NEVER raises.
+
+    Cascades psutil → `vm_stat`, mirroring `memory_pressure_gate`'s own probe
+    cascade rather than inventing a second one. The cascade is not
+    defensive decoration: `psutil.swap_memory()` raises OSError outright
+    under a restricted sandbox on this very machine (verified), while
+    `vm_stat` answers there — so a single-source probe would report
+    "unknown" for every caller that happens to be sandboxed.
+
+    A FIRST call can only return unknown: a rate needs two points in time,
+    and inventing one from a cumulative counter would be a fabricated
+    measurement driving a real refusal.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._last: Optional[Tuple[float, int]] = None      # (monotonic, bytes)
+        self._rate: Optional[float] = None                  # last GOOD rate
+        self._rate_at: float = 0.0
+
+    @staticmethod
+    def _read_swapin_bytes() -> Optional[int]:
+        """Cumulative swap-in bytes since boot, or None. NEVER raises."""
+        try:
+            import psutil
+            return int(psutil.swap_memory().sin)
+        except Exception:  # noqa: BLE001 — OSError under sandbox, or absent
+            pass
+        try:
+            from backend.core.bounded_subprocess import run_bounded
+            completed = run_bounded(["vm_stat"], timeout=3.0, text=True)
+            if completed is None or completed.returncode != 0:
+                return None
+            page_size = 4096
+            m = re.search(r"page size of (\d+) bytes", completed.stdout or "")
+            if m:
+                page_size = int(m.group(1))
+            # `Pageins` is the closest cumulative analogue vm_stat exposes;
+            # it counts pages faulted in from backing store, which is the
+            # same event psutil reports as `sin`.
+            m = re.search(r"Pageins:\s+(\d+)", completed.stdout or "")
+            if not m:
+                return None
+            return int(m.group(1)) * page_size
+        except Exception:  # noqa: BLE001
+            return None
+
+    def rate_bps(self) -> Optional[float]:
+        """Bytes/sec, or None when unknowable.
+
+        HOLDS THE LAST GOOD RATE between samples, and that is load-bearing
+        rather than an optimisation. The first version recomputed on every
+        call, and a caller that sampled twice a millisecond apart measured a
+        near-zero delta over a near-zero interval and got ~0 B/s — so the
+        guard silently DISARMED itself under exactly the rapid-polling
+        pattern an admission check produces. Observed: 27.4 MiB/s on one
+        read, `admit` on the next call in the same breath.
+
+        A rate needs time to exist. Below `_MIN_INTERVAL_S` no new rate is
+        computed and the previous one stands, ageing out after
+        `_RATE_TTL_S` — after which the honest answer is again "unknown",
+        not "zero".
+        """
+        now = time.monotonic()
+        with self._lock:
+            prev = self._last
+            cached, cached_at = self._rate, self._rate_at
+
+        if prev is not None and (now - prev[0]) < self._min_interval_s():
+            # Too soon to measure again — serve the last good rate if it is
+            # still fresh, else admit we do not know.
+            if cached is not None and (now - cached_at) < self._rate_ttl_s():
+                return cached
+            return None
+
+        total = self._read_swapin_bytes()
+        if total is None:
+            return None
+        with self._lock:
+            self._last = (now, total)
+        if prev is None:
+            return None                      # first sample: no rate exists yet
+        dt = now - prev[0]
+        if dt <= 0:
+            return None
+        delta = total - prev[1]
+        if delta < 0:
+            return None                      # counter reset (reboot / wrap)
+        rate = delta / dt
+        with self._lock:
+            self._rate, self._rate_at = rate, now
+        return rate
+
+    @staticmethod
+    def _min_interval_s() -> float:
+        """Shortest span over which a swap-in rate is meaningful."""
+        return _envf("JARVIS_LOCAL_PAGING_MIN_INTERVAL_S", 2.0, 0.2, 60.0)
+
+    @staticmethod
+    def _rate_ttl_s() -> float:
+        """How long a computed rate stays quotable before it is stale."""
+        return _envf("JARVIS_LOCAL_PAGING_RATE_TTL_S", 20.0, 1.0, 600.0)
+
+
+_paging_sampler = _PagingSampler()
+
+_LEVEL_ORDER: Tuple[str, ...] = ("ok", "warn", "high", "critical")
+
+
+def _escalate(level: str, rungs: int) -> str:
+    """Move `level` up the EXISTING ladder, saturating at critical.
+
+    An unrecognised level (notably ``unknown``, which `_read_host_pressure`
+    returns when the probe fails) is left ALONE. Escalating from a level we
+    could not read would let a broken memory probe manufacture a refusal out
+    of nothing — the exact fail-toward-OK posture this module already keeps.
+    """
+    if rungs <= 0 or level not in _LEVEL_ORDER:
+        return level
+    idx = min(len(_LEVEL_ORDER) - 1, _LEVEL_ORDER.index(level) + rungs)
+    return _LEVEL_ORDER[idx]
+
+
+def _read_contention() -> Tuple[int, List[str], Dict[str, Any]]:
+    """(rungs_to_escalate, reasons, evidence). NEVER raises.
+
+    Synchronous and cheap by construction: the paging sampler is two counter
+    reads, and the audio probe is TTL-cached — its ~2s `log show` runs at
+    most once per TTL and never on this call's critical path when warm. A
+    cold audio probe here would block, so an unwarmed cache reports unknown
+    and the memory dimension rules alone; `warm_contention_async` exists for
+    callers that can await and want the audio dimension live.
+    """
+    rungs = 0
+    reasons: List[str] = []
+    evidence: Dict[str, Any] = {}
+
+    if not contention_enabled():
+        return (0, [], {"enabled": False})
+
+    # -- paging rate ----------------------------------------------------
+    try:
+        rate = _paging_sampler.rate_bps()
+    except Exception:  # noqa: BLE001
+        rate = None
+    evidence["paging_bps"] = rate
+    if rate is not None:
+        threshold = paging_rate_threshold_bps()
+        evidence["paging_threshold_bps"] = threshold
+        if rate > threshold:
+            rungs += 1
+            reasons.append(
+                f"swapping in at {rate / (1024 * 1024):.1f} MiB/s")
+
+    # -- audio contention ------------------------------------------------
+    try:
+        from backend.core.ouroboros.governance.audio_contention_probe import (
+            probe as _audio_probe,
+        )
+        audio = _audio_probe()
+        evidence["audio"] = audio.to_dict()
+        # Only `paging_implicated` moves an ADMISSION decision. A bare
+        # overload can be caused by things a local model cannot influence
+        # (a USB interface, a hostile plugin), and refusing local inference
+        # for those would be a guard punishing the innocent. Page faults
+        # inside the IO cycle are memory pressure, which loading weights
+        # provably makes worse.
+        if audio.paging_implicated:
+            rungs += 1
+            reasons.append(
+                f"audio graph missed {audio.overloads} deadline(s) while "
+                f"page-faulting")
+    except Exception:  # noqa: BLE001 — probe absent ⇒ memory dimension rules
+        evidence["audio"] = {"ok": False, "error": "unavailable"}
+
+    return (rungs, reasons, evidence)
+
+
+async def warm_contention_async() -> None:
+    """Refresh the audio probe OFF the loop so `_read_contention` finds it
+    warm. NEVER raises, never blocks the caller beyond the offload hop.
+
+    Exists because the audio probe costs ~1.4-3.7s (measured) and must never
+    run inside a synchronous admission decision. A caller about to dispatch
+    local work awaits this first; everything else reads the cache.
+    """
+    try:
+        from backend.core.ouroboros.governance.audio_contention_probe import (
+            probe_async,
+        )
+        await probe_async()
+    except Exception:  # noqa: BLE001
+        logger.debug("[LocalModelAdmission] audio warm failed", exc_info=True)
+
+
 async def assess_async(
     requested_ctx: Optional[int] = None,
     *,
@@ -606,6 +861,9 @@ async def assess_async(
             await ct.resolve_jit()
     except Exception as exc:  # noqa: BLE001 — a stale reading beats no ruling
         logger.debug("[LocalModelAdmission] JIT probe degraded: %s", exc)
+    # This is the caller that can await, so it is the one that pays for a
+    # live audio reading — `assess` itself must stay synchronous and cheap.
+    await warm_contention_async()
     return assess(requested_ctx, weight_bytes=weight_bytes, model_id=model_id)
 
 
@@ -698,6 +956,24 @@ def _assess_impl(
                                  reason="admission control disabled")
 
     level, free_pct, source = _read_host_pressure()
+
+    # Contention escalation, applied BEFORE the ladder so every rung below
+    # reads ONE effective level rather than each branch learning about
+    # paging separately. See the block comment above `_read_contention`:
+    # measured on this host, the gate said `warn` (22.8% free) while the
+    # machine swapped in at 3.6 MiB/s and coreaudiod logged a real overload
+    # with page faults inside the IO cycle.
+    _rungs, _reasons, _ = _read_contention()
+    if _rungs:
+        _raw = level
+        level = _escalate(level, _rungs)
+        if level != _raw:
+            logger.info(
+                "[LocalModelAdmission] host level %s -> %s — %.1f%% free says "
+                "otherwise, but: %s",
+                _raw, level, free_pct, "; ".join(_reasons))
+            source = f"{source}+contention"
+
     reading = _read_accelerator()
     topology = getattr(getattr(reading, "topology", None), "value", "unknown")
 

--- a/tests/governance/test_local_contention_gate.py
+++ b/tests/governance/test_local_contention_gate.py
@@ -1,0 +1,205 @@
+"""A level says how much is left. It cannot say what is being destroyed.
+
+WHAT WAS MEASURED, ON THIS HOST
+-------------------------------
+The canonical memory gate reported ``warn`` — 22.8% free, well clear of its
+own thresholds — at the same moment that:
+
+  * the machine was swapping IN at 3.6 MiB/s (later 25.7 MiB/s), and
+  * ``coreaudiod`` had logged a real overload four minutes earlier, with
+    ``safety_violation: 1`` and ``multi_cycle_io_page_faults_duration:
+    3141689`` — page faults taken INSIDE the real-time IO cycle.
+
+`local_model_admission`'s docstring had described that exact failure since it
+was written ("a swap storm during model load is exactly the condition that
+turns a dropped buffer into a severed sentence"). It was PROSE. Nothing read
+it, and the ladder would have admitted a model load into it.
+
+These tests pin the two dimensions that were missing — a RATE and a VICTIM —
+and the composition that turns them into the existing admit/prune/defer
+ladder rather than a second decision path.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from backend.core.ouroboros.governance import audio_contention_probe as acp
+from backend.core.ouroboros.governance import local_model_admission as lma
+
+
+#: A real record, copied from `/usr/bin/log show` on this machine.
+REAL_OVERLOAD = (
+    '2026-08-17 11:35:46.195 Df coreaudiod[413:edf] '
+    '[com.apple.audioanalytics:carc] Sending message. { reporterID=683329, '
+    'category=IO, type=error, message=["io_frame_counter": Optional(1024), '
+    '"is_recovering": Optional(0), "overload_type": Optional(Overload), '
+    '"multi_cycle_io_page_faults_duration": Optional(3141689), '
+    '"safety_violation": Optional(1), "scheduler_latency": Optional(31083), '
+    '"deadline": Optional(2151), "lateness": Optional(271)] }'
+)
+
+
+class TestTheAudioProbeReadsTheRealRecord:
+
+    def test_it_extracts_the_causal_fields(self):
+        """A parser that always returned zero would pass a quiet-machine
+        test. This is the record it must actually understand."""
+        r = acp._parse(REAL_OVERLOAD, 120.0)
+        assert r.ok and r.overloads == 1
+        assert r.safety_violations == 1
+        assert r.worst_lateness == 271
+        assert r.page_fault_ns == 3141689
+        assert r.contended is True
+        assert r.paging_implicated is True
+
+    def test_an_overload_without_page_faults_is_not_paging_implicated(self):
+        """Audio can overload for reasons a local model cannot cause — a USB
+        interface, a hostile plugin. Refusing local inference for those would
+        be a guard punishing the innocent; only mid-cycle page faults are
+        evidence that MEMORY did it."""
+        clean = REAL_OVERLOAD.replace(
+            '"multi_cycle_io_page_faults_duration": Optional(3141689)',
+            '"multi_cycle_io_page_faults_duration": Optional(0)')
+        r = acp._parse(clean, 120.0)
+        assert r.contended is True
+        assert r.paging_implicated is False
+
+    def test_a_quiet_window_is_measured_not_unknown(self):
+        r = acp._parse("", 120.0)
+        assert r.ok is True and r.overloads == 0 and r.contended is False
+
+    def test_unknown_is_never_read_as_healthy(self):
+        """`ok=False` must not satisfy `contended` OR its negation by
+        accident — an unmeasured probe means the memory dimension rules
+        alone, not that audio is fine."""
+        unknown = acp.AudioContention(ok=False, error="unanswered")
+        assert unknown.contended is False
+        assert unknown.paging_implicated is False
+        assert unknown.ok is False
+
+    def test_disabled_returns_unknown_not_healthy(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_AUDIO_CONTENTION_PROBE_ENABLED", "0")
+        acp.reset_for_tests()
+        r = acp.probe()
+        assert r.ok is False and r.error == "disabled"
+
+
+class TestThePagingRateSurvivesRapidPolling:
+
+    def test_a_rate_needs_two_samples(self):
+        s = lma._PagingSampler()
+        assert s.rate_bps() is None, "a rate was invented from one sample"
+
+    def test_it_holds_the_last_good_rate_between_samples(self, monkeypatch):
+        """THE BUG THIS PINS. The first version recomputed on every call, so
+        a caller sampling twice a millisecond apart measured a near-zero
+        delta over a near-zero interval and got ~0 B/s — the guard silently
+        DISARMED itself under exactly the rapid-polling pattern an admission
+        check produces. Observed live: 27.4 MiB/s on one read, `admit` on the
+        very next call."""
+        monkeypatch.setenv("JARVIS_LOCAL_PAGING_MIN_INTERVAL_S", "5")
+        monkeypatch.setenv("JARVIS_LOCAL_PAGING_RATE_TTL_S", "60")
+        s = lma._PagingSampler()
+
+        counter = {"v": 0}
+        monkeypatch.setattr(s, "_read_swapin_bytes",
+                            staticmethod(lambda: counter["v"]))
+        assert s.rate_bps() is None            # baseline
+        time.sleep(0.05)
+        counter["v"] = 10 * 1024 * 1024
+        # Still inside min_interval -> no NEW rate, and none cached yet.
+        assert s.rate_bps() is None
+
+        # Force a measurable interval, then read a real rate.
+        monkeypatch.setenv("JARVIS_LOCAL_PAGING_MIN_INTERVAL_S", "0.2")
+        time.sleep(0.25)
+        first = s.rate_bps()
+        assert first is not None and first > 0
+
+        # Immediately re-poll: must serve the held rate, NOT collapse to 0.
+        again = s.rate_bps()
+        assert again == pytest.approx(first), (
+            f"rapid re-poll collapsed the rate {first} -> {again}; the guard "
+            f"disarms itself under admission-check polling")
+
+    def test_a_stale_held_rate_expires_to_unknown_not_zero(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_LOCAL_PAGING_MIN_INTERVAL_S", "60")
+        monkeypatch.setenv("JARVIS_LOCAL_PAGING_RATE_TTL_S", "0.05")
+        s = lma._PagingSampler()
+        monkeypatch.setattr(s, "_read_swapin_bytes", staticmethod(lambda: 1))
+        s.rate_bps()
+        time.sleep(0.1)
+        assert s.rate_bps() is None, "a stale rate was reported as fact"
+
+    def test_a_counter_reset_is_unknown_not_negative(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_LOCAL_PAGING_MIN_INTERVAL_S", "0.01")
+        s = lma._PagingSampler()
+        vals = iter([10_000_000, 5])           # reboot / wrap
+        monkeypatch.setattr(s, "_read_swapin_bytes",
+                            staticmethod(lambda: next(vals)))
+        s.rate_bps()
+        time.sleep(0.05)
+        assert s.rate_bps() is None
+
+
+class TestTheEscalationUsesTheExistingLadder:
+
+    def test_it_climbs_the_ladder_and_saturates(self):
+        assert lma._escalate("ok", 1) == "warn"
+        assert lma._escalate("warn", 1) == "high"
+        assert lma._escalate("warn", 2) == "critical"
+        assert lma._escalate("high", 1) == "critical"
+        assert lma._escalate("critical", 1) == "critical"
+
+    def test_an_unreadable_level_is_never_escalated(self):
+        """`_read_host_pressure` returns 'unknown' when its probe fails.
+        Escalating from a level nobody could read would let one broken
+        probe manufacture a refusal out of nothing — the fail-toward-OK
+        posture this module already keeps."""
+        assert lma._escalate("unknown", 3) == "unknown"
+
+    def test_zero_rungs_is_identity(self):
+        assert lma._escalate("warn", 0) == "warn"
+
+    def test_the_gate_can_be_switched_off_to_restore_the_old_ladder(
+            self, monkeypatch):
+        monkeypatch.setenv("JARVIS_LOCAL_CONTENTION_GATE_ENABLED", "0")
+        rungs, reasons, evidence = lma._read_contention()
+        assert rungs == 0 and reasons == []
+        assert evidence == {"enabled": False}
+
+    def test_each_signal_contributes_one_rung(self, monkeypatch):
+        """Strictest-wins composition, matching this module's own stated
+        discipline across its accelerator and host bounds."""
+        monkeypatch.setenv("JARVIS_LOCAL_CONTENTION_GATE_ENABLED", "1")
+        monkeypatch.setenv("JARVIS_LOCAL_PAGING_RATE_BPS", "1000")
+        monkeypatch.setattr(lma._paging_sampler, "rate_bps",
+                            lambda: 50_000.0)          # over threshold
+        monkeypatch.setattr(
+            acp, "probe",
+            lambda force=False: acp._parse(REAL_OVERLOAD, 120.0))
+        rungs, reasons, _ = lma._read_contention()
+        assert rungs == 2, f"expected paging+audio = 2 rungs, got {rungs}: {reasons}"
+
+    def test_quiet_machine_escalates_nothing(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_LOCAL_CONTENTION_GATE_ENABLED", "1")
+        monkeypatch.setenv("JARVIS_LOCAL_PAGING_RATE_BPS", "1000000")
+        monkeypatch.setattr(lma._paging_sampler, "rate_bps", lambda: 10.0)
+        monkeypatch.setattr(acp, "probe",
+                            lambda force=False: acp._parse("", 120.0))
+        rungs, reasons, _ = lma._read_contention()
+        assert rungs == 0 and reasons == []
+
+    def test_unmeasurable_signals_never_escalate(self, monkeypatch):
+        """Unknown is not contention. A probe that cannot answer must not
+        become a permanent refusal — that is how a safety guard turns into
+        the reason a tier is dark forever."""
+        monkeypatch.setenv("JARVIS_LOCAL_CONTENTION_GATE_ENABLED", "1")
+        monkeypatch.setattr(lma._paging_sampler, "rate_bps", lambda: None)
+        monkeypatch.setattr(
+            acp, "probe",
+            lambda force=False: acp.AudioContention(ok=False, error="x"))
+        rungs, _, _ = lma._read_contention()
+        assert rungs == 0


### PR DESCRIPTION
## Audit first — two of the three phases were already built

**Phase 2 (hybrid routing) exists end-to-end.** It is an *arming* question, not a build one:

```
build_local_prime_client()  →  LocalPrimeClient (Ollama OpenAI-compat)
    + LocalInferenceDirector attached as its governor
  →  PrimeProvider  →  CandidateGenerator(jprime=)
  →  _try_jprime_primacy on BACKGROUND / SPECULATIVE
```

Gated by `JARVIS_LOCAL_PRIME_ENABLED` (builds the client) and `JARVIS_JPRIME_PRIMACY` (routes BG/SPEC to it; Claude still skipped on those routes by design). **Nothing was added to that path.**

**Phase 3 (dark-code map) exists** as `dynamic_dispatch_registry.note_invocation` — *"The ONLY thing that earns `FIRING_DYNAMICALLY`"* — with verdicts `FIRING_DYNAMICALLY` / `REGISTERED_NEVER_INVOKED` / `UNSEEN`, plus `capability_liveness.py` and `liveness_repl.py`. A second breadcrumb system would be the exact duplication this session keeps finding.

## What was actually missing

The admission ladder read **one number**: `free_pct`. Measured on this host while writing this, the canonical gate said **`warn` (22.8% free — clear of its own thresholds)** while:

- the machine swapped **in** at 3.6 MiB/s, later **25.7 MiB/s**, and
- `coreaudiod` had logged a real overload minutes earlier carrying `safety_violation: 1` and `multi_cycle_io_page_faults_duration: 3141689` — **page faults taken inside the real-time IO cycle**

That is `local_model_admission`'s own docstring — *"a swap storm during model load is exactly the condition that turns a dropped buffer into a severed sentence"* — happening in real time, while the ladder would have **admitted** a model load into it. The docstring was prose. Nothing read it.

**A level says how much is left. It cannot say what is being destroyed.** Two dimensions were missing — a rate and a victim:

- **`audio_contention_probe.py`** (new) reads the overload records coreaudiod already publishes, via `/usr/bin/log show` through `bounded_subprocess` (process-group reap), off-loop, TTL-cached and single-flight — the probe costs **~1.4–3.7s measured**, dominated by process startup rather than window length. Its `paging_implicated` flag is the causal join.
- **a swap-in rate sampler**, cascading psutil → `vm_stat`, mirroring the gate's own cascade rather than inventing a second. That cascade is load-bearing: `psutil.swap_memory()` raises `OSError` outright under a restricted sandbox on this machine (verified).

Each independent signal escalates the host level **one rung through the existing `admit`/`prune`/`defer` ladder**. No new action vocabulary, no second decision path — strictest-wins, the same composition discipline this module already applies across its accelerator and host bounds.

## A bug this found in itself

The first rate sampler recomputed on every call. An admission check polls rapidly, so it measured a near-zero delta over a near-zero interval and reported ~0 B/s — **the guard silently disarmed under exactly the pattern it exists to serve.** Observed live: **27.4 MiB/s on one read, `admit` on the very next call.** It now holds the last good rate between samples and ages it out to **unknown, never to zero.** Pinned by test.

**Polarity, everywhere: unknown is not contention.** An unreadable level is never escalated; an unanswered audio probe lets the memory dimension rule alone. Reading "could not measure" as "is suffering" is how a safety guard becomes the reason a tier is permanently dark.

## Verified live on this host

With paging at 25.7 MiB/s:

```
assess → DEFER | level: critical | source: psutil+contention
"19.6% memory free — loading a local model now would swap,
 and the audio graph shares this memory"
```

Before this change, the same machine state returned **ADMIT**.

## Flags

Masters `JARVIS_LOCAL_CONTENTION_GATE_ENABLED` (default true; off restores the level-only ladder byte-for-byte) and `JARVIS_AUDIO_CONTENTION_PROBE_ENABLED`. Knobs: `JARVIS_LOCAL_PAGING_RATE_BPS` / `_MIN_INTERVAL_S` / `_RATE_TTL_S`, `JARVIS_AUDIO_CONTENTION_WINDOW_S` / `_TTL_S` / `_TIMEOUT_S`. No hardcoded timeouts or thresholds — every one env-tunable and clamped.

## Tests

16, including the **real coreaudiod record verbatim** — a parser that always returned zero would pass a quiet-machine test, so it is pinned against the record it must actually understand. 163 pass across the sibling admission suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds contention-aware admission for local models by escalating the host level based on swap-in rate and CoreAudio overloads. Previously decisions used only memory free_pct; now active paging or audio page-fault overload moves the level up before the admit/prune/defer ladder, which can turn ADMIT into PRUNE or DEFER without adding a new decision path.

- New `audio_contention_probe.py`: TTL-cached, single-flight, off-loop probe via `bounded_subprocess` that parses `coreaudiod` overloads from `/usr/bin/log show` and exposes `contended` and `paging_implicated`.
- Swap-in rate sampler in `local_model_admission`: cascades `psutil.swap_memory()` to `vm_stat`, holds the last good rate between samples, and expires to unknown (not zero). Fixes a bug where rapid polling collapsed the rate to ~0 B/s and silently disarmed the guard.
- Level escalation: each independent signal contributes one rung; saturates at `critical`. Unknown or unavailable signals do not escalate. `assess_async` warms the audio cache via `warm_contention_async`; synchronous `assess` stays cheap. Logs include escalation reasons and annotate the source as `+contention`.
- Tests: add coverage for the real `coreaudiod` record and the rate sampler behavior.

**Rollout**
- Default on: `JARVIS_LOCAL_CONTENTION_GATE_ENABLED=1`. Set to `0` to restore the previous level-only ladder.
- Audio probe controls: `JARVIS_AUDIO_CONTENTION_PROBE_ENABLED`, `JARVIS_AUDIO_CONTENTION_WINDOW_S`, `JARVIS_AUDIO_CONTENTION_TTL_S`, `JARVIS_AUDIO_CONTENTION_TIMEOUT_S`.
- Paging rate controls: `JARVIS_LOCAL_PAGING_RATE_BPS`, `JARVIS_LOCAL_PAGING_MIN_INTERVAL_S`, `JARVIS_LOCAL_PAGING_RATE_TTL_S`.
- No migrations required. Expect more conservative admissions on hosts actively swapping or logging `coreaudiod` page-fault overloads.

<sup>Written for commit befadb022d6b62b5b232499b795d914491658cc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

