### PR TITLE
fix: The cockpit could not cold-boot, because a name nothing defined

### DIFF
--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -20,6 +20,7 @@ Everything after the verb forwards verbatim to the bootstrap, e.g.
 """
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import time
@@ -70,6 +71,19 @@ from backend.core.ouroboros.ui.semantic_tokens import (  # noqa: E402
 #: Semantic colour roles — the SAME name and access pattern as every
 #: other module. One vocabulary, one spelling, one owner.
 _SEM = _role_palette()
+
+#: `ov` referenced a bare `logger` in `_client_extra_bindings` while no such
+#: name existed. The call raised NameError, the surrounding handler
+#: referenced `logger` AGAIN while handling it, and the outer
+#: `except Exception: return None` discarded the ENTIRE extra key-binding
+#: set — confirm actions, the completion arbiter, paste collapse, rewind,
+#: transcript hatches and mode. All built, all mounted, all thrown away one
+#: line later. A comment at the audio scope already carried the diagnosis
+#: ("`ov` has no module-level logger ... a bare `logger` here resolved to
+#: nothing but a swallowed NameError") and worked around it locally rather
+#: than declaring one. Stdlib only, per this module's import-isolation
+#: mandate.
+logger = logging.getLogger("Ouroboros.Ov")
 
 
 def version_line() -> str:
@@ -3925,7 +3939,10 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
                 # actually lives. A KEEPER task, not a one-shot connect: the
                 # host usually starts AFTER the cockpit (wake spawns it), and
                 # may restart at any point in the session.
-                _audio["rms_task"] = asyncio.get_running_loop().create_task(
+                # `_aio` is this scope's already-imported alias for asyncio.
+                # The bare name was never bound here and raised NameError, so
+                # the RMS keeper task was never created.
+                _audio["rms_task"] = _aio.get_running_loop().create_task(
                     _keep_rms_stream(_scope, _audio),
                 )
                 _audio.update(pump=_pump, latch=_latch, mode=_mode)
@@ -4181,7 +4198,7 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
                     _t.cancel()
                     try:
                         await _t
-                    except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    except (_aio.CancelledError, Exception):  # noqa: BLE001
                         pass
                 _c = _audio.get("rms_client")
                 if _c is not None:

--- a/backend/core/ouroboros/cli/thin_client.py
+++ b/backend/core/ouroboros/cli/thin_client.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import plistlib
 import random
@@ -48,6 +49,16 @@ import sys
 import time
 from pathlib import Path
 from typing import Any, Callable, Optional
+
+#: THE MODULE USED THIS AND NEVER DEFINED IT.
+#:
+#: `spawn_daemon` has called `logger.debug(...)` since 2026-08-08 (#70440)
+#: while `logging` was not imported and no `logger` existed. Every ignition
+#: therefore raised `NameError: name 'logger' is not defined`, its blanket
+#: `except Exception: return None` swallowed it, and `ensure_daemon` reported
+#: "⚠ ignition failed" -- so bare `ov` could not cold-boot the organism at
+#: all for ten days. Stdlib only, per the import-isolation mandate above.
+logger = logging.getLogger("Ouroboros.ThinClient")
 
 _TRUTHY = ("1", "true", "yes", "on")
 
@@ -414,7 +425,17 @@ def spawn_daemon(
                 env=env,
             )
         return proc if getattr(proc, "pid", None) is not None else None
-    except Exception:  # noqa: BLE001
+    except Exception:  # noqa: BLE001 — ignition must never raise at the caller
+        # exc_info is load-bearing, not decoration. Returning a bare None here
+        # turns EVERY failure -- a missing binary, an unwritable log, a typo in
+        # this function -- into the single operator-facing sentence "ignition
+        # failed", which names no cause and cannot be acted on. That is how a
+        # NameError on the line above survived ten days and every CI run: the
+        # only symptom was a cockpit that would not start.
+        logger.warning(
+            "[ov] ignition failed before the daemon was spawned — see %s",
+            daemon_log_path(), exc_info=True,
+        )
         return None
 
 

--- a/ci/ov-surface-suites.txt
+++ b/ci/ov-surface-suites.txt
@@ -1,6 +1,7 @@
 tests/api/test_hive_aggregator.py
 tests/api/test_hive_emitter.py
 tests/cli/test_thin_client.py
+tests/cli/test_cli_undefined_names.py
 tests/cli/test_ov_doctor.py
 tests/cli/test_ov_doctor_edge_registry.py
 tests/cli/test_ov_dispatch.py

--- a/ci/requirements-ov-surface.txt
+++ b/ci/requirements-ov-surface.txt
@@ -11,3 +11,7 @@ aiofiles>=23
 uuid6>=2024.1
 numpy>=1.26
 aiohttp>=3.9
+# Undefined-name gate for cli/ (tests/cli/test_cli_undefined_names.py).
+# Two NameErrors in the operator's front door were swallowed by blanket
+# handlers and surfaced only as a cockpit that would not start.
+pyflakes>=3

--- a/tests/cli/test_cli_undefined_names.py
+++ b/tests/cli/test_cli_undefined_names.py
@@ -1,0 +1,110 @@
+"""No name may be used in `cli/` that nothing defines.
+
+TWICE NOW, in the operator's front door, and both times invisibly:
+
+* `thin_client.spawn_daemon` called `logger.debug(...)` while the module
+  imported no `logging` and defined no `logger` (since 2026-08-08, #70440).
+  Every ignition raised `NameError`, the function's blanket
+  `except Exception: return None` swallowed it, and `ensure_daemon` reported
+  the single sentence "⚠ ignition failed". Bare `ov` could not cold-boot the
+  organism for ten days.
+
+* `ov._client_extra_bindings` did the same, then referenced `logger` AGAIN
+  inside the handler catching the first NameError, so the outer
+  `except Exception: return None` discarded the ENTIRE extra key-binding set:
+  confirm actions, the completion arbiter, paste collapse, rewind, transcript
+  hatches and transcript mode. All built, all mounted, all thrown away one
+  line later.
+
+`ov.py` also used a bare `asyncio` twice in a scope whose alias is `_aio`, so
+the RMS keeper task was never created and a cleanup `except` clause raised
+while handling another exception.
+
+Nothing caught any of it. `flake8` runs in `ci-cd-pipeline.yml` as
+`flake8 backend/ ... || true` — the result is discarded, which is the same
+"green because nobody looked" failure this repo keeps paying for. Removing
+that `|| true` is not available: the repo carries ~812 undefined-name findings
+overall, most in vendored `venv/` and in `core/quarantine`.
+
+So this gate is SCOPED to where the count is genuinely zero and the blast
+radius is the operator's cockpit. It is deliberately not repo-wide, and it
+says so, because a gate that cannot pass is a gate somebody disables.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pyflakes_checker = pytest.importorskip(
+    "pyflakes.checker",
+    reason="pyflakes is declared in ci/requirements-ov-surface.txt; a runner "
+           "without it cannot enforce this gate",
+)
+from pyflakes import messages as pyflakes_messages  # noqa: E402
+
+#: The package this gate covers. Chosen because it is at zero today and it is
+#: what an operator runs.
+GATED = Path("backend/core/ouroboros/cli")
+
+#: Packages knowingly NOT covered, with their counts at the time this gate
+#: landed. Named so nobody reads a passing run as a repo-wide clean bill.
+UNGATED_KNOWN = {
+    "backend/core/ouroboros/governance": 16,
+    "backend/core/ouroboros/battle_test": 8,
+}
+
+
+def _undefined_names(path: Path):
+    src = path.read_text(encoding="utf-8", errors="replace")
+    tree = ast.parse(src, filename=str(path))
+    check = pyflakes_checker.Checker(tree, filename=str(path))
+    return [
+        (m.lineno, m.message % m.message_args)
+        for m in check.messages
+        if isinstance(m, pyflakes_messages.UndefinedName)
+    ]
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def test_cli_package_has_no_undefined_names():
+    root = _repo_root()
+    target = root / GATED
+    assert target.is_dir(), f"gated package missing: {target}"
+
+    offenders = []
+    for path in sorted(target.glob("*.py")):
+        for lineno, msg in _undefined_names(path):
+            offenders.append(f"{path.relative_to(root)}:{lineno}: {msg}")
+
+    assert not offenders, (
+        "a name is used here that nothing defines. Every occurrence of this "
+        "in `cli/` so far has been swallowed by a blanket `except Exception` "
+        "and surfaced only as a cockpit that would not start:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_the_gate_can_actually_fail():
+    """Guards the guard. A detector that cannot fire proves nothing."""
+    tree = ast.parse("def f():\n    return no_such_name\n", filename="<probe>")
+    check = pyflakes_checker.Checker(tree, filename="<probe>")
+    found = [m for m in check.messages
+             if isinstance(m, pyflakes_messages.UndefinedName)]
+    assert found, "pyflakes did not flag an obviously undefined name"
+
+
+def test_ungated_packages_are_named_not_forgotten():
+    """The honest half: this gate is scoped, and the scope is written down.
+
+    A passing run means `cli/` is clean, never that the repository is."""
+    assert UNGATED_KNOWN, "if nothing is ungated, say so explicitly"
+    for pkg in UNGATED_KNOWN:
+        assert (_repo_root() / pkg).is_dir(), (
+            f"{pkg} is named as ungated but does not exist — this note has "
+            "gone stale and would mislead the next reader"
+        )


### PR DESCRIPTION
**Correcting my own diagnosis from #70531.** I reported this as "the post-spawn readiness probe never observes SERVING". It isn't the readiness probe at all — the status line `⚠ ignition failed` maps to `if proc is None:`, so **nothing was ever waited on**.

## The defect

`spawn_daemon` calls `logger.debug(...)`. `thin_client` imports no `logging` and defines no `logger`. Every ignition raised `NameError: name 'logger' is not defined`, the function's blanket `except Exception: return None` swallowed it, and `ensure_daemon` reported one unactionable sentence.

`ensure_daemon` is on the production path (`ov.py:4564`), so **bare `ov` has been unable to cold-boot the organism since 2026-08-08 (#70440) — ten days.**

## The same defect in `ov.py`, twice, and worse

`_client_extra_bindings` calls `logger.debug` *after* mounting the confirm actions — and the handler catching that `NameError` references `logger` **again**, so it propagates to the outer `except Exception: return None`. The **entire extra key-binding set is discarded**: confirm actions, completion arbiter, paste collapse, rewind, transcript hatches, transcript mode. All built, all mounted, all thrown away one line later.

Proven at runtime: the function returned `None` before this change and a `KeyBindings` after.

> This corrects something I told you earlier in this session. I verified §28 C2 (single-key gate answering) as "built and mounted on both surfaces". It is built and mounted — and on the attach surface it was being discarded a line later. `bipartite_layout` installs it separately, so that mount was unaffected.

`ov.py` also used a bare `asyncio` twice in a scope whose alias is `_aio`, so the RMS keeper task was never created and a cleanup `except` clause raised while handling another exception. Bound to the alias already in scope rather than adding a second name for one module.

A comment in `ov.py` already carried the diagnosis — *"`ov` has no module-level logger ... a bare `logger` here resolved to nothing but a swallowed NameError"* — and worked around it **locally** with `import logging as _lg` instead of declaring one. That workaround is why the other two sites survived.

## Why nothing caught it

`ci-cd-pipeline.yml` runs `flake8 backend/ ... || true`. **The result is discarded.** pyflakes flags this line in 0.2s.

Removing the `|| true` isn't available — the repo carries ~812 undefined-name findings, most in vendored `venv/` and `core/quarantine`. So the gate here is **scoped to `cli/`**, which is at zero and is what an operator runs. It:

- names the packages it does *not* cover (governance 16, battle_test 8), so a passing run is never read as a repo-wide clean bill;
- carries its own guard test proving the detector can fire;
- was verified by deleting the logger again and watching it fail.

`spawn_daemon`'s handler now logs with `exc_info` before returning `None`. A bare `None` turned every possible failure — missing binary, unwritable log, a typo in this function — into "ignition failed", which names no cause. That is how a `NameError` survived ten days and every CI run.

## Evidence

**`ov surface` CI lane: 448 passed / 1 failed → 452 passed / 0 failed.** First fully green run of this lane in the session.

Full `tests/cli/`: 995 passed / 7 failed, all 7 verified **identical against the pre-commit versions of both files** (2 assert on `ov.py` docstring text, 1 trinity handshake, 4 `subprocess.TimeoutExpired` in supervisor tests).

## Still open

The 16 undefined names in `governance/` and 8 in `battle_test/` are real findings of this same class — including `doubleword_provider.py:2974: undefined name 'aiohttp'`, `failover_lifecycle.py:1066: undefined name 'FailoverTier'`, and `governed_loop_service.py:666: undefined name 'BrainSelectionResult'`. Some may be guarded by `TYPE_CHECKING`; each needs reading before it is touched. Not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cockpit cold-boot by defining module loggers and correcting swallowed NameErrors. Previously ignition returned None because `logger` was undefined in `thin_client.spawn_daemon` and `ov._client_extra_bindings`, and a bare `asyncio` was used instead of `_aio`; now ignition yields a process handle, extra key bindings load, the RMS keeper task starts, and failures log with traceback.

- In `backend/core/ouroboros/cli/thin_client.py`: import `logging`, add a module `logger`, and log `spawn_daemon` failures with `exc_info` before returning None.
- In `backend/core/ouroboros/cli/ov.py`: import `logging`, add a module `logger`, and replace two bare `asyncio` references with `_aio` to create and cancel the RMS keeper task.
- CI guard: add `tests/cli/test_cli_undefined_names.py`, include it in `ci/ov-surface-suites.txt`, and add `pyflakes>=3` to `ci/requirements-ov-surface.txt`. The undefined-name gate is scoped to `backend/core/ouroboros/cli` and lists ungated packages to avoid false repo-wide conclusions. No runtime dependency or operator action required.

<sup>Written for commit ba080d92d6655f07145d36c7478c784cb52dd927. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

