### PR TITLE
fix: Five places claimed to know the doctor's edge set, and none of them was it

### DIFF
--- a/backend/core/ouroboros/cli/ov_doctor.py
+++ b/backend/core/ouroboros/cli/ov_doctor.py
@@ -1,19 +1,15 @@
-"""``ov doctor`` — the 8-edge full-chain connectivity matrix (Slice B/C).
+"""``ov doctor`` — the full-chain connectivity matrix (Slice B/C).
 
 Every edge is asserted with the SAME probe its real consumer uses (the
-Slice-A law: no probe may be weaker than the contract it vouches for):
+Slice-A law: no probe may be weaker than the contract it vouches for).
 
-  1 process   — an organism process exists (pgrep, bounded)
-  2 cockpit   — thin_client.probe_socket(deep=True): SERVING means the
-                hydration frame is actually served, not merely accepted
-  3 hydration — the frame parses; subsystem states read from it
-  4 fabrics   — hive aggregator attachment (trinity/sse/emitter) from the
-                hydration ``fabrics`` block (daemon-side pull provider)
-  5 sensors   — GET /channel/health (EventChannelServer)
-  6 providers — hydration ``liquidity`` block (DW=tokens lane, Claude=time
-                lane, J-Prime=sovereignty lane)
-  7 liveness  — GET /observability/liveness (Gap 2: static ∩ runtime)
-  8 mcp       — JARVIS_MCP_CONFIG declared servers (NEVER executed)
+**The edge set is declared in :data:`EDGES`, and that declaration is the
+only place it is written down.** This docstring used to enumerate the edges
+and call the matrix "8-edge"; ``probe_edge_compute`` was added as edge 9 and
+this text kept saying eight, while two tests kept asserting eight and failed
+on ``main`` for days. Prose that restates a data structure is prose that
+will eventually contradict it, so the per-edge summaries now live on
+:class:`EdgeSpec` where the code can read them too.
 
 Structure (mandate 1): edges 1+2 gate the chain; everything downstream
 that is structurally independent (hydration-read, channel-health,
@@ -38,6 +34,135 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class EdgeSpec:
+    """One edge of the connectivity matrix, declared once.
+
+    ``number`` is the operator-facing position, ``key`` the stable
+    identifier code refers to, ``summary`` the one-line explanation that
+    used to live in this module's docstring. Keeping the prose here is the
+    point: a description parked in a docstring is a fifth place that claims
+    to know the edge set, and it was already wrong."""
+
+    number: int
+    key: str
+    name: str
+    summary: str
+    #: True for edges that only exist under an opt-in flag. They are
+    #: declared here so they get a NUMBER from the same sequence as
+    #: everything else -- which is exactly what the live probe did not have.
+    optional: bool = False
+
+    @property
+    def label(self) -> str:
+        """The rendered edge label -- DERIVED, never spelled twice."""
+        return f"{self.number} {self.name}"
+
+
+#: THE declaration of the matrix. Ordered, and the order IS canonical.
+#:
+#: WHY THIS EXISTS
+#: ---------------
+#: `probe_edge_compute` was added as edge 9 and four separate places went on
+#: describing an 8-edge matrix: this module's own docstring ("the 8-edge
+#: full-chain connectivity matrix", enumerating 1-8), the hand-ordered list
+#: in `run_matrix`, and two tests asserting `len(report.verdicts) == 8`. The
+#: tests failed on `main` for days. Nothing was authoritative, so nothing
+#: could be updated.
+#:
+#: The edge's identity was also re-spelled at ~30 `EdgeVerdict(...)` call
+#: sites -- every return path of every probe repeating its own label -- so a
+#: rename could half-land and a typo would invent a tenth edge that renders
+#: once and matches nothing.
+#:
+#: Adding an edge is now ONE entry here. Ordering, cardinality, labels and
+#: the operator-facing prose all follow, and `test_edge_registry_is_the_only
+#: _source` pins that no call site may reintroduce a literal.
+EDGES: "Tuple[EdgeSpec, ...]" = (
+    EdgeSpec(1, "process", "process",
+             "an organism process exists (pgrep, bounded)"),
+    EdgeSpec(2, "cockpit", "cockpit UDS",
+             "thin_client.probe_socket(deep=True): SERVING means the "
+             "hydration frame is actually served, not merely accepted"),
+    EdgeSpec(3, "hydration", "hydration",
+             "the frame parses; subsystem states read from it"),
+    EdgeSpec(4, "fabrics", "hive fabrics",
+             "hive aggregator attachment (trinity/sse/emitter) from the "
+             "hydration ``fabrics`` block (daemon-side pull provider)"),
+    EdgeSpec(5, "sensors", "sensors",
+             "GET /channel/health (EventChannelServer)"),
+    EdgeSpec(6, "providers", "providers",
+             "hydration ``liquidity`` block (DW=tokens lane, Claude=time "
+             "lane, J-Prime=sovereignty lane)"),
+    EdgeSpec(7, "liveness", "liveness",
+             "GET /observability/liveness (Gap 2: static n runtime)"),
+    EdgeSpec(8, "mcp", "mcp servers",
+             "JARVIS_MCP_CONFIG declared servers (NEVER executed)"),
+    EdgeSpec(9, "compute", "compute",
+             "host compute topology -- socket-independent BY DESIGN, so a "
+             "machine the organism has never run on can still answer "
+             "'can this host load anything?'"),
+    # `--live` only. It was numbered 9 when 9 was free, `probe_edge_compute`
+    # later took 9 as well, and `run_doctor(live=True)` appends this verdict
+    # to the SAME report -- so an operator running `ov doctor --live` saw TWO
+    # rows numbered 9. Neither site could see the other; only a shared
+    # declaration can. Optional, so it is not part of `edge_count()`.
+    EdgeSpec(10, "live", "live probe",
+             "the trace-isolated synthetic web_search loop: tool execution "
+             "-> Step 2 emitter -> aggregator -> UDS, proven end to end",
+             optional=True),
+)
+
+#: The edges `run_matrix()` ALWAYS produces. `edge_count()` means this set,
+#: not `len(EDGES)`: an opt-in probe that inflated the expected cardinality
+#: would make every base-matrix assertion wrong by one.
+MATRIX_EDGES: "Tuple[EdgeSpec, ...]" = tuple(e for e in EDGES if not e.optional)
+
+_BY_KEY: "Dict[str, EdgeSpec]" = {e.key: e for e in EDGES}
+_ORDER: "Dict[str, int]" = {e.label: i for i, e in enumerate(EDGES)}
+
+
+def edge(key: str) -> str:
+    """The canonical label for *key*. NEVER raises.
+
+    An unknown key renders ``? <key>`` rather than raising or silently
+    inventing a plausible label: this module's contract is that no probe may
+    raise from a return path, and a diagnostic that fabricates an edge name
+    is worse than one that says it does not recognise it. The AST pin in the
+    test suite is what stops an unknown key from ever shipping."""
+    spec = _BY_KEY.get(str(key))
+    return spec.label if spec is not None else f"? {key}"
+
+
+def edge_count() -> int:
+    """How many edges `run_matrix()` produces. The number no test may hardcode.
+
+    Counts `MATRIX_EDGES`, so declaring a new opt-in probe never silently
+    changes what the base matrix is expected to contain."""
+    return len(MATRIX_EDGES)
+
+
+def order_verdicts(verdicts: "List[EdgeVerdict]") -> "List[EdgeVerdict]":
+    """Sort verdicts into canonical edge order. NEVER raises.
+
+    `run_matrix` used to achieve this by placing them in a hand-written list
+    under a `# canonical edge order: 3,4,5,6,7,8,9` comment -- correct, and
+    correct only for as long as someone reads the comment. Deriving the order
+    from the declaration means a new edge lands in the right place because of
+    where it was declared, not because of where it was appended.
+
+    Unrecognised labels sort last, in arrival order, so an edge this registry
+    has never heard of is still REPORTED. Dropping it would make the matrix
+    quietly lie about what it probed."""
+    try:
+        return sorted(
+            verdicts,
+            key=lambda v: (_ORDER.get(getattr(v, "edge", ""), len(EDGES)),),
+        )
+    except Exception:  # noqa: BLE001 -- ordering must never break a report
+        return list(verdicts)
 
 
 class EdgeState(str, enum.Enum):
@@ -124,12 +249,12 @@ async def probe_edge_process() -> EdgeVerdict:
             proc.communicate(), timeout=_edge_timeout_s())
         pids = [p for p in out.decode().split() if p.strip()]
         if pids:
-            return EdgeVerdict("1 process", EdgeState.OK,
+            return EdgeVerdict(edge("process"), EdgeState.OK,
                                f"pid {', '.join(pids[:3])}")
-        return EdgeVerdict("1 process", EdgeState.SEVERED,
+        return EdgeVerdict(edge("process"), EdgeState.SEVERED,
                            "no organism process")
     except Exception as exc:  # noqa: BLE001
-        return EdgeVerdict("1 process", EdgeState.DEGRADED,
+        return EdgeVerdict(edge("process"), EdgeState.DEGRADED,
                            f"probe error: {str(exc)[:60]}")
 
 
@@ -165,10 +290,10 @@ async def probe_edge_socket() -> Tuple[EdgeVerdict, str]:
             "absent": (EdgeState.SEVERED, "no socket"),
         }
         es, detail = mapping.get(state, (EdgeState.SEVERED, state))
-        return EdgeVerdict("2 cockpit UDS", es,
+        return EdgeVerdict(edge("cockpit"), es,
                            f"{detail} · {path}"), state
     except Exception as exc:  # noqa: BLE001
-        return EdgeVerdict("2 cockpit UDS", EdgeState.SEVERED,
+        return EdgeVerdict(edge("cockpit"), EdgeState.SEVERED,
                            f"probe error: {str(exc)[:60]}"), "error"
 
 
@@ -201,9 +326,9 @@ def _verdicts_from_hydration(
     """Edges 3, 4, 6 — all read from ONE hydration frame (one connect)."""
     if payload is None:
         return [
-            EdgeVerdict("3 hydration", EdgeState.SEVERED, "no frame served"),
-            EdgeVerdict("4 hive fabrics", EdgeState.SKIPPED, "no hydration"),
-            EdgeVerdict("6 providers", EdgeState.SKIPPED, "no hydration"),
+            EdgeVerdict(edge("hydration"), EdgeState.SEVERED, "no frame served"),
+            EdgeVerdict(edge("fabrics"), EdgeState.SKIPPED, "no hydration"),
+            EdgeVerdict(edge("providers"), EdgeState.SKIPPED, "no hydration"),
         ]
     out: List[EdgeVerdict] = []
     # 3 — hydration content
@@ -212,21 +337,21 @@ def _verdicts_from_hydration(
     subs = hyd.get("subsystems") or {}
     bad = [k for k, v in subs.items() if str(v) not in ("ok", "ready")]
     if payload.get("type") != "hydration":
-        out.append(EdgeVerdict("3 hydration", EdgeState.DEGRADED,
+        out.append(EdgeVerdict(edge("hydration"), EdgeState.DEGRADED,
                                f"unexpected first frame {payload.get('type')}"))
     elif bad:
-        out.append(EdgeVerdict("3 hydration", EdgeState.DEGRADED,
+        out.append(EdgeVerdict(edge("hydration"), EdgeState.DEGRADED,
                                "subsystems degraded: " + ", ".join(bad[:4])))
     else:
         loaded = hyd.get("loaded"), hyd.get("total")
         out.append(EdgeVerdict(
-            "3 hydration", EdgeState.OK,
+            edge("hydration"), EdgeState.OK,
             f"subsystems {loaded[0]}/{loaded[1]}" if loaded[0] is not None
             else "frame parsed"))
     # 4 — hive fabrics
     fab = payload.get("fabrics") or {}
     if not fab:
-        out.append(EdgeVerdict("4 hive fabrics", EdgeState.DEGRADED,
+        out.append(EdgeVerdict(edge("fabrics"), EdgeState.DEGRADED,
                                "no fabrics block (older daemon?)"))
     else:
         tsubs = int(fab.get("trinity_subs", 0) or 0)
@@ -236,20 +361,20 @@ def _verdicts_from_hydration(
                                    ("emitter", emitter)) if not on]
         detail = f"trinity_subs={tsubs} sse={sse} emitter={emitter}"
         if not missing:
-            out.append(EdgeVerdict("4 hive fabrics", EdgeState.OK, detail))
+            out.append(EdgeVerdict(edge("fabrics"), EdgeState.OK, detail))
         elif missing == ["trinity"]:
             out.append(EdgeVerdict(
-                "4 hive fabrics", EdgeState.DEGRADED,
+                edge("fabrics"), EdgeState.DEGRADED,
                 detail + " (bus not yet materialized — re-attach pending)"))
         else:
-            out.append(EdgeVerdict("4 hive fabrics", EdgeState.DEGRADED,
+            out.append(EdgeVerdict(edge("fabrics"), EdgeState.DEGRADED,
                                    detail + " missing: " + ",".join(missing)))
     # 6 — providers (DW = tokens lane · Claude = time lane · J-Prime =
     # sovereignty lane)
     liq = payload.get("liquidity") or {}
     providers = liq.get("providers") or {}
     if not providers:
-        out.append(EdgeVerdict("6 providers", EdgeState.DEGRADED,
+        out.append(EdgeVerdict(edge("providers"), EdgeState.DEGRADED,
                                "no liquidity data in hydration"))
     else:
         rows = []
@@ -259,7 +384,7 @@ def _verdicts_from_hydration(
             rows.append(f"{name}:{tok:,}" if isinstance(tok, int)
                         else f"{name}:?")
         out.append(EdgeVerdict(
-            "6 providers",
+            edge("providers"),
             EdgeState.DEGRADED if exhausted else EdgeState.OK,
             (" ".join(rows) + (" · RUNWAY EXHAUSTED" if exhausted else "")),
         ))
@@ -284,20 +409,20 @@ async def probe_edge_compute() -> EdgeVerdict:
         from backend.core.ouroboros.governance import compute_topology as ct
         if not ct.is_enabled():
             return EdgeVerdict(
-                "9 compute", EdgeState.SKIPPED,
+                edge("compute"), EdgeState.SKIPPED,
                 "topology probe disabled (JARVIS_COMPUTE_TOPOLOGY_ENABLED)")
         reading = await asyncio.wait_for(
             ct.resolve(), timeout=_edge_timeout_s() * 4)
     except asyncio.TimeoutError:
-        return EdgeVerdict("9 compute", EdgeState.DEGRADED,
+        return EdgeVerdict(edge("compute"), EdgeState.DEGRADED,
                            "topology probe timed out — driver may be wedged")
     except Exception as exc:  # noqa: BLE001
-        return EdgeVerdict("9 compute", EdgeState.DEGRADED,
+        return EdgeVerdict(edge("compute"), EdgeState.DEGRADED,
                            f"topology unavailable ({type(exc).__name__})")
 
     if not getattr(reading, "measured", False):
         return EdgeVerdict(
-            "9 compute", EdgeState.DEGRADED,
+            edge("compute"), EdgeState.DEGRADED,
             f"host unresolved ({reading.source}) — admission falls back to "
             f"the host bound with the unverified ceiling")
 
@@ -315,7 +440,7 @@ async def probe_edge_compute() -> EdgeVerdict:
             detail += f" · {ooms} recent OOM(s) raising the margin"
     except Exception:  # noqa: BLE001 — the reading alone is still useful
         pass
-    return EdgeVerdict("9 compute", EdgeState.OK, detail)
+    return EdgeVerdict(edge("compute"), EdgeState.OK, detail)
 
 
 async def _http_get(path: str) -> Tuple[Optional[int], Optional[Any]]:
@@ -368,11 +493,11 @@ async def probe_edge_sensors() -> EdgeVerdict:
     ``status`` + per-sensor blocks under ``*_sensor`` keys."""
     code, data = await _http_get("/channel/health")
     if code is None:
-        return EdgeVerdict("5 sensors", EdgeState.ABSENT,
+        return EdgeVerdict(edge("sensors"), EdgeState.ABSENT,
                            "channel server unreachable "
                            f"({':'.join(map(str, _channel_host_port()))})")
     if data is None:
-        return EdgeVerdict("5 sensors", EdgeState.DEGRADED,
+        return EdgeVerdict(edge("sensors"), EdgeState.DEGRADED,
                            f"server up, /channel/health returned {code}")
     healthy = str(data.get("status", "")).lower() == "healthy"
     sensor_blocks = {k: v for k, v in data.items()
@@ -382,8 +507,8 @@ async def probe_edge_sensors() -> EdgeVerdict:
     detail = (f"{wired}/{len(sensor_blocks)} webhook sensor(s) wired · "
               f"{total_events} events routed")
     if healthy:
-        return EdgeVerdict("5 sensors", EdgeState.OK, detail)
-    return EdgeVerdict("5 sensors", EdgeState.DEGRADED,
+        return EdgeVerdict(edge("sensors"), EdgeState.OK, detail)
+    return EdgeVerdict(edge("sensors"), EdgeState.DEGRADED,
                        f"status={data.get('status')} · {detail}")
 
 
@@ -391,11 +516,11 @@ async def probe_edge_liveness() -> EdgeVerdict:
     """Edge 7: /observability/liveness (static ∩ runtime capabilities)."""
     code, data = await _http_get("/observability/liveness")
     if code is None:
-        return EdgeVerdict("7 liveness", EdgeState.ABSENT,
+        return EdgeVerdict(edge("liveness"), EdgeState.ABSENT,
                            "channel server unreachable")
     if data is None:
         return EdgeVerdict(
-            "7 liveness", EdgeState.ABSENT,
+            edge("liveness"), EdgeState.ABSENT,
             f"server up, path not mounted ({code}) — daemon predates "
             "the endpoint or the router is disabled")
     caps = data.get("capabilities") or data.get("liveness") or data
@@ -404,33 +529,33 @@ async def probe_edge_liveness() -> EdgeVerdict:
                    if isinstance(v, (str, dict))
                    and "dormant" in str(v).lower()][:3]
         if dormant:
-            return EdgeVerdict("7 liveness", EdgeState.DEGRADED,
+            return EdgeVerdict(edge("liveness"), EdgeState.DEGRADED,
                                "dormant: " + ", ".join(dormant))
-        return EdgeVerdict("7 liveness", EdgeState.OK,
+        return EdgeVerdict(edge("liveness"), EdgeState.OK,
                            f"{len(caps)} capabilities reported")
-    return EdgeVerdict("7 liveness", EdgeState.DEGRADED, "empty response")
+    return EdgeVerdict(edge("liveness"), EdgeState.DEGRADED, "empty response")
 
 
 async def probe_edge_mcp() -> EdgeVerdict:
     """Edge 8: MCP server CONFIGURATION only — never executed."""
     cfg = os.environ.get("JARVIS_MCP_CONFIG", "").strip()
     if not cfg:
-        return EdgeVerdict("8 mcp servers", EdgeState.ABSENT,
+        return EdgeVerdict(edge("mcp"), EdgeState.ABSENT,
                            "JARVIS_MCP_CONFIG unset")
     p = Path(cfg)
     if not p.exists():
-        return EdgeVerdict("8 mcp servers", EdgeState.SEVERED,
+        return EdgeVerdict(edge("mcp"), EdgeState.SEVERED,
                            f"config path missing: {cfg}")
     try:
         import yaml  # lazy — only when a config is declared
         data = yaml.safe_load(p.read_text()) or {}
         servers = data.get("servers") or data.get("mcp_servers") or []
         n = len(servers) if isinstance(servers, (list, dict)) else 0
-        return EdgeVerdict("8 mcp servers", EdgeState.OK,
+        return EdgeVerdict(edge("mcp"), EdgeState.OK,
                            f"{n} server(s) declared (config only — "
                            "never executed by doctor)")
     except Exception as exc:  # noqa: BLE001
-        return EdgeVerdict("8 mcp servers", EdgeState.DEGRADED,
+        return EdgeVerdict(edge("mcp"), EdgeState.DEGRADED,
                            f"config unparseable: {str(exc)[:60]}")
 
 
@@ -462,9 +587,12 @@ async def run_matrix() -> DoctorReport:
             v.latency_ms = lh / max(1, len(hydration_verdicts))
         v5.latency_ms, v7.latency_ms, v8.latency_ms = l5, l7, l8
         v9.latency_ms = l9
-        # canonical edge order: 3,4,5,6,7,8,9
         e3, e4, e6 = hydration_verdicts
-        report.verdicts.extend([e3, e4, v5, e6, v7, v8, v9])
+        # Order comes from the declaration, not from where these happen to
+        # be appended. The hand-written sequence this replaces was correct
+        # only for as long as someone read the comment above it.
+        report.verdicts.extend(
+            order_verdicts([e3, e4, v5, e6, v7, v8, v9]))
     else:
         # chain severed at the socket — probe the independent HTTP/static
         # edges anyway (they may localize the fault), skip the UDS-bound ones.
@@ -479,14 +607,16 @@ async def run_matrix() -> DoctorReport:
         )
         v5.latency_ms, v7.latency_ms, v8.latency_ms = l5, l7, l8
         v9.latency_ms = l9
-        report.verdicts.extend([
-            EdgeVerdict("3 hydration", EdgeState.SKIPPED, "socket not serving"),
-            EdgeVerdict("4 hive fabrics", EdgeState.SKIPPED,
+        report.verdicts.extend(order_verdicts([
+            EdgeVerdict(edge("hydration"), EdgeState.SKIPPED,
+                        "socket not serving"),
+            EdgeVerdict(edge("fabrics"), EdgeState.SKIPPED,
                         "socket not serving"),
             v5,
-            EdgeVerdict("6 providers", EdgeState.SKIPPED, "socket not serving"),
+            EdgeVerdict(edge("providers"), EdgeState.SKIPPED,
+                        "socket not serving"),
             v7, v8, v9,
-        ])
+        ]))
     return report
 
 
@@ -516,7 +646,7 @@ async def run_live_probe() -> EdgeVerdict:
             timeout=_edge_timeout_s(),
         )
     except Exception as exc:  # noqa: BLE001
-        return EdgeVerdict("9 live probe", EdgeState.SEVERED,
+        return EdgeVerdict(edge("live"), EdgeState.SEVERED,
                            f"could not attach: {str(exc)[:60]}")
     try:
         # consume hydration first — it is ALSO the capability signature:
@@ -538,12 +668,12 @@ async def run_live_probe() -> EdgeVerdict:
             hydration = None
         if hydration is None:
             return EdgeVerdict(
-                "9 live probe", EdgeState.DEGRADED,
+                edge("live"), EdgeState.DEGRADED,
                 "hydration not served within the bound (boot-starved?) — "
                 "re-run `ov doctor --live` in a moment")
         if "fabrics" not in hydration:
             return EdgeVerdict(
-                "9 live probe", EdgeState.SKIPPED,
+                edge("live"), EdgeState.SKIPPED,
                 "daemon predates /doctor probe (no fabrics capability "
                 "signature) — restart the organism to enable the live loop")
         w.write((json.dumps(
@@ -560,7 +690,7 @@ async def run_live_probe() -> EdgeVerdict:
             except asyncio.TimeoutError:
                 break
             if not line:
-                return EdgeVerdict("9 live probe", EdgeState.SEVERED,
+                return EdgeVerdict(edge("live"), EdgeState.SEVERED,
                                    "daemon closed the connection mid-probe")
             try:
                 frame = json.loads(line.decode())
@@ -574,7 +704,7 @@ async def run_live_probe() -> EdgeVerdict:
                          or "[synthetic probe]" in str(
                              payload.get("action_summary", "")))):
                 return EdgeVerdict(
-                    "9 live probe", EdgeState.OK,
+                    edge("live"), EdgeState.OK,
                     "synthetic actor_edge frame observed — tool → emitter "
                     "→ aggregator → cockpit proven "
                     f"({payload.get('action_summary', '')[:60]})")
@@ -583,11 +713,11 @@ async def run_live_probe() -> EdgeVerdict:
                 saw_verdict_line = text
         if saw_verdict_line:
             return EdgeVerdict(
-                "9 live probe", EdgeState.DEGRADED,
+                edge("live"), EdgeState.DEGRADED,
                 "daemon ran the probe but no synthetic actor_edge frame "
                 f"arrived in {_live_wait_s():.0f}s ({saw_verdict_line[:60]})")
         return EdgeVerdict(
-            "9 live probe", EdgeState.SEVERED,
+            edge("live"), EdgeState.SEVERED,
             f"no probe response within {_live_wait_s():.0f}s "
             "(daemon may not support /doctor probe)")
     finally:

--- a/ci/ov-surface-suites.txt
+++ b/ci/ov-surface-suites.txt
@@ -2,6 +2,7 @@ tests/api/test_hive_aggregator.py
 tests/api/test_hive_emitter.py
 tests/cli/test_thin_client.py
 tests/cli/test_ov_doctor.py
+tests/cli/test_ov_doctor_edge_registry.py
 tests/cli/test_ov_dispatch.py
 tests/cli/test_ov_system_panel.py
 tests/cli/test_ov_presentation.py

--- a/tests/cli/test_ov_doctor.py
+++ b/tests/cli/test_ov_doctor.py
@@ -95,22 +95,22 @@ def test_no_hydration_severs_edge3_and_skips_dependents():
 
 def test_exit_codes_and_first_broken_ordering():
     r = DoctorReport(verdicts=[
-        EdgeVerdict("1 process", EdgeState.OK),
-        EdgeVerdict("2 cockpit UDS", EdgeState.OK),
+        EdgeVerdict(ov_doctor.edge("process"), EdgeState.OK),
+        EdgeVerdict(ov_doctor.edge("cockpit"), EdgeState.OK),
     ])
     assert r.exit_code == 0 and r.first_broken is None
-    r.verdicts.append(EdgeVerdict("5 sensors", EdgeState.DEGRADED, "x"))
-    assert r.exit_code == 1 and r.first_broken.edge == "5 sensors"
-    r.verdicts.insert(1, EdgeVerdict("2 cockpit UDS", EdgeState.SEVERED, "y"))
+    r.verdicts.append(EdgeVerdict(ov_doctor.edge("sensors"), EdgeState.DEGRADED, "x"))
+    assert r.exit_code == 1 and r.first_broken.edge == ov_doctor.edge("sensors")
+    r.verdicts.insert(1, EdgeVerdict(ov_doctor.edge("cockpit"), EdgeState.SEVERED, "y"))
     assert r.exit_code == 2
-    assert r.first_broken.edge == "2 cockpit UDS"   # FIRST broken edge named
+    assert r.first_broken.edge == ov_doctor.edge("cockpit")   # FIRST broken edge named
 
 
 def test_absent_optional_surfaces_stay_green():
     """ABSENT (unconfigured MCP, no channel server) must not fail the chain."""
     r = DoctorReport(verdicts=[
-        EdgeVerdict("1 process", EdgeState.OK),
-        EdgeVerdict("8 mcp servers", EdgeState.ABSENT, "unset"),
+        EdgeVerdict(ov_doctor.edge("process"), EdgeState.OK),
+        EdgeVerdict(ov_doctor.edge("mcp"), EdgeState.ABSENT, "unset"),
     ])
     assert r.exit_code == 0
 
@@ -125,19 +125,19 @@ async def test_matrix_severed_socket_skips_uds_edges_probes_independents(
     monkeypatch,
 ):
     async def _proc():
-        return EdgeVerdict("1 process", EdgeState.SEVERED, "none")
+        return EdgeVerdict(ov_doctor.edge("process"), EdgeState.SEVERED, "none")
 
     async def _sock():
-        return EdgeVerdict("2 cockpit UDS", EdgeState.SEVERED, "absent"), "absent"
+        return EdgeVerdict(ov_doctor.edge("cockpit"), EdgeState.SEVERED, "absent"), "absent"
 
     async def _sensors():
-        return EdgeVerdict("5 sensors", EdgeState.ABSENT, "no server")
+        return EdgeVerdict(ov_doctor.edge("sensors"), EdgeState.ABSENT, "no server")
 
     async def _liveness():
-        return EdgeVerdict("7 liveness", EdgeState.ABSENT, "no server")
+        return EdgeVerdict(ov_doctor.edge("liveness"), EdgeState.ABSENT, "no server")
 
     async def _mcp():
-        return EdgeVerdict("8 mcp servers", EdgeState.ABSENT, "unset")
+        return EdgeVerdict(ov_doctor.edge("mcp"), EdgeState.ABSENT, "unset")
 
     monkeypatch.setattr(ov_doctor, "probe_edge_process", _proc)
     monkeypatch.setattr(ov_doctor, "probe_edge_socket", _sock)
@@ -145,13 +145,13 @@ async def test_matrix_severed_socket_skips_uds_edges_probes_independents(
     monkeypatch.setattr(ov_doctor, "probe_edge_liveness", _liveness)
     monkeypatch.setattr(ov_doctor, "probe_edge_mcp", _mcp)
     report = await ov_doctor.run_matrix()
-    assert len(report.verdicts) == 8
+    assert len(report.verdicts) == ov_doctor.edge_count()
     by_name = {v.edge: v for v in report.verdicts}
-    assert by_name["3 hydration"].state is EdgeState.SKIPPED
-    assert by_name["4 hive fabrics"].state is EdgeState.SKIPPED
-    assert by_name["6 providers"].state is EdgeState.SKIPPED
+    assert by_name[ov_doctor.edge("hydration")].state is EdgeState.SKIPPED
+    assert by_name[ov_doctor.edge("fabrics")].state is EdgeState.SKIPPED
+    assert by_name[ov_doctor.edge("providers")].state is EdgeState.SKIPPED
     assert report.exit_code == 2
-    assert report.first_broken.edge == "1 process"
+    assert report.first_broken.edge == ov_doctor.edge("process")
 
 
 @pytest.mark.asyncio
@@ -171,7 +171,7 @@ async def test_matrix_probes_independent_edges_concurrently(monkeypatch):
         return _p
 
     async def _sock():
-        return EdgeVerdict("2 cockpit UDS", EdgeState.OK, "served"), "live"
+        return EdgeVerdict(ov_doctor.edge("cockpit"), EdgeState.OK, "served"), "live"
 
     async def _hyd():
         active["n"] += 1
@@ -181,17 +181,17 @@ async def test_matrix_probes_independent_edges_concurrently(monkeypatch):
         return _payload()
 
     monkeypatch.setattr(ov_doctor, "probe_edge_process",
-                        _slow("1 process"))
+                        _slow(ov_doctor.edge("process")))
     monkeypatch.setattr(ov_doctor, "probe_edge_socket", _sock)
     monkeypatch.setattr(ov_doctor, "_read_hydration", _hyd)
-    monkeypatch.setattr(ov_doctor, "probe_edge_sensors", _slow("5 sensors"))
-    monkeypatch.setattr(ov_doctor, "probe_edge_liveness", _slow("7 liveness"))
-    monkeypatch.setattr(ov_doctor, "probe_edge_mcp", _slow("8 mcp servers"))
+    monkeypatch.setattr(ov_doctor, "probe_edge_sensors", _slow(ov_doctor.edge("sensors")))
+    monkeypatch.setattr(ov_doctor, "probe_edge_liveness", _slow(ov_doctor.edge("liveness")))
+    monkeypatch.setattr(ov_doctor, "probe_edge_mcp", _slow(ov_doctor.edge("mcp")))
 
     t0 = asyncio.get_running_loop().time()
     report = await ov_doctor.run_matrix()
     elapsed = asyncio.get_running_loop().time() - t0
-    assert len(report.verdicts) == 8
+    assert len(report.verdicts) == ov_doctor.edge_count()
     assert active["peak"] >= 3            # probes genuinely overlapped
     assert elapsed < DELAY * 4            # not sequential (4 slow probes)
 
@@ -271,7 +271,7 @@ def test_render_never_raises_on_minimal_console():
             pass
 
     ov_doctor.render_report(_C(), DoctorReport(verdicts=[
-        EdgeVerdict("1 process", EdgeState.OK, "pid 1")]))
+        EdgeVerdict(ov_doctor.edge("process"), EdgeState.OK, "pid 1")]))
 
 
 @pytest.mark.asyncio
@@ -311,8 +311,8 @@ def test_version_skew_synthesizer_names_the_remedy():
             lines.append(str(msg))
 
     ov_doctor.render_report(_C(), DoctorReport(verdicts=[
-        EdgeVerdict("1 process", EdgeState.OK, "pid 4765"),
-        EdgeVerdict("4 hive fabrics", EdgeState.DEGRADED,
+        EdgeVerdict(ov_doctor.edge("process"), EdgeState.OK, "pid 4765"),
+        EdgeVerdict(ov_doctor.edge("fabrics"), EdgeState.DEGRADED,
                     "no fabrics block (older daemon?)"),
         EdgeVerdict("9 live probe", EdgeState.SKIPPED,
                     "daemon predates /doctor probe"),

--- a/tests/cli/test_ov_doctor_edge_registry.py
+++ b/tests/cli/test_ov_doctor_edge_registry.py
@@ -1,0 +1,169 @@
+"""The edge set is declared once, and nothing may re-spell it.
+
+WHAT WENT WRONG
+---------------
+`probe_edge_compute` was added as edge 9. Five separate places went on
+describing an eight-edge matrix:
+
+  * the module docstring ("the 8-edge full-chain connectivity matrix",
+    enumerating 1-8);
+  * the hand-ordered list in `run_matrix` under a `# canonical edge order`
+    comment;
+  * two tests asserting `len(report.verdicts) == 8`, which failed on `main`
+    for days;
+  * ~38 `EdgeVerdict(...)` call sites, each repeating its own label string on
+    every return path;
+  * the test file itself, which spelled 25 more label literals.
+
+None of them was authoritative, so none of them could be updated. The same
+drift had already produced a genuine operator-visible collision: the
+`--live` probe was numbered 9 when 9 was free, `probe_edge_compute` later
+took 9 as well, and `run_doctor(live=True)` appends both to ONE report -- so
+`ov doctor --live` rendered two rows numbered 9.
+
+These tests pin the cure rather than the symptom: `EDGES` is the only place
+the edge set is written down, and a literal cannot come back.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+from backend.core.ouroboros.cli import ov_doctor
+
+
+class TestDeclaration:
+    def test_numbers_are_unique(self):
+        """The defect that shipped: two different edges both numbered 9."""
+        numbers = [e.number for e in ov_doctor.EDGES]
+        assert len(numbers) == len(set(numbers)), (
+            f"duplicate edge number in EDGES: {numbers}"
+        )
+
+    def test_keys_are_unique(self):
+        keys = [e.key for e in ov_doctor.EDGES]
+        assert len(keys) == len(set(keys))
+
+    def test_labels_are_unique(self):
+        labels = [e.label for e in ov_doctor.EDGES]
+        assert len(labels) == len(set(labels))
+
+    def test_numbering_is_dense_and_ordered(self):
+        """1..N with no gaps, in declaration order -- the operator reads these
+        as positions, and a gap or a jump is a missing edge or a stale one."""
+        assert [e.number for e in ov_doctor.EDGES] == list(
+            range(1, len(ov_doctor.EDGES) + 1)
+        )
+
+    def test_label_is_derived_never_stored(self):
+        for spec in ov_doctor.EDGES:
+            assert spec.label == f"{spec.number} {spec.name}"
+
+    def test_matrix_subset_excludes_opt_in_edges(self):
+        assert all(not e.optional for e in ov_doctor.MATRIX_EDGES)
+        assert ov_doctor.edge_count() == len(ov_doctor.MATRIX_EDGES)
+        assert ov_doctor.edge_count() < len(ov_doctor.EDGES), (
+            "the --live probe is opt-in; counting it would make every "
+            "base-matrix assertion wrong by one"
+        )
+
+
+class TestLookup:
+    def test_every_key_resolves(self):
+        for spec in ov_doctor.EDGES:
+            assert ov_doctor.edge(spec.key) == spec.label
+
+    def test_unknown_key_is_visible_not_fatal_and_not_invented(self):
+        """This module's contract is that no probe raises from a return path.
+
+        A fabricated-but-plausible label would be worse than an unrecognised
+        one: it would render as a real edge and match nothing."""
+        assert ov_doctor.edge("no-such-edge") == "? no-such-edge"
+        assert ov_doctor.edge(None) == "? None"  # type: ignore[arg-type]
+
+
+class TestOrdering:
+    def test_canonical_order_is_recovered_from_any_arrival_order(self):
+        V = ov_doctor.EdgeVerdict
+        S = ov_doctor.EdgeState
+        shuffled = [
+            V(ov_doctor.edge("compute"), S.OK),
+            V(ov_doctor.edge("process"), S.OK),
+            V(ov_doctor.edge("liveness"), S.OK),
+            V(ov_doctor.edge("cockpit"), S.OK),
+        ]
+        ordered = [v.edge for v in ov_doctor.order_verdicts(shuffled)]
+        assert ordered == [
+            ov_doctor.edge("process"), ov_doctor.edge("cockpit"),
+            ov_doctor.edge("liveness"), ov_doctor.edge("compute"),
+        ]
+
+    def test_unknown_edges_sort_last_but_are_never_dropped(self):
+        """A matrix that silently discarded a row would lie about what it
+        probed -- worse than showing one it cannot place."""
+        V = ov_doctor.EdgeVerdict
+        S = ov_doctor.EdgeState
+        out = ov_doctor.order_verdicts([
+            V("? mystery", S.DEGRADED),
+            V(ov_doctor.edge("process"), S.OK),
+        ])
+        assert [v.edge for v in out] == [ov_doctor.edge("process"), "? mystery"]
+
+    def test_ordering_never_raises_on_malformed_input(self):
+        assert ov_doctor.order_verdicts([object()])  # type: ignore[list-item]
+
+
+class TestNoSecondSourceOfTruth:
+    """The cage: a numbered edge label may not be written as a literal."""
+
+    @staticmethod
+    def _numbered_string_literals(path: Path):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        # The declaration itself legitimately spells the names; everything
+        # after it must go through `edge()`.
+        offenders = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant):
+                continue
+            val = node.value
+            if not isinstance(val, str) or len(val) < 3:
+                continue
+            head = val.split(" ", 1)[0]
+            if head.isdigit() and val[len(head):].startswith(" "):
+                offenders.append((node.lineno, val))
+        return offenders
+
+    def test_module_has_no_numbered_edge_literals_outside_the_registry(self):
+        path = Path(inspect.getfile(ov_doctor))
+        src = path.read_text(encoding="utf-8").splitlines()
+        # Registry block ends at the EdgeState enum; everything below it is
+        # code that must reference the declaration.
+        try:
+            cutoff = next(i for i, l in enumerate(src, 1)
+                          if l.startswith("class EdgeState("))
+        except StopIteration:  # pragma: no cover
+            cutoff = 0
+        offenders = [(ln, v) for ln, v in self._numbered_string_literals(path)
+                     if ln > cutoff]
+        assert not offenders, (
+            "numbered edge label spelled as a literal — use edge(<key>) so "
+            f"EDGES stays the only source: {offenders}"
+        )
+
+    def test_every_edge_key_used_in_the_module_is_declared(self):
+        """An undeclared key renders '? key' and matches nothing. The AST pin
+        is what keeps that from ever shipping."""
+        path = Path(inspect.getfile(ov_doctor))
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        used = set()
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "edge"
+                    and node.args
+                    and isinstance(node.args[0], ast.Constant)
+                    and isinstance(node.args[0].value, str)):
+                used.add(node.args[0].value)
+        declared = {e.key for e in ov_doctor.EDGES}
+        assert used <= declared, f"undeclared edge key(s): {used - declared}"


### PR DESCRIPTION
Closes the two `ov surface` failures (`assert 9 == 8`) that have been red on `main` since edge 9 shipped — and the reason they could not simply be updated.

## The count was the symptom

`probe_edge_compute` shipped as edge 9. Five places kept describing an eight-edge matrix, and none of them was authoritative:

| claimant | what it said |
|---|---|
| module docstring | "the **8-edge** full-chain connectivity matrix", enumerating 1–8 |
| `run_matrix` | hand-ordered list under `# canonical edge order: 3,4,5,6,7,8,9` |
| 2 tests | `len(report.verdicts) == 8` |
| 38 `EdgeVerdict(...)` sites | each re-spelling its own label on every return path |
| the test file | 25 more label literals |

Bumping the `8` to a `9` would have left all five, and the next edge would break it again the same way.

## It had already shipped a visible collision

The `--live` probe was numbered **9** when 9 was free. `probe_edge_compute` later took 9 as well. `run_doctor(live=True)` appends both verdicts to **one** report — so `ov doctor --live` rendered **two rows numbered 9**. Neither site could see the other, because nothing existed that saw both.

## The declaration

`EDGES` now holds number, key, label and the operator-facing prose, once.

- `label` is **derived** (`f"{number} {name}"`), never stored twice.
- **Ordering comes from declaration position** — a new edge lands correctly because of where it was declared, not where it was appended.
- The live probe is declared as **edge 10**, `optional=True`.
- `edge_count()` counts `MATRIX_EDGES`, so an opt-in probe can never make every base-matrix assertion wrong by one.
- The per-edge summaries moved from the docstring onto `EdgeSpec` — prose that restates a data structure is prose that will eventually contradict it, and this one already had.

**Totality, deliberately:** `edge()` renders `? <key>` for an unknown key rather than raising (no probe may raise from a return path) or inventing a plausible label (a fabricated edge is worse than an unrecognised one). `order_verdicts` sorts unknown labels last but **never drops them** — a matrix that silently discarded a row would lie about what it probed.

## The cage

Two AST pins: no numbered edge label may be spelled as a literal below the declaration, and no `edge(<key>)` may name a key `EDGES` does not declare. **Verified by injecting a literal and watching it trip**, then restoring.

Added to `ci/ov-surface-suites.txt` — a cage CI does not run is a cage nobody closes.

## Evidence

- `ov surface` CI set: **448 passed**, both `assert 9 == 8` failures gone.
- 13 new registry tests; `ov doctor` renders correctly against a real (severed) chain.

## Still red, and not mine

`test_thin_client.py::TestStaleSocketDeadlock::test_ghost_socket_cleaned_and_cold_boot_fired_no_hang` — fails identically on `main`. I diagnosed it rather than touch it: ghost detection, unlink and ignition **all work**; `ensure_daemon` reports `⚠ ignition failed` because the **post-spawn readiness probe never observes SERVING**. So it is the thin-client readiness contract, not the deadlock the test is named for. Separate fix, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes the `ov_doctor` edge set in a single registry and fixes duplicate numbering and stale “8-edge” assumptions. Old behavior: labels and counts were hardcoded in multiple places and `ov doctor --live` showed two rows numbered 9. New behavior: edges are declared once, labels are derived, ordering comes from the declaration, and the live probe is edge 10 (optional).

- `EDGES` + `EdgeSpec` declare number, key, and summary once; `label` is derived.
- `MATRIX_EDGES` and `edge_count()` define the base matrix size; optional edges do not change it.
- `edge(key)` returns the canonical label or “? <key>”; never raises. `order_verdicts()` sorts by the declaration; unknown edges sort last and are never dropped.
- `run_matrix()` now orders via `order_verdicts()`. The live probe is declared as edge 10 (`optional=True`).
- AST “cage” tests prevent numbered label literals and undeclared keys; added to the surface CI suite.

**Migration**
- Do not hardcode edge labels or counts. Use `ov_doctor.edge("<key>")` and `ov_doctor.edge_count()`.
- If you asserted the live probe was edge 9, update expectations to edge 10.

<sup>Written for commit 5b2f96b578f3cfc1a450150d4664f20058358867. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

