### PR TITLE
fix: The loop closed its generators without cancelling what was running them

### DIFF
--- a/backend/core/ouroboros/battle_test/loop_teardown.py
+++ b/backend/core/ouroboros/battle_test/loop_teardown.py
@@ -1,0 +1,255 @@
+"""The cancellation phase this loop's teardown was missing.
+
+WHAT WENT WRONG
+---------------
+Session ``bt-2026-08-18-021438``, at ``post_asyncio_teardown``, immediately
+after "Shutdown complete"::
+
+    [PANIC] RuntimeError: an error occurred during closing of asynchronous
+            generator <async_generator object StreamEventBroker.stream_iter>
+    RuntimeError: aclose(): asynchronous generator is already running
+    ... ExecutionGraphProgressTracker._drain_subscriber ... same
+    [PANIC] UnknownError: Task was destroyed but it is pending!
+
+Three symptoms, one cause. ``scripts/ouroboros_battle_test.py`` owns its loop
+by hand and tears it down as::
+
+    loop.run_until_complete(harness.run())
+    finally:
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.run_until_complete(loop.shutdown_default_executor())
+        loop.close()
+
+:func:`asyncio.run` performs FOUR steps in that position, and this performs
+the last three. The missing first one is *cancel every remaining task and let
+it finish*. Without it, any task the harness did not explicitly own is still
+alive and still parked inside an async generator when ``shutdown_asyncgens()``
+calls ``aclose()`` on it -- which is exactly what "aclose(): asynchronous
+generator is already running" means. The generators are not at fault: both
+handle ``CancelledError`` and unsubscribe in ``finally``. Nobody cancelled
+them. "Task was destroyed but it is pending" two seconds later is the same
+un-cancelled task meeting ``loop.close()``.
+
+WHY NOT AsyncExitStack
+----------------------
+An exit stack manages resources a single owner holds. Seven-plus modules
+consume ``stream_iter`` from independently-spawned tasks; there is no single
+owner to hold a stack, and adding one per consumer would be seven partial
+fixes for a defect that lives in one place. The lifecycle phase is the defect,
+so the lifecycle phase is the fix -- and it covers every future consumer
+without any of them knowing this module exists.
+
+WHY NOT asyncio.runners._cancel_all_tasks
+-----------------------------------------
+It is the right algorithm and the wrong contract: it ``gather``s the cancelled
+tasks with no timeout, so a single task that swallows ``CancelledError`` hangs
+teardown forever. This process already learned that lesson -- the
+``BoundedShutdownWatchdog`` armed one frame earlier exists because a previous
+session sat 1h50m in executor shutdown. Everything on this path must be
+bounded, so the cancellation phase is bounded too, and reports by name whatever
+outlived its deadline instead of pretending it finished.
+
+DISCIPLINE
+----------
+* **Bounded** -- deadline from the environment, never a literal.
+* **Adaptive sweeps** -- a cancelled task's ``finally`` may legitimately spawn
+  cleanup work, so the sweep repeats until the task set is empty or the budget
+  is spent. One pass would leave exactly the tasks that clean up after
+  themselves.
+* **No silent caps** -- survivors are named in the report. A teardown that
+  quietly gave up would be the "receipt for work it did not do" pattern this
+  codebase spends its time removing.
+* **Never raises.** It runs inside a ``finally`` that is the last thing
+  standing between a session and its artifacts.
+* **Not a watchdog.** It reads no application state-ledger and makes no
+  liveness judgement; it cancels, waits a bounded time, and reports. The
+  Slice-47 Watchdog Isolation Invariant is untouched -- the real watchdog is
+  armed independently, one frame above, and neither consults the other.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Set
+
+logger = logging.getLogger("Ouroboros.LoopTeardown")
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+ENABLED_ENV = "JARVIS_TEARDOWN_CANCEL_ENABLED"
+DEADLINE_ENV = "JARVIS_TEARDOWN_CANCEL_DEADLINE_S"
+MAX_SWEEPS_ENV = "JARVIS_TEARDOWN_CANCEL_MAX_SWEEPS"
+
+
+def cancel_phase_enabled() -> bool:
+    """Master gate. Default ON; OFF restores the exact prior teardown."""
+    return os.environ.get(ENABLED_ENV, "1").strip().lower() in _TRUTHY
+
+
+def cancel_deadline_s() -> float:
+    """Total budget for the whole cancellation phase.
+
+    Default 5s. Sized well inside ``JARVIS_BATTLE_SHUTDOWN_DEADLINE_S`` (30s),
+    because this phase runs INSIDE that watchdog's window and must leave room
+    for ``shutdown_asyncgens`` + ``shutdown_default_executor`` behind it. A
+    cooperative task answers cancellation in milliseconds; anything still
+    running at five seconds is not going to finish, and waiting longer only
+    spends the budget the steps after this one need."""
+    try:
+        return max(0.0, float(os.environ.get(DEADLINE_ENV, "5.0")))
+    except (TypeError, ValueError):
+        return 5.0
+
+
+def max_sweeps() -> int:
+    """How many times to re-scan for tasks spawned during cancellation.
+
+    Default 3. Bounded because a task that spawns a replacement from its own
+    ``finally`` on every cancellation would otherwise loop forever -- and that
+    is a defect to REPORT, not to chase."""
+    try:
+        return max(1, int(os.environ.get(MAX_SWEEPS_ENV, "3")))
+    except (TypeError, ValueError):
+        return 3
+
+
+@dataclass
+class TeardownReport:
+    """What the cancellation phase actually achieved. Honest by construction."""
+
+    cancelled: int = 0
+    finished: int = 0
+    sweeps: int = 0
+    #: Tasks still running when the budget ran out. NAMED, because a teardown
+    #: that hid them would report success for work it abandoned.
+    survivors: List[str] = field(default_factory=list)
+    #: Non-cancellation exceptions raised by tasks as they wound down.
+    errors: List[str] = field(default_factory=list)
+    skipped: bool = False
+
+    @property
+    def clean(self) -> bool:
+        return not self.survivors and not self.errors
+
+    def render(self) -> str:
+        if self.skipped:
+            return "[LoopTeardown] cancellation phase disabled"
+        if self.cancelled == 0:
+            return "[LoopTeardown] no outstanding tasks"
+        head = (
+            f"[LoopTeardown] cancelled={self.cancelled} finished={self.finished} "
+            f"sweeps={self.sweeps}"
+        )
+        if self.survivors:
+            head += f" SURVIVED={len(self.survivors)} {self.survivors[:8]}"
+        if self.errors:
+            head += f" errors={len(self.errors)} {self.errors[:4]}"
+        return head
+
+
+def _describe(task: "asyncio.Task") -> str:
+    """A name a human can act on. NEVER raises."""
+    try:
+        name = task.get_name()
+    except Exception:  # noqa: BLE001
+        name = "<task>"
+    try:
+        coro = task.get_coro()
+        qual = getattr(coro, "__qualname__", None) or getattr(
+            getattr(coro, "cr_code", None), "co_name", "",
+        )
+    except Exception:  # noqa: BLE001
+        qual = ""
+    return f"{name}:{qual}" if qual else str(name)
+
+
+def _live_tasks(
+    loop: "Optional[asyncio.AbstractEventLoop]",
+    exclude: "Set[Any]",
+) -> "List[asyncio.Task]":
+    """Every unfinished task except this one and any explicitly excluded."""
+    try:
+        current = asyncio.current_task()
+    except Exception:  # noqa: BLE001
+        current = None
+    try:
+        tasks = asyncio.all_tasks(loop) if loop is not None else asyncio.all_tasks()
+    except Exception:  # noqa: BLE001
+        return []
+    out = []
+    for t in tasks:
+        try:
+            if t is current or t in exclude or t.done():
+                continue
+        except Exception:  # noqa: BLE001
+            continue
+        out.append(t)
+    return out
+
+
+async def cancel_remaining_tasks(
+    *,
+    deadline_s: Optional[float] = None,
+    exclude: "Optional[Set[Any]]" = None,
+) -> TeardownReport:
+    """Cancel every outstanding task and wait, bounded, for it to finish.
+
+    THE phase that must run before ``loop.shutdown_asyncgens()``. Returns a
+    report rather than raising: this executes inside the teardown ``finally``,
+    where an exception would cost the session its artifacts.
+    """
+    report = TeardownReport()
+    if not cancel_phase_enabled():
+        report.skipped = True
+        return report
+
+    budget = cancel_deadline_s() if deadline_s is None else max(0.0, deadline_s)
+    excluded: "Set[Any]" = set(exclude or ())
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:  # pragma: no cover — called off-loop
+        return report
+
+    try:
+        deadline = loop.time() + budget
+        for _ in range(max_sweeps()):
+            pending = _live_tasks(loop, excluded)
+            if not pending:
+                break
+            report.sweeps += 1
+            for task in pending:
+                try:
+                    task.cancel()
+                    report.cancelled += 1
+                except Exception:  # noqa: BLE001
+                    continue
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                break
+            done, still = await asyncio.wait(pending, timeout=remaining)
+            report.finished += len(done)
+            # Surface non-cancellation failures. A task that died of a real
+            # error while winding down is a defect, and swallowing it here
+            # would make the teardown the place bugs go to disappear.
+            for task in done:
+                try:
+                    if task.cancelled():
+                        continue
+                    exc = task.exception()
+                    if exc is not None:
+                        report.errors.append(f"{_describe(task)}: {exc!r}")
+                except Exception:  # noqa: BLE001
+                    continue
+            if still:
+                # Out of budget with tasks still running: stop sweeping and
+                # let the report name them.
+                break
+
+        # Whatever is left after the sweeps is a survivor, named.
+        for task in _live_tasks(loop, excluded):
+            report.survivors.append(_describe(task))
+    except Exception:  # noqa: BLE001 — teardown must never raise
+        logger.debug("[LoopTeardown] cancellation phase degraded", exc_info=True)
+    return report

--- a/scripts/ouroboros_battle_test.py
+++ b/scripts/ouroboros_battle_test.py
@@ -2182,6 +2182,32 @@ def main(argv: "list[str] | None" = None) -> None:
         # closed" during otherwise-clean session exit. See
         # memory/project_async_shutdown_race_triage.md for the full
         # traceback + root cause analysis.
+        # THE MISSING PHASE. `asyncio.run` does four things here and this
+        # block did the last three; the first — cancel every remaining task
+        # and let it finish — was absent. Without it any task the harness did
+        # not explicitly own is still parked inside an async generator when
+        # `shutdown_asyncgens()` calls `aclose()` on it, which is precisely
+        # `RuntimeError: aclose(): asynchronous generator is already running`
+        # (bt-2026-08-18-021438, on StreamEventBroker.stream_iter and
+        # ExecutionGraphProgressTracker._drain_subscriber), and precisely the
+        # "Task was destroyed but it is pending!" panic two seconds later.
+        #
+        # Bounded, unlike the stdlib's unbounded gather: a task that swallows
+        # CancelledError must not hang teardown, and survivors are NAMED
+        # rather than silently abandoned.
+        try:
+            from backend.core.ouroboros.battle_test.loop_teardown import (  # noqa: E501
+                cancel_remaining_tasks as _cancel_remaining_tasks,
+            )
+            _td_report = loop.run_until_complete(_cancel_remaining_tasks())
+            if not _td_report.skipped and _td_report.cancelled:
+                _log = logging.getLogger("Ouroboros.LoopTeardown")
+                (_log.warning if not _td_report.clean else _log.info)(
+                    "%s", _td_report.render(),
+                )
+        except Exception:  # noqa: BLE001 — teardown must never raise
+            pass
+
         try:
             loop.run_until_complete(loop.shutdown_asyncgens())
         except Exception:

--- a/tests/battle_test/test_loop_teardown.py
+++ b/tests/battle_test/test_loop_teardown.py
@@ -1,0 +1,267 @@
+"""Teardown cancels what it is about to close.
+
+`bt-2026-08-18-021438`, at `post_asyncio_teardown`, produced three symptoms
+with one cause::
+
+    RuntimeError: aclose(): asynchronous generator is already running
+        <async_generator object StreamEventBroker.stream_iter>
+        <async_generator object ExecutionGraphProgressTracker._drain_subscriber>
+    UnknownError: Task was destroyed but it is pending!
+
+`asyncio.run` does four things when it tears a loop down; the harness script
+owns its loop by hand and did the last three, skipping *cancel every remaining
+task and let it finish*. So tasks were still parked inside those generators
+when `shutdown_asyncgens()` called `aclose()` on them. The generators were
+never at fault -- both handle `CancelledError` and unsubscribe in `finally`.
+
+The first test here is the production defect itself, driven through the REAL
+broker: it fails without the phase and passes with it.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+
+import pytest
+
+from backend.core.ouroboros.battle_test import loop_teardown as lt
+
+
+# ---------------------------------------------------------------------------
+# The production defect
+# ---------------------------------------------------------------------------
+
+
+def _drive(with_phase: bool) -> int:
+    """Park a consumer inside the real `stream_iter`, tear down, count aclose
+    failures. Runs on its OWN loop because it is the loop teardown under test."""
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        get_default_broker,
+    )
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    seen = []
+    loop.set_exception_handler(
+        lambda l, ctx: seen.append(str(ctx.get("message", "")))
+    )
+    try:
+        broker = get_default_broker()
+        sub = broker.subscribe()
+
+        async def consume():
+            async for _ in broker.stream_iter(sub, heartbeat_s=0):
+                pass
+
+        async def start():
+            asyncio.ensure_future(consume())
+            await asyncio.sleep(0.05)      # park it on queue.get()
+
+        loop.run_until_complete(start())
+        if with_phase:
+            loop.run_until_complete(lt.cancel_remaining_tasks())
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            try:
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            except Exception as exc:  # noqa: BLE001
+                seen.append(repr(exc))
+            seen.extend(buf.getvalue().splitlines())
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+    return len([s for s in seen
+                if "aclose" in s or "asynchronous generator" in s])
+
+
+def test_the_defect_reproduces_without_the_phase():
+    """Guards the guard: if this stops failing, the test below proves nothing."""
+    assert _drive(with_phase=False) >= 1
+
+
+def test_the_phase_closes_the_generator_cleanly():
+    assert _drive(with_phase=True) == 0
+
+
+# ---------------------------------------------------------------------------
+# Behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_tasks_is_a_clean_no_op():
+    report = await lt.cancel_remaining_tasks()
+    assert report.cancelled == 0
+    assert report.clean
+    assert "no outstanding tasks" in report.render()
+
+
+@pytest.mark.asyncio
+async def test_never_cancels_the_calling_task():
+    """The phase runs INSIDE a task; cancelling itself would abort teardown."""
+    report = await lt.cancel_remaining_tasks()
+    assert not asyncio.current_task().cancelled()
+    assert report.clean
+
+
+@pytest.mark.asyncio
+async def test_a_parked_task_is_cancelled_and_awaited():
+    async def parked():
+        await asyncio.Event().wait()      # never resolves on its own
+
+    t = asyncio.ensure_future(parked())
+    await asyncio.sleep(0)
+    report = await lt.cancel_remaining_tasks()
+    assert report.cancelled >= 1
+    assert report.finished >= 1
+    assert t.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_a_task_that_swallows_cancellation_is_named_not_awaited_forever():
+    """The reason this is bounded and the stdlib's version is not.
+
+    `asyncio.runners._cancel_all_tasks` gathers with no timeout, so one task
+    like this hangs teardown forever -- and this process already paid for that
+    once with a 1h50m executor wedge."""
+    started = asyncio.Event()
+    # Stubborn, but RELEASABLE. The first draft ignored cancellation
+    # unconditionally, which made it genuinely immortal -- it survived into the
+    # next test's loop and hung the suite. A test that models "ignores
+    # cancellation" must still be killable by the test that made it, or the
+    # suite inherits the exact pathology it is describing.
+    release = asyncio.Event()
+
+    async def stubborn():
+        started.set()
+        while not release.is_set():
+            try:
+                await asyncio.sleep(0.01)
+            except asyncio.CancelledError:
+                continue                   # deliberately ignores it
+
+    t = asyncio.ensure_future(stubborn())
+    await started.wait()
+    report = await lt.cancel_remaining_tasks(deadline_s=0.15)
+    assert report.survivors, "a task that outlived the budget must be NAMED"
+    assert any("stubborn" in s for s in report.survivors)
+    assert "SURVIVED" in report.render()
+    assert not report.clean
+
+    release.set()
+    with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+        await asyncio.wait_for(t, timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_spawned_during_cancellation_is_also_cancelled():
+    """A cancelled task's `finally` may legitimately spawn cleanup work.
+
+    One pass would leave exactly the tasks that clean up after themselves --
+    which is why the sweep repeats."""
+    spawned = {}
+
+    async def child():
+        await asyncio.Event().wait()
+
+    async def parent():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            spawned["t"] = asyncio.ensure_future(child())
+
+    asyncio.ensure_future(parent())
+    await asyncio.sleep(0)
+    report = await lt.cancel_remaining_tasks()
+    await asyncio.sleep(0)
+    assert report.sweeps >= 2, "the second sweep is what catches the child"
+    assert spawned["t"].cancelled() or spawned["t"].done()
+    assert report.clean
+
+
+@pytest.mark.asyncio
+async def test_a_real_error_during_wind_down_is_surfaced_not_swallowed():
+    """Teardown must not be the place bugs go to disappear."""
+    # The error must happen DURING wind-down, not before it. A task that
+    # merely raises soon is cancelled at its next suspension point and never
+    # reaches the raise -- so the failure this guards is a `finally` that
+    # blows up while unwinding, which replaces the CancelledError and is
+    # exactly the case a teardown could quietly eat.
+    async def boom():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            raise ValueError("wind-down failure")
+
+    asyncio.ensure_future(boom())
+    await asyncio.sleep(0)
+    report = await lt.cancel_remaining_tasks()
+    assert any("wind-down failure" in e for e in report.errors)
+    assert not report.clean
+
+
+@pytest.mark.asyncio
+async def test_master_flag_off_is_byte_identical_legacy(monkeypatch):
+    monkeypatch.setenv(lt.ENABLED_ENV, "0")
+    async def parked():
+        await asyncio.Event().wait()
+    t = asyncio.ensure_future(parked())
+    await asyncio.sleep(0)
+    report = await lt.cancel_remaining_tasks()
+    assert report.skipped
+    assert report.cancelled == 0
+    assert not t.cancelled(), "OFF must not cancel anything"
+    t.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await t
+
+
+@pytest.mark.asyncio
+async def test_excluded_tasks_are_left_running():
+    async def keeper():
+        await asyncio.Event().wait()
+    t = asyncio.ensure_future(keeper())
+    await asyncio.sleep(0)
+    report = await lt.cancel_remaining_tasks(exclude={t})
+    assert not t.cancelled()
+    assert report.cancelled == 0
+    t.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await t
+
+
+class TestConfiguration:
+    def test_knobs_read_the_environment(self, monkeypatch):
+        monkeypatch.setenv(lt.DEADLINE_ENV, "12.5")
+        monkeypatch.setenv(lt.MAX_SWEEPS_ENV, "7")
+        assert lt.cancel_deadline_s() == 12.5
+        assert lt.max_sweeps() == 7
+
+    def test_malformed_knobs_fall_back_rather_than_raising(self, monkeypatch):
+        monkeypatch.setenv(lt.DEADLINE_ENV, "banana")
+        monkeypatch.setenv(lt.MAX_SWEEPS_ENV, "none")
+        assert lt.cancel_deadline_s() == 5.0
+        assert lt.max_sweeps() == 3
+
+    def test_sweeps_can_never_be_zero(self, monkeypatch):
+        """Zero sweeps would silently disable the phase while it reported
+        itself enabled."""
+        monkeypatch.setenv(lt.MAX_SWEEPS_ENV, "0")
+        assert lt.max_sweeps() >= 1
+
+    def test_negative_deadline_is_clamped(self, monkeypatch):
+        monkeypatch.setenv(lt.DEADLINE_ENV, "-3")
+        assert lt.cancel_deadline_s() == 0.0
+
+
+@pytest.mark.asyncio
+async def test_never_raises_on_a_hostile_task_object(monkeypatch):
+    class _Hostile:
+        def done(self): raise RuntimeError("boom")
+        def cancel(self): raise RuntimeError("boom")
+        def get_name(self): raise RuntimeError("boom")
+
+    monkeypatch.setattr(lt.asyncio, "all_tasks", lambda *a, **k: {_Hostile()})
+    report = await lt.cancel_remaining_tasks()
+    assert isinstance(report, lt.TeardownReport)


### PR DESCRIPTION
Traces the `aclose()` owners from `bt-2026-08-18-021438` to a single missing lifecycle phase.

## Three symptoms, one cause

At `post_asyncio_teardown`, immediately after "Shutdown complete":

```
RuntimeError: aclose(): asynchronous generator is already running
    <async_generator object StreamEventBroker.stream_iter>
    <async_generator object ExecutionGraphProgressTracker._drain_subscriber>
UnknownError: Task was destroyed but it is pending!
```

`asyncio.run` does **four** things when it tears a loop down. `scripts/ouroboros_battle_test.py` owns its loop by hand and did the last three:

```python
loop.run_until_complete(harness.run())
finally:
    loop.run_until_complete(loop.shutdown_asyncgens())
    loop.run_until_complete(loop.shutdown_default_executor())
    loop.close()
```

The missing first step is **cancel every remaining task and let it finish**. Without it, any task the harness didn't explicitly own is still parked inside an async generator when `shutdown_asyncgens()` calls `aclose()` on it — which is precisely what that error means. "Task was destroyed but it is pending" two seconds later is the same un-cancelled task meeting `loop.close()`.

**The generators were never at fault.** Both handle `CancelledError` and unsubscribe in `finally`. Nobody cancelled them.

## Why not the two obvious tools

**Not `AsyncExitStack`.** A stack manages resources a *single owner* holds. Seven-plus modules consume `stream_iter` from independently-spawned tasks — there is no owner to hold one, and adding one per consumer would be seven partial fixes for a defect that lives in one place. The lifecycle phase is the defect, so it's the fix, and every future consumer is covered without knowing this module exists.

**Not `asyncio.runners._cancel_all_tasks`.** Right algorithm, wrong contract: it gathers with **no timeout**, so one task that swallows `CancelledError` hangs teardown forever. This process already paid for that with a 1h50m executor wedge — which is why a `BoundedShutdownWatchdog` is armed one frame above. So the phase is bounded, and **names** whatever outlived its budget rather than quietly abandoning it (`SURVIVED=1 ['Task-7:stubborn']`).

Adaptive sweeps, because a cancelled task's `finally` may legitimately spawn cleanup work — one pass would leave exactly the tasks that clean up after themselves.

Not a watchdog: it reads no application state-ledger and makes no liveness judgement. The Slice-47 isolation invariant is untouched.

## Evidence

Reproduced against the **real** `StreamEventBroker` and the **real** `ExecutionGraphProgressTracker`:

| generator | without phase | with phase |
|---|---|---|
| `StreamEventBroker.stream_iter` | 1 aclose failure | **0** |
| `ExecutionGraphProgressTracker._drain_subscriber` | 1 aclose failure | **0** |

The first test in the suite asserts **the defect still reproduces** — so if the shape ever changes, the passing test can't silently stop proving anything.

15 new tests, 130 passed across adjacent suites. Teardown order verified: cancel (2202) → asyncgens (2212) → executor (2216) → close (2219).

## Found while tracing, not fixed here

`ExecutionGraphProgressTracker._drain_subscriber` is `while True: await queue.get()` and its docstring says it "terminates when `close()` is called or the tracker is garbage-collected". **Neither mechanism exists** — `unsubscribe_all()` clears a list without waking the parked `get()`, so a consumer can only ever leave by cancellation. Harmless now that cancellation actually happens, but the docstring states a contract the code doesn't implement. Separate fix.

The 33 unclosed `aiohttp` sessions from the same session are also still open — different owner, different trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded “cancel remaining tasks” phase to the battle-test event loop teardown so we match asyncio.run semantics and stop hitting aclose errors and “Task was destroyed but it is pending!”. Previously we skipped straight to `loop.shutdown_asyncgens()`/executor shutdown/close; now we first cancel outstanding tasks, wait within a budget, and report survivors.

- Runs before `shutdown_asyncgens`: `cancel → shutdown_asyncgens → shutdown_default_executor → close`. Implemented in `backend/core/ouroboros/battle_test/loop_teardown.py` and invoked from `scripts/ouroboros_battle_test.py`.
- Bounded and adaptive: total deadline is `JARVIS_TEARDOWN_CANCEL_DEADLINE_S` (default 5s), sweeps up to `JARVIS_TEARDOWN_CANCEL_MAX_SWEEPS` (default 3), master switch `JARVIS_TEARDOWN_CANCEL_ENABLED` (default ON). Never raises; logs via `Ouroboros.LoopTeardown`, naming any survivors and surfacing non-cancellation wind-down errors.
- Why not stdlib `_cancel_all_tasks`: it gathers without a timeout; this implementation avoids teardown hangs and makes survivors observable.
- Tests: new suite reproduces the failure without the phase and verifies zero generator `aclose()` failures with the phase; also covers no-op behavior, exclusion, hostile tasks, and error reporting.

<sup>Written for commit 38d3d8c84ea68b4709a4f1e5c2524840f6e19bf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

