### PR TITLE
fix: Five instruments that lied, and the render channel that dropped its output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,6 +189,15 @@ htmlcov/
 coverage.xml
 *.cover
 
+# E2E suite output. Declared as RESULTS_DIR by
+# .github/workflows/biometric-voice-unlock-e2e.yml and
+# unlock-integration-e2e.yml, which write reports here on every run --
+# so a LOCAL run of either suite permanently dirties the working tree.
+# That matters more here than it looks: the battle-test harness stashes
+# uncommitted work at boot, so an artifact directory nobody ignores becomes
+# a standing hazard to real work.
+test-results/
+
 # Testing framework artifacts
 .hypothesis/
 **/.hypothesis/

--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -56,9 +56,13 @@ import asyncio
 import json
 import logging
 import os
+import threading
 import time
+from collections import deque
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Set
+from typing import (
+    Any, Callable, Deque, Dict, List, Optional, Set, Tuple,
+)
 
 logger = logging.getLogger("Ouroboros.CockpitAttach")
 
@@ -298,6 +302,184 @@ def tool_activity_enabled() -> bool:
     ).strip().lower() in _TRUTHY
 
 
+def offline_backlog_enabled() -> bool:
+    """Master gate for retaining render frames emitted with NO cockpit attached.
+
+    Default ON. OFF is byte-identical to the pre-backlog behaviour: frames
+    emitted to an empty audience are dropped exactly as before."""
+    return os.environ.get(
+        "JARVIS_ATTACH_OFFLINE_BACKLOG_ENABLED", "1",
+    ).strip().lower() in _TRUTHY
+
+
+def _backlog_size() -> int:
+    """How many unheard frames to retain. Env ``JARVIS_ATTACH_BACKLOG_SIZE``.
+
+    A ring, not a buffer: the organism is long-lived and may run unattended
+    for hours, so this is sized to "what an operator can usefully read on
+    reattach", never to "everything that happened". Overflow is COUNTED, per
+    the no-silent-caps discipline -- a truncated backlog that presented itself
+    as complete would be a receipt for work it did not show."""
+    try:
+        return max(1, min(10000, int(
+            os.environ.get("JARVIS_ATTACH_BACKLOG_SIZE", "200"),
+        )))
+    except Exception:  # noqa: BLE001
+        return 200
+
+
+def _backlog_ttl_s() -> float:
+    """Age past which a retained frame is no longer worth showing.
+
+    Env ``JARVIS_ATTACH_BACKLOG_TTL_S``, default 1800 (30 min); ``0``
+    disables ageing. Render frames describe what the organism was doing at a
+    MOMENT. Replaying six-hour-old tool activity into a fresh cockpit would
+    paint history as present tense -- the same class of dishonesty as a
+    cached blast radius reported as a live measurement."""
+    try:
+        return max(0.0, float(
+            os.environ.get("JARVIS_ATTACH_BACKLOG_TTL_S", "1800"),
+        ))
+    except Exception:  # noqa: BLE001
+        return 1800.0
+
+
+class _OfflineBacklog:
+    """Render frames emitted while nobody was listening.
+
+    THE DEFECT THIS CLOSES
+    ----------------------
+    ``publish_line`` / ``publish_markup`` both open with ``if not
+    self._clients: return``. That is correct about the socket -- there is
+    nobody to write to -- and wrong about the ORGANISM, which went on
+    working. Every ``Update(path)`` block, every tool result, every diff
+    produced while the operator was detached was composed, formatted, and
+    discarded. Reattaching then showed an idle-looking cockpit for a session
+    that had been busy, which is indistinguishable from the organism having
+    done nothing.
+
+    WHAT IS RETAINED, AND WHAT IS DELIBERATELY NOT
+    ---------------------------------------------
+    * **Only the two RENDER channels.** The other ~9 ``not self._clients``
+      early returns in this module are control-plane (pending prompts, audio
+      state, autonomy holds, telemetry). A prompt frame replayed after its
+      gate resolved would offer the operator a decision that no longer
+      exists; ``focus_shield`` owns that lifecycle and has its own queue.
+      Retention here would be a second, disagreeing opinion about a live FSM.
+
+    * **Only AMBIENT frames.** A frame emitted under a session ContextVar is
+      one cockpit's private verb output. Its asker is gone, and session ids
+      are per-run, so replaying it to whoever attaches next paints someone
+      else's ``/posture status`` into a stranger's scrollback -- precisely
+      what ``_broadcast``'s addressing exists to prevent, arriving through a
+      new door. Ambient output has no owner and is everyone's business,
+      which is exactly what makes it safe to replay.
+
+    * **Only while the audience is EMPTY.** Retention stops the moment a
+      cockpit attaches. A second cockpit attaching later is joining a live
+      session, not recovering a gap, so it correctly sees nothing.
+
+    TWO-PHASE DRAIN
+    ---------------
+    :meth:`peek` then :meth:`commit`. The flush happens mid-handshake, and a
+    client whose socket breaks during it never saw a byte; clearing the ring
+    on read would destroy the backlog on behalf of a cockpit that failed to
+    receive it. So nothing is discarded until the write is known to have
+    landed.
+
+    Thread-safe: producers call from arbitrary threads (the publishers hop to
+    the loop only AFTER this point), the drain runs on the loop.
+    """
+
+    __slots__ = ("_frames", "_lock", "retained", "overflowed",
+                 "replayed", "dropped_stale")
+
+    def __init__(self) -> None:
+        self._frames: Deque[Tuple[float, Dict[str, Any]]] = deque(
+            maxlen=_backlog_size(),
+        )
+        self._lock = threading.Lock()
+        self.retained = 0
+        self.overflowed = 0
+        self.replayed = 0
+        self.dropped_stale = 0
+
+    def _evict_stale(self, now: float) -> None:
+        """Drop aged frames from the front. Caller holds the lock."""
+        ttl = _backlog_ttl_s()
+        if ttl <= 0.0:
+            return
+        cutoff = now - ttl
+        while self._frames and self._frames[0][0] < cutoff:
+            self._frames.popleft()
+            self.dropped_stale += 1
+
+    def retain(self, msg: Dict[str, Any]) -> None:
+        """Record one unheard frame. NEVER raises."""
+        try:
+            now = time.time()
+            with self._lock:
+                # `maxlen` silently discards the oldest, so overflow is
+                # detected by watching the ring sit at capacity rather than by
+                # trusting append to tell us. Counted, never silent.
+                if (self._frames.maxlen is not None
+                        and len(self._frames) == self._frames.maxlen):
+                    self.overflowed += 1
+                self._frames.append((now, msg))
+                self.retained += 1
+                self._evict_stale(now)
+        except Exception:  # noqa: BLE001 — retention must never break a publish
+            pass
+
+    def peek(self) -> List[Dict[str, Any]]:
+        """Frames to replay, oldest first. Does NOT consume. NEVER raises."""
+        try:
+            now = time.time()
+            with self._lock:
+                self._evict_stale(now)
+                out = []
+                for ts, msg in self._frames:
+                    frame = dict(msg)
+                    # Honest provenance: this is history, and it carries the
+                    # moment it happened rather than the moment it was
+                    # replayed. A client that stamped `ts` at receipt would
+                    # date an hour-old diff to now.
+                    frame["backlogged"] = True
+                    frame["ts"] = ts
+                    frame["addressed"] = False
+                    out.append(frame)
+                return out
+        except Exception:  # noqa: BLE001
+            return []
+
+    def commit(self, count: int) -> None:
+        """Discard the *count* frames a client has now provably received."""
+        try:
+            with self._lock:
+                for _ in range(max(0, int(count))):
+                    if not self._frames:
+                        break
+                    self._frames.popleft()
+                    self.replayed += 1
+        except Exception:  # noqa: BLE001
+            pass
+
+    def snapshot(self) -> Dict[str, int]:
+        """Counters for `/doctor` and the bridge stats. NEVER raises."""
+        try:
+            with self._lock:
+                pending = len(self._frames)
+        except Exception:  # noqa: BLE001
+            pending = 0
+        return {
+            "backlog_pending": pending,
+            "backlog_retained": self.retained,
+            "backlog_replayed": self.replayed,
+            "backlog_overflowed": self.overflowed,
+            "backlog_dropped_stale": self.dropped_stale,
+        }
+
+
 def _sentinel_interval_s() -> float:
     """Socket self-heal cadence (0 disables). The bridge binds once at
     boot; if ANY confused peer unlinks the inode (a CLI misclassifying
@@ -384,6 +566,10 @@ class CockpitAttachBridge:
         self._server: Optional[asyncio.AbstractServer] = None
         self._sentinel_task: Optional[asyncio.Task] = None
         self._clients: Set[asyncio.StreamWriter] = set()
+        #: Render frames composed while `_clients` was empty. The organism
+        #: does not stop working when the operator closes a terminal; before
+        #: this, everything it rendered in that window was discarded.
+        self._backlog = _OfflineBacklog()
         #: session_id → that cockpit's writer. Populated from the session
         #: field on inbound frames; entries are removed by _drop so a
         #: detached cockpit can never be addressed.
@@ -519,6 +705,18 @@ class CockpitAttachBridge:
     def client_count(self) -> int:
         return len(self._clients)
 
+    def backlog_stats(self) -> Dict[str, int]:
+        """Counters for the offline render backlog. NEVER raises.
+
+        Separate from ``self.stats`` because those are lifetime totals that
+        several call sites increment in place, while these are owned entirely
+        by the ring and include a LIVE gauge (`backlog_pending`) that would be
+        wrong the moment it were copied into a totals dict."""
+        try:
+            return self._backlog.snapshot()
+        except Exception:  # noqa: BLE001
+            return {}
+
     def _publish_presence(self) -> None:
         """Republish operator attention from the ONE authority for it —
         ``_clients`` — to the process-wide ledger that gates operator
@@ -567,15 +765,45 @@ class CockpitAttachBridge:
 
     # ---- publish (the harness _repl_print mirror) ----
 
+    def _retain_unheard(self, msg: Dict[str, Any]) -> None:
+        """Capture one render frame nobody was there to receive.
+
+        ONE seam for both render channels so the retention rule cannot drift
+        between them -- the two publishers already differ in escaping policy
+        and that is exactly the kind of divergence that produced a palette
+        fixed on one surface and dead on the other.
+
+        Ambience is resolved through ``attach_session.current_session()``, the
+        SAME call ``_broadcast`` uses to address a frame. Reading the session
+        a second way here would mean two opinions about who owns a line, and
+        the one that decides retention would be invisible."""
+        if not offline_backlog_enabled():
+            return
+        try:
+            from backend.core.ouroboros.battle_test.attach_session import (
+                current_session,
+            )
+            if current_session() is not None:
+                # Addressed output: it belongs to a cockpit that has gone, and
+                # session ids do not survive a reattach. Replaying it would
+                # put one operator's verb answer in another's scrollback.
+                return
+        except Exception:  # noqa: BLE001 — unresolvable ownership -> do not retain
+            return
+        self._backlog.retain(msg)
+
     def publish_line(self, text: str) -> None:
         """Broadcast one (already router-conformed) line to every
         attached terminal. Strictly non-blocking; per-client fail-drop
         (BrokenPipe/ConnectionReset = subscriber gone, organism
         unbothered). Thread-safe. NEVER raises."""
         try:
-            if not self._clients:
-                return
             msg = {"type": "line", "text": str(text), "ts": time.time()}
+            if not self._clients:
+                # Composed, and nobody to receive it. Retained rather than
+                # dropped -- see `_OfflineBacklog`.
+                self._retain_unheard(msg)
+                return
             self.stats["lines_published"] += 1
             loop = self._loop
             if loop is None or loop.is_closed():
@@ -608,11 +836,18 @@ class CockpitAttachBridge:
         broadcasts, which is right for AMBIENT output, since an autonomous
         operation belongs to no one and is everyone's business."""
         try:
-            if not self._clients or not tool_activity_enabled():
+            if not tool_activity_enabled():
+                # The CHANNEL is off. Not an empty audience -- retaining here
+                # would replay frames the operator disabled, so a kill switch
+                # would become a delay.
                 return
             msg = {"type": "markup", "text": str(text), "ts": time.time()}
             if session:
                 msg["session"] = session
+            if not self._clients:
+                if not session:
+                    self._retain_unheard(msg)
+                return
             self.stats["markup_published"] = (
                 self.stats.get("markup_published", 0) + 1
             )
@@ -1278,6 +1513,43 @@ class CockpitAttachBridge:
                 return
             except Exception:  # noqa: BLE001
                 pass
+            # The render backlog rides the SAME pre-join flush, immediately
+            # after the control-plane replay above. Two ordered groups rather
+            # than one timestamp-merged stream: they are different planes, the
+            # existing contract already promises telemetry-before-live, and
+            # merging would have to invent an ordering for `_replay()` frames
+            # that carry no comparable clock.
+            #
+            # Placement before `_clients.add(writer)` is what makes "history
+            # always precedes live" true for this channel too -- a frame
+            # published a microsecond later goes to the live set, and the
+            # backlog is already on the wire ahead of it.
+            _backlog_frames: List[Dict[str, Any]] = []
+            try:
+                _backlog_frames = self._backlog.peek()
+                for frame in _backlog_frames:
+                    writer.write((json.dumps(frame, separators=(",", ":"))
+                                  + "\n").encode())
+                await writer.drain()
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                # The socket died mid-flush: this cockpit received nothing we
+                # can rely on. NOT committed -- the next attach still gets the
+                # backlog, because a client that failed to read it must not be
+                # able to destroy it on everyone else's behalf.
+                self._drop(writer)
+                return
+            except Exception:  # noqa: BLE001
+                _backlog_frames = []
+            else:
+                # Provably on the wire -> discard exactly what was sent.
+                # Counted by length rather than cleared wholesale, so a frame
+                # retained DURING the flush survives to the next attach.
+                if _backlog_frames:
+                    self._backlog.commit(len(_backlog_frames))
+                    logger.info(
+                        "[CockpitAttach] replayed %d unheard render frame(s) "
+                        "to a reattaching cockpit", len(_backlog_frames),
+                    )
             self._clients.add(writer)
             # Attention begins where hydration LANDED, not where the
             # socket connected: a client that never received the payload

--- a/backend/core/ouroboros/governance/a1_trace.py
+++ b/backend/core/ouroboros/governance/a1_trace.py
@@ -85,6 +85,62 @@ def _emit_ledger_size() -> int:
     return len(_emit_ledger)
 
 
+def _operator_extra() -> "Optional[Dict[str, Any]]":
+    """``extra=`` that puts a record on the operator terminal at its TRUE level.
+
+    Lazy + fail-soft so this module still imports with nothing else present
+    (the "stdlib only" constraint in the docstring is about import time, and
+    this keeps it). If the logging authority is unavailable the line simply
+    goes to ``debug.log`` -- the auditor's sink -- which is a degradation of
+    visibility, never of evidence.
+    """
+    try:
+        from backend.core.ouroboros.governance.silent_boot import (  # noqa: PLC0415
+            operator_extra,
+        )
+        return operator_extra()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _in_proof_scope(hop: str, goal_id: Any) -> bool:
+    """Is this hop part of the A1 milestone proof?
+
+    THE PROOF IS ABOUT ONE THING: a strategic GOAL emitted by the roadmap
+    orchestrator, followed across five hops. Sensor ops -- TestFailure,
+    TodoScanner, DocStaleness, the other thirteen -- travel the same pipe and
+    are not what the proof is about. The probe below already KNOWS this: when
+    a goal has no emit record it prints ``source=non-roadmap (ingest without
+    prior emit -- sensor/non-roadmap source?)``. It then logged that at
+    WARNING 188 times in one session, which is the instrument reporting, very
+    loudly, that it is looking at something outside its own scope.
+
+    So scope is read from the ledger rather than asserted: a goal the roadmap
+    emitted is in, anything else is out. The ``emit`` hop is in by definition
+    -- it is the hop that CREATES the record, and asking the ledger about a
+    goal it is in the act of recording would be a race, not a check.
+
+    Dynamic on purpose: nothing here enumerates sensors. A new signal source
+    needs no edit, and the roadmap remains the only thing that widens scope.
+    """
+    if str(hop) == "emit":
+        return True
+    # THE LEDGER IS ONLY AN ORACLE WHILE IT IS BEING WRITTEN. `emit_probe`
+    # returns early when the probe flag is off, so with the probe disabled
+    # `_emit_ledger` stays permanently empty -- and a scope test that reads an
+    # empty ledger would answer "out of scope" for EVERY hop, silently demoting
+    # the entire five-line proof to DEBUG and taking the milestone evidence off
+    # the operator's terminal. The instrument would go quiet in exactly the
+    # configuration where someone had turned part of it off, which is the
+    # worst possible time to lose it. No oracle -> no narrowing.
+    try:
+        if not emit_probe_enabled():
+            return True
+        return str(goal_id) in _emit_ledger
+    except Exception:  # noqa: BLE001
+        return True  # unknown -> keep it loud; never silence by accident
+
+
 def emit_probe(goal_id: Any, *, source: str = "?") -> None:
     """Record the emit hop for *goal_id* and log a structured probe line.
 
@@ -102,10 +158,12 @@ def emit_probe(goal_id: Any, *, source: str = "?") -> None:
         while len(_emit_ledger) > _EMIT_LEDGER_MAX:
             _emit_ledger.popitem(last=False)
         orch = _roadmap_enabled_repr()
-        logger.warning(
+        _x = _operator_extra()
+        logger.log(
+            logging.INFO if _x else logging.WARNING,
             "[A1Trace][emit-probe] EMIT goal=%s source=%s emit_ts=%.6f "
             "orchestrator_enabled=%s",
-            gid, source, ts, orch,
+            gid, source, ts, orch, extra=_x,
         )
     except Exception:  # noqa: BLE001 — a probe must never break a hop
         pass
@@ -147,10 +205,12 @@ def restore_emit_record(goal_id: Any, *, source: str,
         a1trace("emit", gid, source=source, lineage="resumed",
                 original_emit_wall=original_emit_wall)
         # The origin-witness probe line (auditor's _EMIT_PROBE_SOURCE_RE).
-        logger.warning(
+        _x = _operator_extra()
+        logger.log(
+            logging.INFO if _x else logging.WARNING,
             "[A1Trace][emit-probe] EMIT goal=%s source=%s emit_ts=%.6f "
             "orchestrator_enabled=%s lineage=resumed",
-            gid, source, ts, _roadmap_enabled_repr(),
+            gid, source, ts, _roadmap_enabled_repr(), extra=_x,
         )
     except Exception:  # noqa: BLE001 — a probe must never break a hop
         pass
@@ -173,7 +233,13 @@ def probe_ingest_order(goal_id: Any) -> None:
         ingest_ts = time.monotonic()
         record = _emit_ledger.get(gid)
         if record is None:
-            logger.warning(
+            # By construction this is a non-roadmap goal: no emit record
+            # exists because no roadmap emit happened. That is the normal
+            # state for all sixteen sensors, not a warning about anything.
+            # DEBUG keeps it in `debug.log`, where `parse_emit_probe_source`
+            # reads it as a secondary origin witness (the file handler runs
+            # at DEBUG, so the witness is preserved byte-for-byte).
+            logger.debug(
                 "[A1Trace][emit-probe] MISSING goal=%s emit_ts=MISSING "
                 "ingest_ts=%.6f ordered=False source=non-roadmap "
                 "(ingest without prior emit -- sensor/non-roadmap source?)",
@@ -182,10 +248,13 @@ def probe_ingest_order(goal_id: Any) -> None:
             return
         emit_ts, source = record
         ordered = emit_ts <= ingest_ts
-        logger.warning(
+        # A record EXISTS, so the roadmap emitted this goal: in scope.
+        _x = _operator_extra()
+        logger.log(
+            logging.INFO if _x else logging.WARNING,
             "[A1Trace][emit-probe] goal=%s emit_ts=%.6f ingest_ts=%.6f "
             "ordered=%s source=%s",
-            gid, emit_ts, ingest_ts, ordered, source,
+            gid, emit_ts, ingest_ts, ordered, source, extra=_x,
         )
     except Exception:  # noqa: BLE001 — a probe must never break a hop
         pass
@@ -210,6 +279,18 @@ def a1trace(hop: str, goal_id: Any, **kw: Any) -> None:
         )
         if extra:
             msg = f"{msg} {extra}"
-        logger.warning(msg)
+        # Severity tells the truth; the `operator` extra carries the audience.
+        # In-scope hops still reach the soak operator's terminal -- and now
+        # reach the COCKPIT operator too, which WARNING never did once
+        # `_resolve_terminal_threshold` raised that mode to ERROR precisely
+        # BECAUSE of chatter like this. Out-of-scope sensor hops drop to DEBUG
+        # and remain in `debug.log` at full fidelity, so every auditor that
+        # parses `[A1Trace]` (all of them level-agnostic, keyed on the tag)
+        # sees exactly what it saw before.
+        if _in_proof_scope(hop, goal_id):
+            _x = _operator_extra()
+            logger.info(msg, extra=_x) if _x else logger.warning(msg)
+        else:
+            logger.debug(msg)
     except Exception:  # noqa: BLE001 — a breadcrumb must never break a hop
         pass

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -214,6 +214,10 @@ EVENT_TYPE_SOAK_CHUNK_QUARANTINED = "soak_chunk_quarantined"
 #     batch/RT queues are being cancelled. Both keyed by "soak_budget" (an
 #     organism property, no op_id) so ?op_id=soak_budget filters cleanly.
 EVENT_TYPE_SOAK_BUDGET_WARNING = "soak_budget_warning"
+#: A provider is reachable and REFUSING to serve until the account is
+#: funded (HTTP 402). Distinct from an outage on purpose: no amount of
+#: infrastructure fixes a billing state, so the cockpit must say so.
+EVENT_TYPE_PROVIDER_FUNDING_REQUIRED = "provider_funding_required"
 EVENT_TYPE_SOAK_CIRCUIT_TRIPPED = "soak_circuit_tripped"
 
 # Slice 249 (Async Observability + Live Steering) — three op-lifecycle events the
@@ -1526,6 +1530,7 @@ _VALID_EVENT_TYPES = frozenset({
     "worker_op_claimed",
     EVENT_TYPE_GOLDEN_IMAGE_DEGRADED,
     EVENT_TYPE_SOAK_BUDGET_WARNING,
+    EVENT_TYPE_PROVIDER_FUNDING_REQUIRED,
     EVENT_TYPE_SOAK_CIRCUIT_TRIPPED,
     EVENT_TYPE_COGNITIVE_WHY_SNAPSHOT,
     EVENT_TYPE_TASK_CREATED,
@@ -3068,6 +3073,34 @@ def publish_soak_budget_warning(
     except Exception:  # noqa: BLE001 — best-effort telemetry
         logger.debug(
             "[Stream] publish_soak_budget_warning exception", exc_info=True,
+        )
+        return None
+
+
+def publish_provider_funding_required(
+    detail: Mapping[str, Any],
+) -> Optional[str]:
+    """Best-effort publisher for ``provider_funding_required`` SSE frames.
+
+    Fired ONCE, when a provider's deep probe is refused for payment (HTTP
+    402) and the heartbeat freezes. This is deliberately NOT an outage event:
+    the operator's remedy is a billing action, and an outage banner would send
+    them to look at infrastructure that is working correctly. Keyed by the
+    provider surface. Returns the event_id, or None when the stream is
+    disabled / broker missing / payload invalid. NEVER raises."""
+    if not stream_enabled():
+        return None
+    try:
+        if not isinstance(detail, Mapping):
+            return None
+        key = str(detail.get("surface") or "provider")
+        return get_default_broker().publish(
+            EVENT_TYPE_PROVIDER_FUNDING_REQUIRED, key, dict(detail),
+        )
+    except Exception:  # noqa: BLE001 — best-effort telemetry
+        logger.debug(
+            "[Stream] publish_provider_funding_required exception",
+            exc_info=True,
         )
         return None
 

--- a/backend/core/ouroboros/governance/phase_runners/context_expansion_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/context_expansion_runner.py
@@ -192,10 +192,33 @@ class ContextExpansionRunner(PhaseRunner):
                 except Exception as _dep_exc:
                     logger.debug("[Orchestrator] Dependency summary skipped: %s", _dep_exc)
         except Exception as exc:
+            # RUNNER PARITY -- the reason this bug outlived its own fix.
+            #
+            # The inline twin in `orchestrator.py` carries this exact handler
+            # WITH `exc_info=True` and a comment stating that the traceback is
+            # "load-bearing, not decoration ... the message alone ('bool'
+            # object is not callable') names a TYPE and no site", recorded
+            # after observing it live 3-for-3 in bt-2026-08-11-230412.
+            #
+            # That diagnosis was correct and was written on the seam that does
+            # not execute. `dispatch_pipeline` routes CONTEXT_EXPANSION here,
+            # so every real op has taken THIS branch -- which logged a message
+            # and no traceback. The session log proves the split: the inline
+            # site formats `type(exc).__name__` and would print "TypeError:
+            # 'bool' object is not callable", while every line in
+            # bt-2026-08-18-021438 reads ": 'bool' object is not callable"
+            # with no type prefix. Five ops a session for a week, each one
+            # continuing to GENERATE with UNEXPANDED context, and nothing
+            # anywhere naming the site.
+            #
+            # Identical treatment on both paths now, so the next occurrence
+            # names its own line and the underlying defect becomes findable
+            # instead of inferable.
             logger.warning(
-                "[Orchestrator] Context expansion failed for op=%s: %s; "
-                "continuing to GENERATE",
-                ctx.op_id, exc,
+                "[Orchestrator] Context expansion failed for op=%s: %s: %s; "
+                "continuing to GENERATE with UNEXPANDED context",
+                ctx.op_id, type(exc).__name__, exc,
+                exc_info=True,
             )
 
         # ---- ModuleContextRouter: architecture memory injection (MEM-2) ----

--- a/backend/core/ouroboros/governance/provenance_ledger.py
+++ b/backend/core/ouroboros/governance/provenance_ledger.py
@@ -337,7 +337,10 @@ def stamp_provenance(
 ) -> Optional[ProvenanceRecord]:
     """Stamp a hash-chained provenance record at INGESTION and emit a
     structured ``[Provenance] op=.. origin=.. origin_class=.. chain_ok=..``
-    line at WARNING level (so it survives ``silent_boot``).
+    line whose LEVEL follows the outcome: ``INFO`` when the chain verifies
+    (routine, and the auditor reads it from ``debug.log`` regardless),
+    ``WARNING`` when it does not or the stamp fails. Visibility is no longer
+    bought with severity -- see ``silent_boot.operator_extra``.
 
     Gated by ``JARVIS_PROVENANCE_LEDGER_ENABLED`` (default ON): when disabled
     this is a silent no-op (byte-identical to no instrumentation).
@@ -360,13 +363,29 @@ def stamp_provenance(
             )
             return None
         chain_ok = led.verify_chain()
-        logger.warning(
-            "[Provenance] op=%s origin=%s origin_class=%s chain_ok=%s",
-            record.op_id,
-            record.origin,
-            record.origin_class,
-            chain_ok,
-        )
+        # LEVEL BY OUTCOME, NOT BY TRANSPORT. This line was WARNING for the
+        # reason the docstring above still gives -- "so it survives
+        # silent_boot" -- which is a routing need wearing a severity's
+        # clothes. The cost was 182 lines a session announcing that a hash
+        # chain VERIFIED, in the same stream an operator scans for things
+        # that did not.
+        #
+        # A verified chain is INFO and lands in `debug.log`, where
+        # `parse_provenance_line` reads it (the file handler runs at DEBUG,
+        # and that parser is keyed on the `[Provenance]` tag, never on a
+        # level -- so the auditor sees an identical corpus). A chain that
+        # FAILS stays WARNING below, because that is a real warning.
+        if chain_ok:
+            logger.info(
+                "[Provenance] op=%s origin=%s origin_class=%s chain_ok=%s",
+                record.op_id, record.origin, record.origin_class, chain_ok,
+            )
+        else:
+            logger.warning(
+                "[Provenance] op=%s origin=%s origin_class=%s chain_ok=%s"
+                " -- CHAIN VERIFICATION FAILED",
+                record.op_id, record.origin, record.origin_class, chain_ok,
+            )
         return record
     except Exception:  # noqa: BLE001 -- provenance NEVER blocks ingestion
         logger.warning(

--- a/backend/core/ouroboros/governance/provider_heartbeat.py
+++ b/backend/core/ouroboros/governance/provider_heartbeat.py
@@ -149,6 +149,41 @@ class AegisConfigurationError(RuntimeError):
     DW outage. Freezes the heartbeat + routes to the DLQ; never awakens."""
 
 
+class ProviderFundingRequired(RuntimeError):
+    """The data plane answered, and refused to serve until the account is paid.
+
+    A SEPARATE CLASS FROM AN OUTAGE, because the remedies are disjoint and the
+    failover controller acts on the difference. An outage means "this plane is
+    unreachable, stand up another one". HTTP 402 means the plane is reachable,
+    healthy, and declining to work for free -- a condition no amount of
+    infrastructure resolves.
+
+    MEASURED (bt-2026-08-18-021438): the deep probe took 402 down the generic
+    `-> outage degrade` path, the drop streak reached **7,619**, and the
+    lifecycle fired 125 awaken triggers -- 23 of them `HARD OUTAGE escalation
+    ... FORCED AWAKEN` -- against a billing failure. Nothing was provisioned
+    only because `JARVIS_FAILOVER_VM_ORCHESTRATION_HOLD` happened to be set;
+    the guard standing between a payment error and a GCE bill was one env var
+    that nothing in the classification path knows about.
+
+    Raising this instead composes the Safety Law that ALREADY exists for
+    401/403: `beat()` freezes, `consecutive_failures()` and `is_degrading()`
+    both report 0 by construction, and `_hard_outage_confirmed()` can never
+    fire. The breaker is not new machinery -- it is the correct classification
+    reaching machinery that was always there.
+    """
+
+
+class ProviderThrottled(RuntimeError):
+    """The plane is healthy and rate-limiting us (HTTP 429).
+
+    Neither an outage nor a funding stop: it is the provider working, saying
+    "slower". It must not degrade (a VM does not fix a rate limit) and must
+    not freeze (it clears on its own), so it records NO verdict and retries --
+    the same "no information either way" treatment a pre-dispatch skip gets.
+    """
+
+
 class ProbeAuthUnavailable(RuntimeError):
     """The probe could not ASSEMBLE complete credentials, so it never dispatched.
 
@@ -170,6 +205,32 @@ class ProbeAuthUnavailable(RuntimeError):
     """
 
 
+#: Status codes per class. Defaults are a FLOOR that the environment extends
+#: and cannot empty -- a classifier an env var could narrow to nothing is a
+#: classifier a typo silently turns back into "everything is an outage",
+#: which is the state this section exists to leave.
+_DEFAULT_AUTH_CODES = (401, 403)
+_DEFAULT_FUNDING_CODES = (402,)
+_DEFAULT_THROTTLE_CODES = (429,)
+_ENV_AUTH_CODES = "JARVIS_PROBE_AUTH_HTTP_CODES"
+_ENV_FUNDING_CODES = "JARVIS_PROBE_FUNDING_HTTP_CODES"
+_ENV_THROTTLE_CODES = "JARVIS_PROBE_THROTTLE_HTTP_CODES"
+
+
+def _http_codes(env_var: str, defaults: "tuple") -> "frozenset":
+    """Defaults plus any the operator adds. NEVER raises, never returns fewer."""
+    out = set(defaults)
+    try:
+        raw = str(os.environ.get(env_var, "") or "")
+        for piece in raw.replace(",", " ").split():
+            piece = piece.strip()
+            if piece.isdigit():
+                out.add(int(piece))
+    except Exception:  # noqa: BLE001
+        pass
+    return frozenset(out)
+
+
 def _classify_probe_exception(exc: BaseException) -> str:
     """Classify a probe failure as ``"transient"`` (credentials unavailable --
     never dispatched, no information either way), ``"auth"`` (401/403 -- config
@@ -182,8 +243,12 @@ def _classify_probe_exception(exc: BaseException) -> str:
         import urllib.error  # noqa: PLC0415
         if isinstance(exc, urllib.error.HTTPError):
             code = int(getattr(exc, "code", 0))
-            if code in (401, 403):
+            if code in _http_codes(_ENV_AUTH_CODES, _DEFAULT_AUTH_CODES):
                 return "auth"
+            if code in _http_codes(_ENV_FUNDING_CODES, _DEFAULT_FUNDING_CODES):
+                return "funding"
+            if code in _http_codes(_ENV_THROTTLE_CODES, _DEFAULT_THROTTLE_CODES):
+                return "throttled"
             return "outage"
     except Exception:  # noqa: BLE001
         pass
@@ -681,6 +746,16 @@ class DWHeartbeat:
                 raise AegisConfigurationError(
                     "deep probe auth failure (config error, NOT outage): %r" % (exc,)
                 ) from exc
+            if _cls == "funding":
+                # Same law, different cause: reachable plane, unpaid account.
+                raise ProviderFundingRequired(
+                    "deep probe refused for payment (NOT outage): %r" % (exc,)
+                ) from exc
+            if _cls == "throttled":
+                # Healthy plane asking for less traffic. No verdict either way.
+                raise ProviderThrottled(
+                    "deep probe rate-limited (NOT outage): %r" % (exc,)
+                ) from exc
             logger.debug("[DWHeartbeat] deep probe dispatch err=%r -> outage degrade", exc)
             return False
         ok = bool(result) and bool(str(result).strip())
@@ -702,6 +777,42 @@ class DWHeartbeat:
             self._dlq_emit_fn(payload)
         except Exception as exc2:  # noqa: BLE001 -- telemetry never blocks
             logger.debug("[DWHeartbeat] config DLQ emit fail-soft err=%r", exc2)
+
+    def _emit_funding_required(self, exc: BaseException) -> None:
+        """Route a funding stop to the DLQ **and** to the operator's cockpit.
+
+        Two sinks because they answer different questions. The DLQ is the
+        durable record an auditor reads afterwards; the SSE frame is what
+        tells the person sitting in front of the cockpit RIGHT NOW that the
+        organism has stopped for a reason they can fix in a browser tab.
+        Without the second one this state is indistinguishable from the
+        organism being idle -- which is how a soak burns an evening producing
+        `0 done / 12 failed / $0.00` while looking busy. Fail-soft: telemetry
+        never blocks, and the CRITICAL log above is the floor if both sinks
+        are unavailable."""
+        payload = {
+            "event": "provider_funding_required",
+            "error_class": "ProviderFundingRequired",
+            "surface": self._SURFACE.value,
+            "detail": str(exc)[:300],
+            "action": "heartbeat_frozen",
+            "remedy": "billing",
+            "note": (
+                "reachable plane, unpaid account -- NOT an outage; never "
+                "awakens J-Prime, never provisions an instance"
+            ),
+        }
+        try:
+            self._dlq_emit_fn(payload)
+        except Exception as exc2:  # noqa: BLE001 -- telemetry never blocks
+            logger.debug("[DWHeartbeat] funding DLQ emit fail-soft err=%r", exc2)
+        try:
+            from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: PLC0415
+                publish_provider_funding_required,
+            )
+            publish_provider_funding_required(payload)
+        except Exception as exc2:  # noqa: BLE001
+            logger.debug("[DWHeartbeat] funding SSE emit fail-soft err=%r", exc2)
 
     # ------------------------------------------------------------------
     # One probe + record (the testable core)
@@ -746,6 +857,37 @@ class DWHeartbeat:
                 "NOT awaken J-Prime. err=%r", exc,
             )
             self._emit_config_dlq(exc)
+            return
+        except ProviderFundingRequired as exc:
+            # THE SAFETY LAW, SECOND CAUSE. Composes the freeze above rather
+            # than adding a parallel breaker: `_frozen` already makes
+            # `consecutive_failures()` and `is_degrading()` return 0 by
+            # construction, which is what `_hard_outage_confirmed()` reads, so
+            # the awaken path is closed structurally and not by a second
+            # opinion that could disagree with the first. `run()`'s loop
+            # condition (`while not self._stopped and not self._frozen`) ends
+            # the retry storm in the same move.
+            self._frozen = True
+            self._healthy_streak = 0
+            logger.critical(
+                "[DWHeartbeat] PROVIDER FUNDING REQUIRED -- the data plane is "
+                "reachable and refusing to serve (HTTP 402). FREEZING "
+                "heartbeat; this is NOT an outage, will NOT awaken J-Prime, "
+                "and NO instance will be provisioned. Remedy is billing, not "
+                "infrastructure. err=%r", exc,
+            )
+            self._emit_funding_required(exc)
+            return
+        except ProviderThrottled as exc:
+            # No verdict: the plane is healthy and asked for less traffic.
+            # Recording a degrade here would walk the streak toward an awaken
+            # for a condition that clears itself.
+            self._transient_skips += 1
+            logger.info(
+                "[DWHeartbeat] probe THROTTLED (429) -- no freeze, no degrade, "
+                "no verdict recorded (skips=%d): %r",
+                self._transient_skips, exc,
+            )
             return
         except Exception as exc:  # noqa: BLE001 -- a non-auth probe error IS an outage
             logger.debug("[DWHeartbeat] probe raised (outage degrade) err=%r", exc)

--- a/backend/core/ouroboros/governance/silent_boot.py
+++ b/backend/core/ouroboros/governance/silent_boot.py
@@ -158,6 +158,113 @@ class _CockpitErrorFormatter(logging.Formatter):
                 return "⚠ error (unformattable record)"
 
 
+#: Record attribute that promotes a record to the operator terminal
+#: REGARDLESS of its severity. The counterpart to ``file_only``.
+OPERATOR_ATTR = "operator"
+
+
+def operator_extra(**extra: Any) -> Dict[str, Any]:
+    """``extra=`` payload that puts a record on the operator terminal.
+
+    THE PROBLEM THIS SOLVES
+    -----------------------
+    This handler gated the terminal by LEVEL alone, so "who needs to see
+    this" and "how bad is this" were the same dial. A module that wanted an
+    operator to watch something had exactly one lever: claim to be a warning.
+    Two did, and they are the two loudest things in a soak log:
+
+      * ``a1_trace`` — its docstring states it outright: *"WARNING level is
+        load-bearing ... so a soak operator can watch the five ordered lines
+        appear in the terminal."* 376 lines a session, none of them warnings.
+      * ``provenance_ledger`` — *"emit ... at WARNING level (so it survives
+        silent_boot)"*. 182 lines a session reporting that a hash chain
+        VERIFIED.
+
+    Both are correct about what they need and wrong about the only mechanism
+    available to get it, and the cost is that a real warning arrives in a
+    stream of 550 fake ones. ``_resolve_terminal_threshold`` already documents
+    the consequence from the other end — COCKPIT mode had to be raised to
+    ERROR because *"boot chatter uses logger.warning(...) throughout this
+    codebase"* — which means the inflated lines stopped reaching the cockpit
+    operator anyway. Severity inflation did not even buy what it cost.
+
+    So audience becomes its own axis. A record marked here is shown at its
+    HONEST level, in either mode, and every other module can stop lying.
+    """
+    payload: Dict[str, Any] = dict(extra)
+    payload[OPERATOR_ATTR] = True
+    return payload
+
+
+class _TerminalAudienceFilter(logging.Filter):
+    """Decides who sees a record; the level says only how bad it is.
+
+    Installed in BOTH presentation modes and carrying the threshold that
+    used to live on the handler. It has to be a filter rather than a handler
+    level because ``Logger.callHandlers`` compares ``record.levelno`` against
+    ``handler.level`` BEFORE any filter runs — so a record below the handler
+    level can never be promoted by one. Moving the threshold into the filter
+    is what makes promotion expressible at all.
+
+    Three answers, in priority order:
+
+      * ``file_only=True``  -> never (forensic walls belong in the session log)
+      * ``operator=True``   -> always (an audience decision, not a severity one)
+      * otherwise           -> the mode's severity threshold, exactly as before
+
+    NEVER raises: a filter fault admits the record, because losing a routing
+    decision is survivable and losing an error is not."""
+
+    def __init__(self, threshold: int) -> None:
+        super().__init__()
+        try:
+            self._threshold = int(threshold)
+        except Exception:  # noqa: BLE001
+            self._threshold = logging.WARNING
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003
+        try:
+            if getattr(record, "file_only", False):
+                return False
+            if getattr(record, OPERATOR_ATTR, False):
+                return True
+            return record.levelno >= self._threshold
+        except Exception:  # noqa: BLE001
+            return True
+
+
+def terminal_threshold_of(handler: logging.Handler) -> "Optional[int]":
+    """The severity threshold a terminal handler is enforcing, or ``None``.
+
+    Public because the threshold no longer lives on ``handler.level`` and a
+    caller asking "what gets shown" should not have to know that. Reading
+    ``.level`` would now answer ``NOTSET`` and be wrong in a way that looks
+    like an answer -- the same shape of mistake as a blast radius nobody
+    scanned. NEVER raises.
+    """
+    try:
+        for filt in getattr(handler, "filters", ()) or ():
+            if isinstance(filt, _TerminalAudienceFilter):
+                return filt._threshold  # noqa: SLF001 -- its own module
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+def shows_on_terminal(handler: logging.Handler, record: logging.LogRecord) -> bool:
+    """Would this record reach the operator through this handler?
+
+    The behavioural question, answered by the same filters the handler runs,
+    so a test can assert what an operator SEES instead of how the plumbing
+    currently spells it."""
+    try:
+        if record.levelno < handler.level:
+            return False
+        return all(f.filter(record) for f in (handler.filters or ()))
+    except Exception:  # noqa: BLE001
+        return True
+
+
 class _CockpitConsoleFilter(logging.Filter):
     """Two console protections for the cockpit:
 
@@ -468,7 +575,15 @@ def _configure_locked(
             _resolved_mode, terminal_threshold,
         )
         term_handler = logging.StreamHandler(stream=sys.stderr)
-        term_handler.setLevel(threshold)
+        # NOTSET, deliberately: the threshold moved into
+        # `_TerminalAudienceFilter` below. `Logger.callHandlers` tests
+        # `record.levelno >= handler.level` BEFORE filters run, so a handler
+        # level would make `operator=True` promotion unreachable for exactly
+        # the records that need it. The threshold is not weakened -- it is
+        # enforced one layer later, by something that can also say "this one
+        # is for the operator regardless".
+        term_handler.setLevel(logging.NOTSET)
+        term_handler.addFilter(_TerminalAudienceFilter(threshold))
         if str(_resolved_mode).lower().endswith("cockpit") or (
             getattr(_resolved_mode, "value", "") == "cockpit"
         ):

--- a/tests/battle_test/test_cockpit_offline_backlog.py
+++ b/tests/battle_test/test_cockpit_offline_backlog.py
@@ -1,0 +1,177 @@
+"""The organism does not stop working when the operator closes a terminal.
+
+``publish_line`` / ``publish_markup`` both opened with ``if not self._clients:
+return`` -- correct about the socket, wrong about the organism. Every
+``Update(path)`` block, tool result and diff composed while detached was
+formatted and discarded, so reattaching showed an idle-looking cockpit for a
+session that had been busy. That is indistinguishable from the organism having
+done nothing, which is the same defect class as a receipt reading "queued"
+about work that was thrown away.
+
+These tests pin the retention RULES, not just the happy path, because every
+rule here exists to stop the fix from causing a worse bug than the one it
+closes:
+
+  * ambient only  -- replaying one cockpit's private verb output into a
+                     stranger's scrollback is what `_broadcast`'s addressing
+                     exists to prevent;
+  * empty audience only -- a second cockpit is joining a live session, not
+                     recovering a gap;
+  * two-phase drain -- a client whose socket dies mid-flush must not destroy
+                     the backlog on everyone else's behalf;
+  * TTL + overflow counted -- history painted as present tense, and a
+                     truncated backlog presenting itself as complete, are both
+                     dishonesty rather than mere staleness.
+
+No socket is bound here: the bridge's publish path and its ring are exercised
+directly, so the suite runs anywhere. The end-to-end socket cycle (detach ->
+work -> reattach -> replay) was verified live over a real UDS pair.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from backend.core.ouroboros.battle_test import cockpit_attach as ca
+
+
+@pytest.fixture
+def bridge(tmp_path):
+    return ca.CockpitAttachBridge(path=tmp_path / "c.sock")
+
+
+class TestRetention:
+    def test_frames_published_with_no_audience_are_kept(self, bridge):
+        bridge.publish_markup("⏺ Update(a.py)")
+        bridge.publish_line("a plain line")
+        assert bridge.backlog_stats()["backlog_pending"] == 2
+
+    def test_order_is_preserved_oldest_first(self, bridge):
+        for i in range(5):
+            bridge.publish_markup(f"frame-{i}")
+        texts = [f["text"] for f in bridge._backlog.peek()]
+        assert texts == [f"frame-{i}" for i in range(5)]
+
+    def test_replayed_frames_carry_honest_provenance(self, bridge):
+        bridge.publish_markup("⏺ old work")
+        frame = bridge._backlog.peek()[0]
+        assert frame["backlogged"] is True
+        assert frame["addressed"] is False
+        # The moment it HAPPENED, not the moment it was replayed. A client
+        # stamping receipt-time would date an hour-old diff to now.
+        assert frame["ts"] <= time.time()
+
+    def test_addressed_output_is_never_retained(self, bridge):
+        """Session-addressed output belongs to a cockpit that has gone.
+
+        Session ids do not survive a reattach, so replaying this would paint
+        one operator's `/posture status` into another's scrollback."""
+        bridge.publish_markup("private verb answer", session="sess-A")
+        assert bridge.backlog_stats()["backlog_pending"] == 0
+
+    def test_channel_kill_switch_is_not_an_empty_audience(self, bridge, monkeypatch):
+        """A disabled channel must not become a DELAYED channel."""
+        monkeypatch.setenv("JARVIS_ATTACH_TOOL_ACTIVITY_ENABLED", "0")
+        bridge.publish_markup("⏺ should never be kept")
+        assert bridge.backlog_stats()["backlog_pending"] == 0
+
+    def test_master_flag_off_is_byte_identical_drop(self, bridge, monkeypatch):
+        monkeypatch.setenv("JARVIS_ATTACH_OFFLINE_BACKLOG_ENABLED", "0")
+        bridge.publish_markup("⏺ dropped as before")
+        bridge.publish_line("dropped as before")
+        assert bridge.backlog_stats()["backlog_pending"] == 0
+
+
+class TestBounds:
+    def test_overflow_is_counted_never_silent(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_ATTACH_BACKLOG_SIZE", "3")
+        ring = ca._OfflineBacklog()
+        for i in range(7):
+            ring.retain({"type": "line", "text": str(i)})
+        snap = ring.snapshot()
+        assert snap["backlog_pending"] == 3
+        assert snap["backlog_overflowed"] == 4, (
+            "a truncated backlog that reported itself complete would be a "
+            "receipt for work it did not show"
+        )
+
+    def test_the_ring_keeps_the_NEWEST_frames(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_ATTACH_BACKLOG_SIZE", "3")
+        ring = ca._OfflineBacklog()
+        for i in range(6):
+            ring.retain({"type": "line", "text": str(i)})
+        assert [f["text"] for f in ring.peek()] == ["3", "4", "5"]
+
+    def test_stale_frames_age_out(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_ATTACH_BACKLOG_TTL_S", "0.05")
+        ring = ca._OfflineBacklog()
+        ring.retain({"type": "line", "text": "ancient"})
+        time.sleep(0.12)
+        assert ring.peek() == []
+        assert ring.snapshot()["backlog_dropped_stale"] == 1
+
+    def test_ttl_zero_disables_ageing(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_ATTACH_BACKLOG_TTL_S", "0")
+        ring = ca._OfflineBacklog()
+        ring.retain({"type": "line", "text": "kept"})
+        time.sleep(0.05)
+        assert len(ring.peek()) == 1
+
+    def test_size_and_ttl_are_read_from_the_environment(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_ATTACH_BACKLOG_SIZE", "17")
+        monkeypatch.setenv("JARVIS_ATTACH_BACKLOG_TTL_S", "42.5")
+        assert ca._backlog_size() == 17
+        assert ca._backlog_ttl_s() == 42.5
+
+    def test_malformed_env_falls_back_rather_than_raising(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_ATTACH_BACKLOG_SIZE", "not-a-number")
+        monkeypatch.setenv("JARVIS_ATTACH_BACKLOG_TTL_S", "banana")
+        assert ca._backlog_size() == 200
+        assert ca._backlog_ttl_s() == 1800.0
+
+
+class TestTwoPhaseDrain:
+    def test_peek_does_not_consume(self):
+        ring = ca._OfflineBacklog()
+        ring.retain({"type": "line", "text": "x"})
+        assert len(ring.peek()) == 1
+        assert len(ring.peek()) == 1, "a failed flush must leave the ring intact"
+
+    def test_commit_discards_exactly_what_was_sent(self):
+        """A frame retained DURING the flush must survive to the next attach."""
+        ring = ca._OfflineBacklog()
+        for i in range(3):
+            ring.retain({"type": "line", "text": str(i)})
+        sent = ring.peek()
+        ring.retain({"type": "line", "text": "arrived-mid-flush"})
+        ring.commit(len(sent))
+        assert [f["text"] for f in ring.peek()] == ["arrived-mid-flush"]
+        assert ring.snapshot()["backlog_replayed"] == 3
+
+    def test_commit_is_bounded_by_what_is_present(self):
+        ring = ca._OfflineBacklog()
+        ring.retain({"type": "line", "text": "only"})
+        ring.commit(99)          # must not raise or wrap
+        assert ring.peek() == []
+
+
+class TestResilience:
+    def test_retention_never_raises_on_a_hostile_frame(self):
+        ring = ca._OfflineBacklog()
+
+        class _Hostile(dict):
+            def __iter__(self):  # noqa: D105
+                raise RuntimeError("boom")
+
+        ring.retain(_Hostile())          # must be swallowed
+        ring.peek()                      # must not propagate
+
+    def test_publish_never_raises_when_the_ring_is_broken(self, bridge):
+        bridge._backlog = None           # simulate catastrophic state
+        bridge.publish_markup("⏺ still must not raise")
+        bridge.publish_line("still must not raise")
+
+    def test_stats_are_safe_when_the_ring_is_gone(self, bridge):
+        bridge._backlog = None
+        assert bridge.backlog_stats() == {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,10 +105,26 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "permissions: mark test as requiring system permissions"
     )
+    # Applied by COLLECTION, not by hand -- see `tests/pty_gate` for why a
+    # decorator was the wrong mechanism (seven of eight files never wore one).
+    # Registered here so `-m pty` / `-m "not pty"` select correctly and no
+    # PytestUnknownMarkWarning is emitted for a marker nobody typed.
+    config.addinivalue_line(
+        "markers",
+        "pty: test drives a real pseudo-terminal (auto-applied; "
+        "see JARVIS_PTY_TESTS_REQUIRED)",
+    )
 
 
-def pytest_collection_modifyitems(config, items):
-    """Modify test items during collection."""
+def _apply_path_markers(items):
+    """Path-derived markers (`unit`, `vision`, `slow`, ...).
+
+    WAS a `pytest_collection_modifyitems` hook and therefore DEAD: a second
+    definition of that name later in this module rebound it at import time,
+    so Python kept only the last one and pytest never saw this body. Every
+    path marker below has been silently absent -- `-m unit` selected nothing.
+    Now a named helper called from the single composed hook, which is the
+    only arrangement in which adding a third concern cannot delete a second."""
     # Add markers based on test location
     for item in items:
         # Add markers based on path
@@ -190,13 +206,37 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     _report_live_state_writes(terminalreporter)
 
     try:
-        from tests.pty_gate import REQUIRED_ENV_VAR, SKIPPED
+        from tests.pty_gate import (
+            DISABLE_ENV_VAR, REQUIRED_ENV_VAR, SKIPPED, UNDECIDABLE,
+            automark_enabled,
+        )
     except Exception:  # noqa: BLE001 — a reporting aid must never break a run
-        return
-    if not SKIPPED:
         return
 
     write = terminalreporter.write_line
+
+    # A DISARMED detector is louder than a skip, because a skip at least
+    # names itself. If automarking is off, every terminal-driving test in the
+    # repository is ungated and the run says nothing about it -- which is the
+    # precise state this whole mechanism exists to make impossible.
+    if not automark_enabled():
+        write("")
+        write(f"⚠️  pty auto-detection is DISABLED ({DISABLE_ENV_VAR}) — "
+              f"terminal-driving tests are UNGATED.", yellow=True, bold=True)
+
+    # "We could not read the file" is not "the file needs no terminal".
+    # Reported separately from skips so an unreadable path can never be
+    # mistaken for a clean verdict.
+    if UNDECIDABLE:
+        write("")
+        write(f"⚠️  {len(UNDECIDABLE)} file(s) could not be inspected for pty "
+              f"affinity — gating status UNKNOWN, not clear.",
+              yellow=True, bold=True)
+        for path, why in sorted(set(UNDECIDABLE))[:10]:
+            write(f"   {path}: {why}", yellow=True)
+
+    if not SKIPPED:
+        return
     write("")
     write(f"⚠️  {len(SKIPPED)} terminal-dependent test(s) DID NOT RUN — "
           f"no pseudo-terminal was available.", yellow=True, bold=True)
@@ -577,7 +617,7 @@ def pytest_ignore_collect(collection_path=None, path=None, config=None):
     return None if rel in tracked else True
 
 
-def pytest_collection_modifyitems(session, config, items):
+def _amputate_untracked(config, items):
     """Amputate untracked items after traversal. NEVER raises.
 
     `pytest_ignore_collect` above is the right hook and its logic is proven
@@ -634,3 +674,82 @@ def pytest_collection_modifyitems(session, config, items):
                 "paths — OS artifacts are not part of the repository", dropped)
     except Exception:  # noqa: BLE001 — collection must never die here
         return
+
+
+# ---------------------------------------------------------------------------
+# The ONE collection hook
+# ---------------------------------------------------------------------------
+
+
+def pytest_collection_modifyitems(session, config, items):
+    """The single `modifyitems` hook, composing every collection concern.
+
+    THIS SHAPE IS THE FIX, NOT A STYLE CHOICE. This module previously defined
+    `pytest_collection_modifyitems` TWICE at module scope. Python does not
+    merge those -- the second binding replaced the first, so the path-marker
+    pass (`unit`, `integration`, `vision`, `voice`, `slow`, ...) never ran and
+    `-m unit` had been selecting nothing. Nothing reported it, because a hook
+    that does not exist raises no error.
+
+    A hook name that can be silently overwritten is a place where adding a
+    feature deletes one. So there is exactly one definition, it delegates to
+    named helpers, and the next concern is a fourth line here rather than a
+    third `def` that eats the second.
+
+    Order is deliberate:
+      1. amputate untracked paths -- do not spend analysis on items that are
+         about to be dropped;
+      2. path markers -- pure string work on what survived;
+      3. pty affinity -- the only pass that reads and parses files, so it runs
+         on the smallest possible set.
+
+    Each stage is independently fail-safe: a stage that raises is contained
+    here, and the stages after it still run. Collection dying is worse than
+    any one stage being skipped.
+    """
+    for stage, call in (
+        ("amputate_untracked", lambda: _amputate_untracked(config, items)),
+        ("path_markers", lambda: _apply_path_markers(items)),
+        ("pty_affinity", lambda: _mark_pty_items(config, items)),
+    ):
+        try:
+            call()
+        except Exception:  # noqa: BLE001 — one bad stage must not kill collection
+            _logging.getLogger(__name__).warning(
+                "[tests-conftest] collection stage %r failed; continuing",
+                stage, exc_info=True,
+            )
+
+
+def _mark_pty_items(config, items):
+    """Tag terminal-driving tests so the gate can enforce them at setup.
+
+    Delegates wholly to `tests.pty_gate`; this function owns no detection
+    logic of its own, because a second opinion about what needs a terminal is
+    how the first one drifts.
+    """
+    try:
+        from tests.pty_gate import mark_pty_items
+    except Exception:  # noqa: BLE001 — gate absent → no automarking, suite runs
+        return
+    marked = mark_pty_items(items)
+    if marked:
+        _logging.getLogger(__name__).debug(
+            "[tests-conftest] pty affinity: marked %d item(s)", marked)
+
+
+def pytest_runtest_setup(item):
+    """Enforce the terminal requirement BEFORE the test body allocates one.
+
+    Placement is the whole point. `test_region_layout_mount.py` calls
+    `pty.openpty()` in its own body, so on a machine without `/dev/ptmx` it
+    ERRORED with a raw `OSError` while its gated neighbours skipped cleanly --
+    one cause, two verdicts, and only the skips were legible. Deciding at
+    setup makes the verdict identical for every terminal-driving test in the
+    repository regardless of how each one happens to allocate.
+    """
+    try:
+        from tests.pty_gate import gate_item
+    except Exception:  # noqa: BLE001
+        return
+    gate_item(item)

--- a/tests/governance/test_a1_trace_breadcrumbs.py
+++ b/tests/governance/test_a1_trace_breadcrumbs.py
@@ -17,8 +17,14 @@ import pytest
 from backend.core.ouroboros.governance import a1_trace
 
 
-def test_emits_warning_with_hop_and_goal(caplog):
-    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+def test_emits_hop_and_goal(caplog):
+    """The MESSAGE is the contract; the level is a routing decision.
+
+    `g-123` was never emitted by the roadmap, so this hop is out of the A1
+    proof's scope and lands at DEBUG -- in `debug.log`, which is the sink
+    every auditor reads. The text is byte-identical to what it always was.
+    """
+    with caplog.at_level(logging.DEBUG, logger=a1_trace.logger.name):
         a1_trace.a1trace("ingest", "g-123", router="attached")
     msgs = [r.getMessage() for r in caplog.records]
     assert any(
@@ -26,22 +32,66 @@ def test_emits_warning_with_hop_and_goal(caplog):
     ), msgs
 
 
-def test_warning_level_so_it_survives_silent_boot(caplog):
-    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+def test_in_scope_hop_reaches_the_operator_without_faking_severity(caplog):
+    """The proof still reaches the terminal -- by AUDIENCE, not by severity.
+
+    Replaces `test_warning_level_so_it_survives_silent_boot`, which pinned
+    the workaround rather than the requirement. The requirement is that a
+    soak operator sees the five ordered hops; WARNING was merely the only
+    lever that existed before `silent_boot.operator_extra`. Asserting the
+    old lever would forbid ever fixing the 376-line-per-session cost of it.
+    """
+    with caplog.at_level(logging.DEBUG, logger=a1_trace.logger.name):
         a1_trace.a1trace("emit", "g-1")
     assert caplog.records, "no record emitted"
-    assert all(r.levelno >= logging.WARNING for r in caplog.records)
+    rec = caplog.records[-1]
+    assert rec.getMessage() == "[A1Trace] emit goal=g-1"
+    # Honest severity ...
+    assert rec.levelno == logging.INFO
+    # ... and an explicit audience decision that carries it to the terminal.
+    assert getattr(rec, "operator", False) is True
+
+
+def test_out_of_scope_hop_is_not_promoted_to_the_operator(caplog):
+    """A sensor op must not spend the operator's attention.
+
+    188 `[A1Trace][emit-probe] MISSING ... source=non-roadmap` lines in one
+    session is the measurement this whole change answers.
+    """
+    a1_trace._emit_ledger.clear()
+    with caplog.at_level(logging.DEBUG, logger=a1_trace.logger.name):
+        a1_trace.a1trace("ingest", "op-sensor-42")
+    rec = caplog.records[-1]
+    assert rec.levelno == logging.DEBUG
+    assert getattr(rec, "operator", False) is False
+
+
+def test_scope_never_narrows_when_the_ledger_cannot_answer(monkeypatch, caplog):
+    """Probe OFF means no oracle -- and no oracle must not mean silence.
+
+    `emit_probe` returns early when its flag is off, so `_emit_ledger` stays
+    empty forever. A scope test that trusted an empty ledger would demote the
+    ENTIRE proof to DEBUG in exactly the configuration where someone had
+    already turned half the instrument off.
+    """
+    monkeypatch.setenv("JARVIS_A1_EMIT_PROBE_ENABLED", "false")
+    a1_trace._emit_ledger.clear()
+    with caplog.at_level(logging.DEBUG, logger=a1_trace.logger.name):
+        a1_trace.a1trace("accept", "g-unknown")
+    rec = caplog.records[-1]
+    assert rec.levelno == logging.INFO
+    assert getattr(rec, "operator", False) is True
 
 
 def test_gated_off_is_silent(caplog, monkeypatch):
     monkeypatch.setenv("JARVIS_A1_TRACE_ENABLED", "false")
-    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+    with caplog.at_level(logging.DEBUG, logger=a1_trace.logger.name):
         a1_trace.a1trace("dequeue", "g-9")
     assert not caplog.records
 
 
 def test_none_kwargs_skipped(caplog):
-    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+    with caplog.at_level(logging.DEBUG, logger=a1_trace.logger.name):
         a1_trace.a1trace("submit", "g-7", phase=None, target="GLS")
     msg = caplog.records[-1].getMessage()
     assert "phase=" not in msg

--- a/tests/governance/test_provenance_ledger.py
+++ b/tests/governance/test_provenance_ledger.py
@@ -137,7 +137,7 @@ def test_latest_for_op_returns_record():
 
 def test_stamp_emits_structured_line(caplog):
     led = pl.ProvenanceLedger()
-    with caplog.at_level(logging.WARNING, logger=pl.logger.name):
+    with caplog.at_level(logging.INFO, logger=pl.logger.name):
         pl.stamp_provenance("op-abc", "test_failure", ledger=led)
     line = [r.getMessage() for r in caplog.records if "[Provenance]" in r.getMessage()]
     assert line, "no [Provenance] line emitted"
@@ -150,7 +150,7 @@ def test_stamp_emits_structured_line(caplog):
 
 def test_stamp_roadmap_origin_class(caplog):
     led = pl.ProvenanceLedger()
-    with caplog.at_level(logging.WARNING, logger=pl.logger.name):
+    with caplog.at_level(logging.INFO, logger=pl.logger.name):
         pl.stamp_provenance("op-r", SignalSource.ROADMAP, ledger=led)
     msg = [r.getMessage() for r in caplog.records if "[Provenance]" in r.getMessage()][-1]
     assert "origin_class=roadmap" in msg
@@ -159,7 +159,7 @@ def test_stamp_roadmap_origin_class(caplog):
 def test_stamp_off_flag_is_byte_identical_noop(caplog, monkeypatch):
     monkeypatch.setenv("JARVIS_PROVENANCE_LEDGER_ENABLED", "false")
     led = pl.ProvenanceLedger()
-    with caplog.at_level(logging.WARNING, logger=pl.logger.name):
+    with caplog.at_level(logging.INFO, logger=pl.logger.name):
         result = pl.stamp_provenance("op-x", "test_failure", ledger=led)
     assert result is None
     assert not [r for r in caplog.records if "[Provenance]" in r.getMessage()]
@@ -187,3 +187,28 @@ def test_default_ledger_singleton_and_reset():
     assert a is b
     pl.reset_default_ledger()
     assert pl.get_default_ledger() is not a
+
+
+def test_verified_chain_is_info_and_failure_is_warning(caplog, monkeypatch):
+    """Severity follows the OUTCOME, not the transport.
+
+    This line was WARNING so it would "survive silent_boot" -- a routing need
+    solved with a severity dial, at a cost of 182 lines a session announcing
+    that a hash chain VERIFIED. An operator scanning for warnings was being
+    handed 182 non-warnings. A chain that FAILS is still a warning, and now
+    it is the only one.
+    """
+    led = pl.ProvenanceLedger()
+    with caplog.at_level(logging.DEBUG, logger=pl.logger.name):
+        pl.stamp_provenance("op-ok", "test_failure", ledger=led)
+    ok = [r for r in caplog.records if "[Provenance]" in r.getMessage()][-1]
+    assert ok.levelno == logging.INFO
+    assert "chain_ok=True" in ok.getMessage()
+
+    caplog.clear()
+    monkeypatch.setattr(led, "verify_chain", lambda: False)
+    with caplog.at_level(logging.DEBUG, logger=pl.logger.name):
+        pl.stamp_provenance("op-bad", "test_failure", ledger=led)
+    bad = [r for r in caplog.records if "[Provenance]" in r.getMessage()][-1]
+    assert bad.levelno == logging.WARNING
+    assert "chain_ok=False" in bad.getMessage()

--- a/tests/governance/test_provider_funding_breaker.py
+++ b/tests/governance/test_provider_funding_breaker.py
@@ -1,0 +1,150 @@
+"""A billing state is not an availability state.
+
+MEASURED (bt-2026-08-18-021438): DoubleWord answered every deep probe with
+``HTTPError 402: Payment Required``. The classifier had no entry for 402, so
+it fell through to ``-> outage degrade``; the drop streak reached **7,619**
+and ``failover_lifecycle`` fired 125 awaken triggers, 23 of them
+``HARD OUTAGE escalation ... FORCED AWAKEN``. Nothing was provisioned only
+because ``JARVIS_FAILOVER_VM_ORCHESTRATION_HOLD`` happened to be set -- the
+sole thing standing between a payment error and a GCE bill was an env var
+that nothing in the classification path consults.
+
+The law these tests pin already existed for 401/403 and is stated in
+``provider_heartbeat`` itself: an auth error "is NOT a DW outage ... freezes
+the loop instead of degrading (which would conflate a config bug with an
+outage -> false awaken)". 402 belongs to that family. So does 429, with a
+different remedy again: the plane is healthy and asking for less traffic.
+
+Each test uses its OWN ledger. The shared one is durable and currently holds
+7,699 real failures, which silently confounds any streak assertion made
+against it -- the first version of this verification read ``degrading=True``
+for 429 and looked like a bug in the fix rather than history in the file.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import os
+import tempfile
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import provider_heartbeat as ph
+
+
+def _http(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError("u", code, "m", {}, io.BytesIO(b""))
+
+
+def _beat(code: int):
+    """One beat against a fresh ledger. Returns (heartbeat, dlq_payloads)."""
+    tmp = tempfile.mkdtemp()
+    # Path, not str: `SurfaceHealthLedger.load()` calls `p.exists()` directly,
+    # so a str silently fails the record inside the ledger's own fail-soft
+    # handler and every streak assertion quietly reads 0. The annotation says
+    # `Optional[Path]`; it is not enforced, and the first draft of this file
+    # read a clean 0 for a real 5xx outage because of it.
+    ledger = ph.SurfaceHealthLedger(path=Path(tmp) / "ledger.json")
+    hb = ph.DWHeartbeat(ledger=ledger)
+    captured = []
+    hb._dlq_emit_fn = lambda payload: captured.append(payload)
+    hb._inference_dispatch_fn = lambda: (_ for _ in ()).throw(_http(code))
+    hb._probe_fn = hb._deep_inference_probe
+    asyncio.run(hb.beat())
+    return hb, captured
+
+
+@pytest.fixture(autouse=True)
+def _armed(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_HEARTBEAT_ENABLED", "true")
+
+
+class TestClassification:
+    @pytest.mark.parametrize("code,expected", [
+        (401, "auth"), (403, "auth"),
+        (402, "funding"),
+        (429, "throttled"),
+        (500, "outage"), (503, "outage"), (502, "outage"),
+    ])
+    def test_status_code_maps_to_its_remedy(self, code, expected):
+        assert ph._classify_probe_exception(_http(code)) == expected
+
+    def test_unknown_error_is_still_conservatively_an_outage(self):
+        assert ph._classify_probe_exception(RuntimeError("?")) == "outage"
+
+    def test_env_extends_a_class_and_can_never_empty_one(self, monkeypatch):
+        """Config widens the net; it must not be able to cut a hole in it.
+
+        A classifier an env var could narrow to nothing is a classifier a
+        typo turns back into "everything is an outage" -- which is the state
+        this whole module exists to leave."""
+        monkeypatch.setenv("JARVIS_PROBE_FUNDING_HTTP_CODES", "1402")
+        assert ph._classify_probe_exception(_http(1402)) == "funding"
+        assert ph._classify_probe_exception(_http(402)) == "funding"
+
+
+class TestFundingBreaker:
+    def test_402_freezes_and_closes_the_awaken_path(self):
+        hb, dlq = _beat(402)
+        assert hb._frozen is True
+        # The two inputs `_hard_outage_confirmed()` reads. Both zero BY
+        # CONSTRUCTION while frozen, which is what makes the awaken
+        # structurally unreachable rather than merely unlikely.
+        assert hb.consecutive_failures() == 0
+        assert hb.is_degrading() is False
+        assert dlq and dlq[0]["event"] == "provider_funding_required"
+        assert dlq[0]["remedy"] == "billing"
+
+    def test_402_records_no_degrade_verdict_at_all(self):
+        hb, _ = _beat(402)
+        assert hb.consecutive_failures() == 0
+
+    def test_frozen_heartbeat_stops_its_own_retry_loop(self):
+        """`run()`'s loop condition is the breaker; the freeze is the trip."""
+        hb, _ = _beat(402)
+        beats = []
+        hb._probe_fn = lambda: beats.append(1)
+        asyncio.run(hb.run())
+        assert beats == [], "a frozen heartbeat must not beat again"
+
+
+class TestThrottle:
+    def test_429_neither_freezes_nor_degrades(self):
+        hb, dlq = _beat(429)
+        assert hb._frozen is False, "a rate limit clears itself; freezing is wrong"
+        assert hb.consecutive_failures() == 0, "a 429 must not walk toward an awaken"
+        assert not dlq
+
+    def test_429_is_counted_so_it_is_never_invisible(self):
+        hb, _ = _beat(429)
+        assert hb._transient_skips >= 1
+
+
+class TestNoRegressionForRealOutages:
+    def test_5xx_still_degrades(self):
+        """The failover must still work. A fix that disarmed it would be worse
+        than the bug: 402 was over-triggering, and silence would be under-."""
+        hb, _ = _beat(503)
+        assert hb._frozen is False
+        assert hb.consecutive_failures() == 1
+
+    def test_401_keeps_its_existing_law(self):
+        hb, dlq = _beat(401)
+        assert hb._frozen is True
+        assert dlq and dlq[0]["event"] == "aegis_configuration_error"
+
+
+class TestOperatorIsTold:
+    def test_the_funding_event_type_is_registered_or_it_vanishes(self):
+        """An unregistered event_type is dropped SILENTLY by the broker.
+
+        `_VALID_EVENT_TYPES` is exactly where a missing entry disappears
+        without an error, so membership is pinned rather than assumed."""
+        from backend.core.ouroboros.governance import ide_observability_stream as s
+        assert s.EVENT_TYPE_PROVIDER_FUNDING_REQUIRED in s._VALID_EVENT_TYPES
+
+    def test_publisher_never_raises_on_a_bad_payload(self):
+        from backend.core.ouroboros.governance import ide_observability_stream as s
+        assert s.publish_provider_funding_required(None) is None  # type: ignore[arg-type]

--- a/tests/governance/test_silent_boot.py
+++ b/tests/governance/test_silent_boot.py
@@ -205,7 +205,7 @@ class TestTerminalHandler:
             and getattr(h, sb._HANDLER_MARKER, False)
         ]
         assert len(terminal_handlers) == 1
-        assert terminal_handlers[0].level == logging.WARNING
+        assert sb.terminal_threshold_of(terminal_handlers[0]) == logging.WARNING
 
     def test_terminal_threshold_kwarg_overrides(
         self, fresh_registry, session_dir,
@@ -220,7 +220,7 @@ class TestTerminalHandler:
             and not isinstance(h, logging.FileHandler)
             and getattr(h, sb._HANDLER_MARKER, False)
         ]
-        assert terminal_handlers[0].level == logging.ERROR
+        assert sb.terminal_threshold_of(terminal_handlers[0]) == logging.ERROR
 
 
 # ---------------------------------------------------------------------------

--- a/tests/governance/test_silent_boot_cockpit.py
+++ b/tests/governance/test_silent_boot_cockpit.py
@@ -99,7 +99,7 @@ class TestCockpitConsoleThreshold:
         assert handler.level == logging.DEBUG  # file handler unaffected
         root = logging.getLogger()
         term = _terminal_handler(root)
-        assert term.level == logging.ERROR
+        assert sb.terminal_threshold_of(term) == logging.ERROR
 
     def test_cockpit_via_env_var_matches_explicit_mode(
         self, monkeypatch: pytest.MonkeyPatch, fresh_registry, session_dir,
@@ -108,7 +108,7 @@ class TestCockpitConsoleThreshold:
         sb.configure_silent_boot(session_dir)
         root = logging.getLogger()
         term = _terminal_handler(root)
-        assert term.level == logging.ERROR
+        assert sb.terminal_threshold_of(term) == logging.ERROR
 
 
 # ---------------------------------------------------------------------------
@@ -182,7 +182,7 @@ class TestSoakGoldenUnchanged:
         sb.configure_silent_boot(session_dir, mode=PresentationMode.SOAK)
         root = logging.getLogger()
         term = _terminal_handler(root)
-        assert term.level == logging.WARNING
+        assert sb.terminal_threshold_of(term) == logging.WARNING
 
     def test_default_mode_no_env_matches_soak(
         self, fresh_registry, session_dir,
@@ -192,7 +192,7 @@ class TestSoakGoldenUnchanged:
         sb.configure_silent_boot(session_dir)
         root = logging.getLogger()
         term = _terminal_handler(root)
-        assert term.level == logging.WARNING
+        assert sb.terminal_threshold_of(term) == logging.WARNING
 
     def test_soak_warning_reaches_both(
         self, fresh_registry, session_dir, capsys,
@@ -225,7 +225,7 @@ class TestThresholdPrecedence:
         )
         root = logging.getLogger()
         term = _terminal_handler(root)
-        assert term.level == logging.DEBUG
+        assert sb.terminal_threshold_of(term) == logging.DEBUG
 
     def test_explicit_env_override_wins_over_cockpit_default(
         self, monkeypatch: pytest.MonkeyPatch, fresh_registry, session_dir,
@@ -234,7 +234,7 @@ class TestThresholdPrecedence:
         sb.configure_silent_boot(session_dir, mode=PresentationMode.COCKPIT)
         root = logging.getLogger()
         term = _terminal_handler(root)
-        assert term.level == logging.INFO
+        assert sb.terminal_threshold_of(term) == logging.INFO
 
     def test_resolve_terminal_threshold_direct(self, fresh_registry):
         assert sb._resolve_terminal_threshold(

--- a/tests/pty_gate.py
+++ b/tests/pty_gate.py
@@ -82,3 +82,519 @@ def require_pty(nodeid: str = "") -> None:
     master, slave = open_pty(nodeid)
     os.close(master)
     os.close(slave)
+
+
+# ---------------------------------------------------------------------------
+# PTY AFFINITY — deciding WHICH tests need a terminal, without a decorator
+# ---------------------------------------------------------------------------
+#
+# WHY THIS IS AST-BASED AND NOT A MARKER
+# --------------------------------------
+# `require_pty()` above answers "can this machine give us a terminal". It has
+# to be CALLED to matter, and seven of the eight pty-driving files in this
+# repository never call it -- not from malice but because a decorator is a
+# thing a human must remember. One of them (`test_region_layout_mount.py`)
+# allocates directly in the test body, so on a machine without `/dev/ptmx` it
+# does not skip, it ERRORS with a raw `OSError: out of pty devices` while its
+# gated neighbours skip cleanly. Same environment, same cause, two verdicts.
+#
+# So the gate is applied by COLLECTION, from evidence in the source, and the
+# question becomes "what evidence proves a test drives a terminal".
+#
+# TWO SIGNALS THAT LOOK RIGHT AND ARE NOT
+# ---------------------------------------
+# 1. "The module imports prompt_toolkit or rich."  MEASURED: 90 test files do,
+#    and 8 use a pty. Marking on that signal would convert ~82 files of
+#    currently-passing tests into skips on every runner without a terminal --
+#    the exact "reported green while nothing ran" failure this module exists to
+#    prevent, running in the opposite direction. Rendering into a
+#    `Console(record=True)` needs no kernel anything.
+#
+# 2. "The module imports `pty`."  MEASURED: it catches ONE of the eight.
+#    The other seven build a child-process script as a STRING and drive it
+#    through `subprocess`; `pid, fd = pty.fork()` lives inside a triple-quoted
+#    literal. `test_alt_screen_boot.py` imports neither `pty` nor
+#    `prompt_toolkit` nor `rich` at module level. An import graph cannot see
+#    it, and neither can any tool that only walks imports.
+#
+# So the detector reads BOTH the import graph AND the string literals, because
+# in this repository the terminal is driven from inside a string as often as
+# it is driven from an import.
+#
+# CONFIGURATION IS EXTEND-ONLY, DELIBERATELY
+# ------------------------------------------
+# Every signal set below is overridable through the environment, and the
+# override EXTENDS rather than replaces. A detector that an env var could
+# narrow to nothing is a detector that a typo silently disarms, which is how
+# this class of bug returns wearing a configuration flag. The one honest way
+# to turn it off is `JARVIS_PTY_AUTOMARK_DISABLED`, which says so out loud and
+# is reported in the terminal summary.
+
+#: Modules whose import means the test itself allocates a terminal.
+DEFAULT_PTY_MODULES = ("pty",)
+
+#: Attribute names on those modules that allocate. `pty.openpty`/`pty.fork`.
+DEFAULT_PTY_CALLS = ("openpty", "fork")
+
+#: In-tree helpers that own a pty on the caller's behalf. Matched on the FULL
+#: dotted path and on the final segment, so `from .pty_console import ...`
+#: (a relative import, whose `module` is just `pty_console`) is caught too.
+DEFAULT_PTY_HELPERS = ("tests.ui.pty_console", "tests.pty_gate")
+
+#: Substrings that betray a pty driven from inside an embedded child script.
+#: These are matched against STRING LITERALS, which is where seven of the
+#: eight live.
+DEFAULT_PTY_SOURCE_SIGNALS = ("pty.fork(", "pty.openpty(", "TIOCSWINSZ")
+
+MODULES_ENV_VAR = "JARVIS_PTY_SIGNAL_MODULES"
+HELPERS_ENV_VAR = "JARVIS_PTY_HELPER_MODULES"
+SIGNALS_ENV_VAR = "JARVIS_PTY_SOURCE_SIGNALS"
+DISABLE_ENV_VAR = "JARVIS_PTY_AUTOMARK_DISABLED"
+
+#: Marker applied to anything the detector recognises. Registered in
+#: `pytest_configure` so `-m pty` and `-m "not pty"` both work and no
+#: PytestUnknownMarkWarning is emitted.
+PTY_MARKER = "pty"
+
+#: path -> (fingerprint, verdict). Collection asks once per ITEM and a file
+#: holds many; parsing 3,326 files per run without this would cost more than
+#: the suite it gates.
+_AFFINITY_CACHE: "dict" = {}
+
+#: Files the detector could not parse AND could not read. Surfaced in the
+#: summary rather than swallowed: "we could not tell" is not "no".
+UNDECIDABLE: List[Tuple[str, str]] = []
+
+
+def _env_extend(var: str, defaults: Tuple[str, ...]) -> Tuple[str, ...]:
+    """Defaults PLUS anything the environment adds. Never fewer. NEVER raises."""
+    out = list(defaults)
+    try:
+        raw = str(os.environ.get(var, "") or "")
+        for piece in raw.replace(",", " ").split():
+            piece = piece.strip()
+            if piece and piece not in out:
+                out.append(piece)
+    except Exception:  # noqa: BLE001 — a malformed env var must not blind the gate
+        pass
+    return tuple(out)
+
+
+def automark_enabled() -> bool:
+    """Is collection-time pty detection active? NEVER raises."""
+    try:
+        raw = str(os.environ.get(DISABLE_ENV_VAR, "")).strip().lower()
+        return raw in ("", "0", "false", "no", "off")
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def _fingerprint(path: str) -> "Tuple[int, int]":
+    """(mtime_ns, size) — cheap, and it changes whenever the content does."""
+    st = os.stat(path)
+    return (st.st_mtime_ns, st.st_size)
+
+
+def _scan_source(source: str) -> bool:
+    """Does this source drive a terminal? AST first, text as the floor.
+
+    The AST pass answers the import and attribute questions precisely. The
+    literal pass answers the embedded-child-script question, which no import
+    analysis can. A file that fails to parse still gets the literal pass --
+    a `SyntaxError` in a test file is a broken test, not permission to stop
+    gating it.
+    """
+    import ast
+
+    modules = _env_extend(MODULES_ENV_VAR, DEFAULT_PTY_MODULES)
+    calls = _env_extend("", DEFAULT_PTY_CALLS)
+    helpers = _env_extend(HELPERS_ENV_VAR, DEFAULT_PTY_HELPERS)
+    helper_tails = {h.rsplit(".", 1)[-1] for h in helpers}
+
+    def _literal_hit(text: str) -> bool:
+        signals = _env_extend(SIGNALS_ENV_VAR, DEFAULT_PTY_SOURCE_SIGNALS)
+        return any(sig in text for sig in signals)
+
+    try:
+        tree = ast.parse(source)
+    except Exception:  # noqa: BLE001 — SyntaxError, RecursionError, ValueError
+        return _literal_hit(source)
+
+    for node in ast.walk(tree):
+        # `import pty`, `import tests.ui.pty_console`
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                name = alias.name or ""
+                root = name.split(".")[0]
+                if root in modules or name in helpers:
+                    return True
+                if name.rsplit(".", 1)[-1] in helper_tails:
+                    return True
+        # `from pty import openpty`, `from .pty_console import PtyConsole`
+        elif isinstance(node, ast.ImportFrom):
+            name = node.module or ""
+            root = name.split(".")[0]
+            if root in modules or name in helpers:
+                return True
+            if name and name.rsplit(".", 1)[-1] in helper_tails:
+                return True
+        # `pty.openpty(...)` / `pty.fork(...)` however the module was bound
+        elif isinstance(node, ast.Attribute):
+            if node.attr in calls:
+                base = node.value
+                if isinstance(base, ast.Name) and base.id in modules:
+                    return True
+        # The embedded child script -- seven of the eight live here.
+        elif isinstance(node, ast.Constant):
+            if isinstance(node.value, str) and _literal_hit(node.value):
+                return True
+
+    return False
+
+
+def module_needs_pty(path: "str") -> bool:
+    """Does the test module at ``path`` drive a real terminal? NEVER raises.
+
+    Unreadable or unstattable files answer **False** and are recorded in
+    :data:`UNDECIDABLE`. False is the honest answer for "we could not look":
+    marking on a failed read would gate tests on the health of this detector
+    rather than on what they do, and a detector that fails closed would take
+    the suite down with it the first time a path went strange.
+    """
+    if not path:
+        return False
+    try:
+        fp = _fingerprint(path)
+    except Exception as exc:  # noqa: BLE001
+        UNDECIDABLE.append((str(path), f"stat failed: {exc}"))
+        return False
+
+    cached = _AFFINITY_CACHE.get(path)
+    if cached is not None and cached[0] == fp:
+        return bool(cached[1])
+
+    try:
+        with open(path, "rb") as fh:
+            source = fh.read().decode("utf-8", errors="replace")
+    except Exception as exc:  # noqa: BLE001
+        UNDECIDABLE.append((str(path), f"read failed: {exc}"))
+        return False
+
+    try:
+        verdict = _scan_source(source)
+    except Exception as exc:  # noqa: BLE001 — detection must never kill collection
+        UNDECIDABLE.append((str(path), f"scan failed: {exc}"))
+        verdict = False
+
+    _AFFINITY_CACHE[path] = (fp, verdict)
+    return verdict
+
+
+def item_path(item: "object") -> str:
+    """The filesystem path of a collected item, across pytest versions."""
+    try:
+        raw = getattr(item, "path", None)
+        if raw is None:
+            raw = getattr(item, "fspath", None)
+        return str(raw) if raw is not None else ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def mark_pty_items(items: "object") -> int:
+    """Apply the pty marker to every item whose module drives a terminal.
+
+    Returns how many were marked. Mutates items in place; never raises; a
+    single unmarkable item never stops the rest.
+    """
+    if not automark_enabled():
+        return 0
+    marked = 0
+    try:
+        mark = getattr(pytest.mark, PTY_MARKER)
+    except Exception:  # noqa: BLE001
+        return 0
+    for item in items or ():
+        try:
+            if item.get_closest_marker(PTY_MARKER) is not None:
+                continue
+            # Per-ITEM, never per-module: see the taint section below for the
+            # measurement that made module granularity unacceptable.
+            if item_needs_pty(item):
+                item.add_marker(mark)
+                marked += 1
+        except Exception:  # noqa: BLE001
+            continue
+    return marked
+
+
+def gate_item(item: "object") -> None:
+    """Enforce the terminal requirement for one marked item. NEVER raises past pytest.
+
+    Runs at SETUP, before the test body allocates anything. That placement is
+    the whole point: it is why a machine without `/dev/ptmx` now produces the
+    same verdict for all eight files instead of one raw `OSError` among seven
+    clean skips. Delegates the decision to :func:`require_pty` so there is
+    still exactly ONE definition of "can this machine give us a terminal".
+    """
+    try:
+        if item.get_closest_marker(PTY_MARKER) is None:
+            return
+    except Exception:  # noqa: BLE001
+        return
+    require_pty(getattr(item, "nodeid", "") or "")
+
+
+# ---------------------------------------------------------------------------
+# ITEM-LEVEL AFFINITY — because a module is the wrong unit
+# ---------------------------------------------------------------------------
+#
+# MEASURED, and the reason this section exists: gating at MODULE level turned
+# `test_region_layout_mount.py` from "4 errored, 5 passed" into "9 skipped".
+# Exactly one of its six tests touches a terminal (`test_renders_without_
+# geometry_panic`, via the module-level helper `_render_at`); the five in the
+# class below it never allocate anything. Skipping those five is the same
+# harm as the import-based signal rejected above -- passing tests silently
+# converted into skips -- just smaller. A fix that trades one regression for
+# a quieter one is not a fix.
+#
+# So affinity is resolved per TEST, by taint analysis inside the module:
+#
+#   * a function is DIRECTLY tainted if its own subtree allocates a terminal
+#     (`pty.openpty`/`pty.fork`), imports `pty`, embeds a child script whose
+#     text does, or references a name already known to be tainted;
+#   * taint PROPAGATES through calls to fixpoint, so a test that calls a
+#     helper that calls a helper that allocates is caught;
+#   * a module-level `import pty` taints NOTHING by itself. An import is not a
+#     use, and treating it as one is what over-gated the five.
+#
+# Fixtures are functions, so they are covered by the same pass: a test whose
+# parameter names a tainted fixture inherits its taint.
+
+def _tainted_seed_names(tree: "object", helpers: "Tuple[str, ...]") -> "set":
+    """Module-level names that carry terminal-driving content.
+
+    Two kinds, both of which the call graph then propagates:
+
+    * a string constant holding an embedded child script (`_SCRIPT = '''...
+      pty.fork() ...'''`) -- the shape seven of the eight files use;
+    * a binding introduced by importing a pty-owning helper, under whatever
+      alias it was given.
+    """
+    import ast
+
+    helper_tails = {h.rsplit(".", 1)[-1] for h in helpers}
+    seeds = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+            val = node.value.value
+            if isinstance(val, str) and _literal_signals_hit(val):
+                for tgt in node.targets:
+                    if isinstance(tgt, ast.Name):
+                        seeds.add(tgt.id)
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if mod in helpers or mod.rsplit(".", 1)[-1] in helper_tails:
+                for alias in node.names:
+                    seeds.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                name = alias.name or ""
+                if name in helpers or name.rsplit(".", 1)[-1] in helper_tails:
+                    seeds.add(alias.asname or name.split(".")[0])
+    return seeds
+
+
+def _literal_signals_hit(text: str) -> bool:
+    """Does this text drive a terminal? Used for embedded child scripts."""
+    try:
+        signals = _env_extend(SIGNALS_ENV_VAR, DEFAULT_PTY_SOURCE_SIGNALS)
+        return any(sig in text for sig in signals)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _function_defs(tree: "object") -> "dict":
+    """Every function in the module, by bare name, including methods.
+
+    Keyed on the bare name because that is what a pytest node id gives us.
+    On a name collision across classes the entries are kept as a LIST and the
+    taint verdict is the OR of them -- conservative in the only direction
+    that cannot silently un-gate a terminal test.
+    """
+    import ast
+
+    out: "dict" = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            out.setdefault(node.name, []).append(node)
+    return out
+
+
+def _direct_taint(fn: "object", seeds: "set") -> bool:
+    """Does this function itself reach a terminal? NEVER raises."""
+    import ast
+
+    modules = _env_extend(MODULES_ENV_VAR, DEFAULT_PTY_MODULES)
+    calls = DEFAULT_PTY_CALLS
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Attribute) and node.attr in calls:
+            base = node.value
+            if isinstance(base, ast.Name) and base.id in modules:
+                return True
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if (alias.name or "").split(".")[0] in modules:
+                    return True
+        elif isinstance(node, ast.ImportFrom):
+            if (node.module or "").split(".")[0] in modules:
+                return True
+        elif isinstance(node, ast.Constant):
+            if isinstance(node.value, str) and _literal_signals_hit(node.value):
+                return True
+        elif isinstance(node, ast.Name) and node.id in seeds:
+            return True
+    return False
+
+
+def _callee_names(fn: "object") -> "set":
+    """Names this function calls, plus its parameter names.
+
+    Parameters are included because a pytest fixture arrives as one, and a
+    fixture that allocates a terminal must taint the tests that request it.
+    """
+    import ast
+
+    names = set()
+    try:
+        for arg in list(getattr(fn.args, "args", []) or []) + \
+                list(getattr(fn.args, "kwonlyargs", []) or []):
+            names.add(arg.arg)
+    except Exception:  # noqa: BLE001
+        pass
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                names.add(func.attr)
+        elif isinstance(node, ast.Name):
+            names.add(node.id)
+    return names
+
+
+def _analyze_module(source: str) -> "Tuple[bool, set]":
+    """(module_touches_pty, {tainted function names}). NEVER raises.
+
+    The boolean is the conservative module-wide answer, kept for callers that
+    have no test name to resolve. The set is the precise one.
+    """
+    import ast
+
+    try:
+        tree = ast.parse(source)
+    except Exception:  # noqa: BLE001 — unparseable: fall back to the text floor
+        return (_literal_signals_hit(source), set())
+
+    helpers = _env_extend(HELPERS_ENV_VAR, DEFAULT_PTY_HELPERS)
+    seeds = _tainted_seed_names(tree, helpers)
+    funcs = _function_defs(tree)
+
+    tainted = set(seeds)
+    for name, defs in funcs.items():
+        if any(_direct_taint(d, seeds) for d in defs):
+            tainted.add(name)
+
+    # Propagate through the call graph to fixpoint. Bounded by the number of
+    # functions, so it always terminates; a cycle simply stops adding.
+    changed = True
+    guard = 0
+    while changed and guard < len(funcs) + 2:
+        changed = False
+        guard += 1
+        for name, defs in funcs.items():
+            if name in tainted:
+                continue
+            for d in defs:
+                if _callee_names(d) & tainted:
+                    tainted.add(name)
+                    changed = True
+                    break
+
+    module_wide = bool(tainted) or _scan_source(source)
+    return (module_wide, tainted)
+
+
+def _module_analysis(path: str) -> "Tuple[bool, set]":
+    """Cached :func:`_analyze_module` for one path. NEVER raises."""
+    key = ("analysis", path)
+    try:
+        fp = _fingerprint(path)
+    except Exception as exc:  # noqa: BLE001
+        UNDECIDABLE.append((str(path), f"stat failed: {exc}"))
+        return (False, set())
+    cached = _AFFINITY_CACHE.get(key)
+    if cached is not None and cached[0] == fp:
+        return cached[1]
+    try:
+        with open(path, "rb") as fh:
+            source = fh.read().decode("utf-8", errors="replace")
+    except Exception as exc:  # noqa: BLE001
+        UNDECIDABLE.append((str(path), f"read failed: {exc}"))
+        return (False, set())
+    try:
+        result = _analyze_module(source)
+    except Exception as exc:  # noqa: BLE001
+        UNDECIDABLE.append((str(path), f"analysis failed: {exc}"))
+        result = (False, set())
+    _AFFINITY_CACHE[key] = (fp, result)
+    return result
+
+
+def _item_function_name(item: "object") -> str:
+    """The bare function name behind a node id.
+
+    `test_x[200]` -> `test_x`; `TestC::test_y` -> `test_y`. Parametrisation
+    and class nesting are presentation, not identity.
+    """
+    try:
+        name = str(getattr(item, "name", "") or "")
+    except Exception:  # noqa: BLE001
+        return ""
+    if "[" in name:
+        name = name.split("[", 1)[0]
+    if "::" in name:
+        name = name.rsplit("::", 1)[-1]
+    return name.strip()
+
+
+def item_needs_pty(item: "object") -> bool:
+    """Does THIS test drive a terminal? NEVER raises.
+
+    Falls back to the module-wide verdict only when the function cannot be
+    resolved -- an unresolvable name must not silently un-gate a test that
+    allocates.
+    """
+    path = item_path(item)
+    if not path:
+        return False
+    module_wide, tainted = _module_analysis(path)
+    if not module_wide:
+        return False
+    fname = _item_function_name(item)
+    if not fname:
+        return True
+    if fname in tainted:
+        return True
+    # A resolvable name that is simply not tainted is a real negative: the
+    # module drives a terminal somewhere, this test does not.
+    try:
+        import ast
+        with open(path, "rb") as fh:
+            src = fh.read().decode("utf-8", errors="replace")
+        if fname in _function_defs(ast.parse(src)):
+            return False
+    except Exception:  # noqa: BLE001
+        pass
+    return True


### PR DESCRIPTION
Phase 1 + Week 2 from the cockpit audit. Every item here is a **measured** defect from `bt-2026-08-18-021438` or from running the repo's own instruments — not a speculative cleanup. Nothing needs provider credit.

## The through-line

Five separate places where an instrument reported something other than what was true, and one where output was composed and thrown away. In four of the five, the correct machinery **already existed** and the defect was that something wasn't routed into it.

| # | Defect | Fix shape |
|---|---|---|
| 1 | 7 of 8 pty files bypassed the one gate; one **errored** where the others skipped | detect at collection by taint analysis, gate at setup |
| 2 | ~550 routine telemetry lines a session at WARNING | decouple audience from severity |
| 3 | HTTP 402 classified as an outage → **125 awaken triggers** | classify into the breaker that already exists |
| 4 | `'bool' object is not callable` on every op, no traceback for a week | the diagnostic was on the seam that never runs |
| 5 | Render frames dropped whenever no cockpit was attached | retain + replay on the existing flush seam |

## Where I deviated from spec, and why

**PTY (#1)** — "mark modules importing prompt_toolkit/rich" would have misfired **both ways**: 90 test files import those and 8 use a pty (≈82 passing files → skips), while 7 of the 8 drive the terminal from inside a child-script *string literal*, so an import graph misses them entirely (`test_alt_screen_boot.py` imports none of the three). Detector reads imports **and** literals, then taints per-item. Module granularity was also wrong — it turned "4 errored, 5 passed" into "9 skipped".

**Logging (#2)** — a blanket demote to DEBUG would have destroyed the A1 milestone proof; `a1_trace` says WARNING is load-bearing *in its own docstring*. The real defect was that severity was the **only** visibility lever, which is why COCKPIT mode had already been raised to ERROR to escape the chatter — meaning the inflated lines stopped reaching the cockpit anyway.

**Failover (#3)** — the circuit breaker already exists for 401/403 and zeroes the exact inputs `_hard_outage_confirmed()` reads. 402 wasn't classified into it. A second breaker would be a second authority for one decision. 429 is split off separately — a rate limit is the plane *working*.

**Backlog (#5)** — `_replay()` already existed (Slice H). What was missing was retention, not a registry.

## Evidence

- **264 passed / 0 failed** across all touched suites; the bridge's own suites **166 / 0**.
- PTY: recall **8/8**, false positives **0/90**. Stashed baseline on `tests/cli tests/ui`: **10 failed → 9 failed + 1 skip**, 75 passed both ways.
- Failover: suites **35 failed / 287 passed identically** before and after (all pre-existing); `503` still degrades — a fix that disarmed the failover would be worse than the bug.
- Auditors verified to parse all six changed line shapes identically at their new levels.
- Backlog verified **live over a real UDS pair**: detached → 5 retained → 5 replayed oldest-first → live frame not retained → second cockpit gets 0.

## Notes for the reviewer

- ⚠️ Bridge tests **fail inside a sandbox** (`start()` returns False on a blocked UDS bind). Run them unsandboxed or the red is a false alarm — that's what the 20→0 swing in this branch's history was.
- #4 makes the traceback reachable; it does **not** fix the underlying `TypeError`. That needs the next boot's output, and guessing at it is what root-cause-only forbids.
- `.gitignore`: `test-results/` is a workflow-declared `RESULTS_DIR` that was never ignored, so local e2e runs dirtied the tree — which matters because the harness stashes uncommitted work at boot.
- Also reverted an unrelated `JARVISWatch.xcscheme` **downgrade** (v1.7→v1.3, dropping three attributes) — an older Xcode rewriting the scheme on open, not an authored change.

## Still open

`StreamEventBroker.stream_iter` / `ExecutionGraphProgressTracker._drain_subscriber` `aclose()` collisions and 33 unclosed aiohttp sessions. Owners not yet traced; wrapping the wrong layer would relocate the leak rather than close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five measured observability defects and preserves cockpit output when detached. Previously: PTY-driven tests often bypassed gating; routine telemetry logged as WARNING; HTTP 402 misclassified as outage (triggering awakens); context-expansion failures lacked tracebacks; cockpit render frames were dropped without a listener. Now: collection-time PTY gating per test; audience-aware logging at honest levels; 402 freezes the heartbeat and notifies the operator; failures include tracebacks; render frames are retained and replayed on reattach. Also ignores the e2e `test-results/` directory.

- Cockpit offline backlog: retain and replay only ambient render frames when no cockpit is attached; pre-join flush with peek/commit; TTL- and size-bounded ring with counters. Env: `JARVIS_ATTACH_OFFLINE_BACKLOG_ENABLED` (default on), `JARVIS_ATTACH_BACKLOG_SIZE`, `JARVIS_ATTACH_BACKLOG_TTL_S`.
- Audience vs severity: `silent_boot` adds `operator_extra` and a terminal filter; `terminal_threshold_of()` exposes the active threshold. `a1_trace` emits in-scope proof lines at INFO to the operator and demotes out-of-scope sensor hops to DEBUG. `provenance_ledger` is INFO on verified chains and WARNING on failures; auditor parsers remain level-agnostic.
- Failover classification: `provider_heartbeat` classifies HTTP 402 as funding (freeze loop; no degrade; DLQ + `provider_funding_required` SSE via `ide_observability_stream`) and 429 as throttled (no freeze/degrade). HTTP code sets are env-extendable without narrowing the defaults.
- Context expansion diagnostics: `context_expansion_runner` logs the exception type and full traceback (`exc_info=True`) so the next occurrence names its site; underlying `TypeError` remains to be fixed.
- PTY test gate: `tests/pty_gate.py` performs AST+literal detection with per-item taint propagation; marks `pty` at collection; enforced at `pytest_runtest_setup` for consistent skips; `conftest.py` unifies collection hooks and adds summary reporting. Env: `JARVIS_PTY_AUTOMARK_DISABLED` to disarm automarking.

<sup>Written for commit 6653484e35ee749b4c496975be8a96f8f7070f3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

