### PR TITLE
fix: The RT lane built a provider per call and let the GC find it

### DIFF
--- a/backend/core/ouroboros/governance/cognition_lanes.py
+++ b/backend/core/ouroboros/governance/cognition_lanes.py
@@ -135,6 +135,11 @@ async def rt_prompt(
         if call_stats is not None:
             call_stats[key] = call_stats.get(key, 0) + delta
 
+    #: Providers THIS call constructed, and therefore owns. An injected
+    #: provider belongs to its caller and is never touched here -- closing
+    #: someone else's pooled session would turn a leak into an outage.
+    _owned: List[Any] = []
+
     async def _resolve() -> Tuple[Any, str]:
         nonlocal dw_provider
         if session is not None and base_url is not None:
@@ -143,9 +148,41 @@ async def rt_prompt(
             from backend.core.ouroboros.governance.doubleword_provider import (
                 DoublewordProvider,
             )
+            # WHOEVER CREATES IT, CLOSES IT.
+            #
+            # This line built a provider on every un-injected call and let it
+            # fall out of scope with `rt_prompt`. The provider lazily opens an
+            # aiohttp.ClientSession inside `_get_session()`, so each call left
+            # one behind for the garbage collector: bt-2026-08-18-021438 logged
+            # 20 "Unclosed client session" + 15 "Unclosed connector" warnings,
+            # every cluster landing against `[CognitionLanes] RT degraded (rt
+            # status 402 ...)` -- one leak per RT attempt.
+            #
+            # The provider is not at fault: it owns `close()` and closes its
+            # session correctly. Nothing called it, because nothing had
+            # decided who owned the object.
             dw_provider = DoublewordProvider()
+            _owned.append(dw_provider)
         return (session or await dw_provider._get_session(),
                 base_url or dw_provider._base_url)
+
+    async def _release_owned() -> None:
+        """Close providers this call created. NEVER raises, never blocks exit.
+
+        Runs in a ``finally`` that may execute while the task is being
+        cancelled or the loop is closing, where an await can itself raise --
+        so every close is individually guarded and a failure to release is
+        logged, never propagated. Losing a session at that point is a leak;
+        raising here would lose the caller's result or their cancellation."""
+        while _owned:
+            provider = _owned.pop()
+            try:
+                await provider.close()
+            except Exception:  # noqa: BLE001 — teardown must not surface here
+                logger.debug(
+                    "[CognitionLanes] owned provider close degraded",
+                    exc_info=True,
+                )
 
     async def _headers() -> Dict[str, str]:
         if auth_headers_fn is not None:
@@ -221,36 +258,47 @@ async def rt_prompt(
             raise RTPromptTimeout(
                 f"rt cognition call exceeded {bound:.0f}s (stream evicted)")
 
-    sem = _rt_semaphore()
-    async with sem:                       # the Cognitive Concurrency Semaphore
-        stats["inflight"] += 1
-        stats["peak_inflight"] = max(stats["peak_inflight"],
-                                     stats["inflight"])
-        try:
+    # The release wraps EVERY exit: the successful return inside the
+    # semaphore, the Claude cascade below it, and any exception or
+    # cancellation through either. The RT path fails far more often than it
+    # succeeds when a provider is down — which is precisely the run that
+    # leaked twenty sessions — so a release reachable only on the happy path
+    # would be a release that never runs when it matters.
+    try:
+        sem = _rt_semaphore()
+        async with sem:                   # the Cognitive Concurrency Semaphore
+            stats["inflight"] += 1
+            stats["peak_inflight"] = max(stats["peak_inflight"],
+                                         stats["inflight"])
             try:
-                return await _rt_attempt()
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:  # noqa: BLE001 — timeout OR transport
-                logger.info("[CognitionLanes] RT degraded (%s: %s) — "
-                            "cascading to Claude (caller=%s)",
-                            type(exc).__name__, str(exc)[:120], caller_id)
-        finally:
-            stats["inflight"] -= 1
+                try:
+                    return await _rt_attempt()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:  # noqa: BLE001 — timeout OR transport
+                    logger.info("[CognitionLanes] RT degraded (%s: %s) — "
+                                "cascading to Claude (caller=%s)",
+                                type(exc).__name__, str(exc)[:120], caller_id)
+            finally:
+                stats["inflight"] -= 1
 
-    # Claude cascade OUTSIDE the semaphore — a fallback turn must not hold
-    # an RT slot hostage while it waits on a different provider.
-    _bump("fallback_calls")
-    nonlocal_claude = claude
-    if nonlocal_claude is None:
-        from backend.core.ouroboros.governance.providers import ClaudeProvider
-        nonlocal_claude = ClaudeProvider(
-            api_key=os.getenv("ANTHROPIC_API_KEY", ""))
-    text = await nonlocal_claude.prompt_only(
-        prompt, caller_id=caller_id, max_tokens=max_tokens,
-        timeout_s=_env_float("JARVIS_COGNITION_FALLBACK_TIMEOUT_S", 60.0))
-    _bump("fallback_ok")
-    return text
+        # Claude cascade OUTSIDE the semaphore — a fallback turn must not hold
+        # an RT slot hostage while it waits on a different provider.
+        _bump("fallback_calls")
+        nonlocal_claude = claude
+        if nonlocal_claude is None:
+            from backend.core.ouroboros.governance.providers import (
+                ClaudeProvider,
+            )
+            nonlocal_claude = ClaudeProvider(
+                api_key=os.getenv("ANTHROPIC_API_KEY", ""))
+        text = await nonlocal_claude.prompt_only(
+            prompt, caller_id=caller_id, max_tokens=max_tokens,
+            timeout_s=_env_float("JARVIS_COGNITION_FALLBACK_TIMEOUT_S", 60.0))
+        _bump("fallback_ok")
+        return text
+    finally:
+        await _release_owned()
 
 
 __all__ = ["SLA_STRICT", "SLA_BULK", "RTPromptTimeout", "rt_prompt", "stats"]

--- a/tests/governance/test_cognition_lanes_session_ownership.py
+++ b/tests/governance/test_cognition_lanes_session_ownership.py
@@ -1,0 +1,175 @@
+"""Whoever creates the provider closes it.
+
+`bt-2026-08-18-021438` logged 20 "Unclosed client session" + 15 "Unclosed
+connector" warnings. Every cluster landed against `[CognitionLanes] RT
+degraded (rt status 402 ...)` -- one leak per RT attempt.
+
+`rt_prompt._resolve()` constructed a `DoublewordProvider` whenever none was
+injected, and the provider lazily opens an `aiohttp.ClientSession` inside
+`_get_session()`. The provider was bound to `rt_prompt`'s own scope, so both
+it and its session fell to the garbage collector when the call returned. The
+provider was never at fault: it owns `close()` and closes its session
+correctly. Nothing called it, because nothing had decided who owned it.
+
+Measured against the real code, three un-injected calls: **3 unclosed
+sessions before, 0 after**.
+
+The second test is the one that matters most for safety. An INJECTED provider
+belongs to its caller, is usually pooled, and is shared across calls --
+closing it here would convert a leak into an outage for everyone else holding
+it.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance import cognition_lanes as cl
+
+
+class _FakeClaude:
+    """The cascade target, so no test ever needs a network or a key."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def prompt_only(self, *a, **k) -> str:
+        self.calls += 1
+        return "fallback"
+
+
+class _FakeProvider:
+    """Stands in for DoublewordProvider: records whether it was closed."""
+
+    def __init__(self, *a, **k) -> None:
+        self.closed = 0
+        self._base_url = "http://provider.invalid"
+
+    async def _get_session(self):
+        raise RuntimeError("rt status 402: Account balance too low")
+
+    async def close(self) -> None:
+        self.closed += 1
+
+
+@pytest.fixture
+def constructed(monkeypatch):
+    """Intercept the provider class rt_prompt imports, recording instances."""
+    made = []
+    from backend.core.ouroboros.governance import doubleword_provider as dwp
+
+    def _factory(*a, **k):
+        p = _FakeProvider()
+        made.append(p)
+        return p
+
+    monkeypatch.setattr(dwp, "DoublewordProvider", _factory)
+    return made
+
+
+@pytest.mark.asyncio
+async def test_a_provider_this_call_created_is_closed(constructed):
+    claude = _FakeClaude()
+    out = await cl.rt_prompt("hi", model="m", caller_id="t",
+                             timeout_s=0.2, claude=claude)
+    assert out == "fallback"
+    assert len(constructed) == 1, "the un-injected path must construct one"
+    assert constructed[0].closed == 1, (
+        "the provider this call created was left for the garbage collector — "
+        "the exact shape of the 20 leaked sessions"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_injected_provider_is_never_closed():
+    """Closing someone else's pooled session turns a leak into an outage."""
+    injected = _FakeProvider()
+    claude = _FakeClaude()
+    await cl.rt_prompt("hi", model="m", caller_id="t", timeout_s=0.2,
+                       dw_provider=injected, claude=claude)
+    assert injected.closed == 0
+
+
+@pytest.mark.asyncio
+async def test_an_injected_session_constructs_no_provider_at_all(constructed):
+    """`session` + `base_url` short-circuits `_resolve` before construction."""
+    class _Sess:
+        def post(self, *a, **k):
+            raise RuntimeError("rt status 402: Account balance too low")
+
+    await cl.rt_prompt("hi", model="m", caller_id="t", timeout_s=0.2,
+                       session=_Sess(), base_url="http://x.invalid",
+                       claude=_FakeClaude())
+    assert constructed == []
+
+
+@pytest.mark.asyncio
+async def test_release_runs_on_the_cascade_path(constructed):
+    """The RT path fails far more often than it succeeds when a provider is
+    down — which is precisely the run that leaked. A release reachable only
+    on the happy path would never run when it matters."""
+    await cl.rt_prompt("hi", model="m", caller_id="t", timeout_s=0.2,
+                       claude=_FakeClaude())
+    assert constructed[0].closed == 1
+
+
+@pytest.mark.asyncio
+async def test_release_runs_when_the_cascade_itself_fails(constructed):
+    """Both lanes down: the caller gets the terminal error AND no leak."""
+    class _DeadClaude:
+        async def prompt_only(self, *a, **k):
+            raise RuntimeError("claude down too")
+
+    with pytest.raises(RuntimeError, match="claude down too"):
+        await cl.rt_prompt("hi", model="m", caller_id="t", timeout_s=0.2,
+                           claude=_DeadClaude())
+    assert constructed[0].closed == 1
+
+
+@pytest.mark.asyncio
+async def test_release_runs_on_cancellation(constructed):
+    """Cancellation must still release. A `finally` that awaits while being
+    cancelled is exactly where a naive release would be skipped."""
+    started = asyncio.Event()
+
+    class _SlowClaude:
+        async def prompt_only(self, *a, **k):
+            started.set()
+            await asyncio.sleep(30)
+
+    task = asyncio.ensure_future(
+        cl.rt_prompt("hi", model="m", caller_id="t", timeout_s=0.2,
+                     claude=_SlowClaude())
+    )
+    await asyncio.wait_for(started.wait(), timeout=10)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert constructed and constructed[0].closed == 1
+
+
+@pytest.mark.asyncio
+async def test_a_failing_close_never_surfaces_to_the_caller(monkeypatch):
+    """Losing a session is a leak; raising here would lose the caller's
+    result. The release is guarded per-provider."""
+    from backend.core.ouroboros.governance import doubleword_provider as dwp
+
+    class _BadClose(_FakeProvider):
+        async def close(self):
+            raise RuntimeError("close exploded")
+
+    monkeypatch.setattr(dwp, "DoublewordProvider", lambda *a, **k: _BadClose())
+    out = await cl.rt_prompt("hi", model="m", caller_id="t", timeout_s=0.2,
+                             claude=_FakeClaude())
+    assert out == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_release_is_idempotent_and_drains_the_ledger(constructed):
+    """Two sequential calls each own and release exactly their own provider."""
+    for _ in range(2):
+        await cl.rt_prompt("hi", model="m", caller_id="t", timeout_s=0.2,
+                           claude=_FakeClaude())
+    assert len(constructed) == 2
+    assert all(p.closed == 1 for p in constructed)


### PR DESCRIPTION
Traces the 20 `Unclosed client session` + 15 `Unclosed connector` warnings from `bt-2026-08-18-021438` to one line, with a measured before/after.

## Attribution first, because the log couldn't give it

aiohttp's warning names no creator — it only records one when `loop.get_debug()` is on at construction, which it wasn't. With **292 `ClientSession` sites** in the repo, guessing would have been malpractice, so I narrowed structurally before touching anything:

- **AST sweep 1** — sessions bound to a local and never closed in scope: **3**, all factories that transfer ownership. Not it.
- **AST sweep 2** — classes owning a session with *no close path at all*: **2**, neither in the soak's hot path. Not it.

That ruled out the obvious shapes and left "an owner that *has* `close()` and nobody calls it". The log resolved the rest — every cluster sits against `[CognitionLanes] RT degraded (rt status 402 ...)`, at ~2 warnings (session + connector) per degrade:

| minute | unclosed | RT degrades |
|---|---|---|
| 19:21 | 8 | 5 |
| 19:23 | 10 | 5 |
| 19:30 | 6 | 5 |

## The defect

`rt_prompt._resolve()` constructs a `DoublewordProvider` whenever none is injected, and the provider lazily opens an `aiohttp.ClientSession` inside `_get_session()`. The provider is bound to `rt_prompt`'s **own scope**, so it and its session both fell to the garbage collector when the call returned — **one leak per RT attempt**.

The provider was never at fault: it owns `close()` and closes its session correctly. Nothing called it, because **nothing had decided who owned the object**.

## The fix

Whoever creates it, closes it. A provider constructed by this call is recorded and released in a `finally` wrapping **every** exit — the successful return inside the semaphore, the Claude cascade below it, and any exception or cancellation through either. The RT path fails far more often than it succeeds when a provider is down — precisely the run that leaked — so a release reachable only on the happy path would never run when it matters.

**An injected provider is never touched.** It belongs to its caller, is usually pooled and shared, and closing it here would convert a leak into an outage for everyone else holding it. Pinned by its own test.

The release is guarded per-provider and never propagates: it runs in a `finally` that may execute while the task is being cancelled or the loop is closing, where an await can itself raise. Losing a session there is a leak; raising would lose the caller's result or their cancellation.

## Evidence

Against the real code, three un-injected calls with `loop.set_debug(True)` so aiohttp records creators:

| | providers constructed | unclosed sessions |
|---|---|---|
| **before** (main) | 3 | **3** |
| **after** | 3 | **0** |

8 new tests; 41 passed across the RT-lane suites; CI suite set unchanged at 1 failed / 448 passed (the known pre-existing `thin_client` readiness test).

The 4 teardown-time `asyncio leak` lines at 20:07 were the async-generator `aclose()` failures, already fixed in #70531 — so between the two PRs the session's leak warnings are accounted for.

## Follow-up, deliberately not folded in

Callers that inject nothing now pay a session setup per call instead of leaking one. `CouncilVoice` holds `self._dw` and passes it straight through, so the pooling fix belongs there — but it has **no close path of its own today**, and giving it a cached provider without one would trade twenty leaks for a smaller number rather than none. That wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops RT RT-lane session leaks by taking ownership of providers created inside `rt_prompt`. Before: un-injected calls built a `DoublewordProvider` per call and never closed it, leaving `aiohttp` `ClientSession`/connector warnings; now: the call tracks any provider it creates and closes it in a `finally` on every exit, while never touching injected providers.

- Behavior and safety: Un-injected calls now create-and-close a provider per call; injected providers are not closed. Release runs on success, fallback, exceptions, and cancellation; close errors are logged and do not propagate. Measured: 3 un-injected calls — 3 unclosed sessions before, 0 after.
- Review focus: `backend/core/ouroboros/governance/cognition_lanes.py` adds an `_owned` ledger and `_release_owned()` invoked in a top-level `finally` that wraps the semaphore block and the Claude fallback; no public API changes. New tests in `tests/governance/test_cognition_lanes_session_ownership.py` cover created vs. injected provider ownership, cascade and cancellation paths, failure to close, and idempotency. Operational note: leak warnings disappear; non-injecting callers now pay a per-call session setup (pooling belongs with callers like `CouncilVoice`). No migration required.

<sup>Written for commit b6431e98c9af6869fdb9dae17fc0d8e8f7984cf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

