### PR TITLE
fix: Five real undefined names, and the gate that stops the sixth

### DIFF
--- a/.github/workflows/lint-gate.yml
+++ b/.github/workflows/lint-gate.yml
@@ -1,0 +1,69 @@
+# lint gate — no NEW undefined name may land
+#
+# The root problem this closes: `ci-cd-pipeline.yml` runs
+# `flake8 backend/ ... || true`. The result is DISCARDED, so an undefined
+# name has never failed a build. Two shipped in the operator's front door
+# and stayed invisible for ten days — `thin_client` used a `logger` it never
+# defined (bare `ov` could not cold-boot the organism), and
+# `ov._client_extra_bindings` did the same and discarded the entire extra
+# key-binding set. Both were swallowed by blanket `except Exception`.
+#
+# Removing that `|| true` is not available: ~812 undefined-name findings
+# exist, the bulk in vendored `venv/` and in `core/quarantine`. A gate that
+# cannot pass is a gate somebody disables. So this one is DIFFERENTIAL —
+# it reports only findings on lines the branch actually touched. Legacy debt
+# never fails a build; a new undefined name cannot land.
+#
+# Design invariants:
+#   * KEYLESS + HERMETIC — pyflakes and git, nothing else.
+#   * fetch-depth: 0 — a shallow checkout has no merge-base, and a gate that
+#     cannot see the change surface must not report success.
+#   * --require-base — so that blindness FAILS here rather than skipping.
+#     This runner is expected to resolve the base ref; a developer laptop on
+#     a detached HEAD legitimately is not.
+#   * On a push to `main` the merge-base IS HEAD, so the diff is empty and
+#     the differential half passes trivially. That is correct: nothing is
+#     new relative to trunk. The whole-package half still runs.
+
+name: lint gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  undefined-names:
+    name: no new undefined names
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The merge-base is the whole mechanism. Without full history there
+          # is no change surface to compute and the gate is blind.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install the analyzer
+        run: python -m pip install -q "pyflakes>=3"
+
+      - name: Make the base ref resolvable
+        run: |
+          git fetch --no-tags --depth=0 origin +refs/heads/main:refs/remotes/origin/main || \
+          git fetch --no-tags origin main
+
+      - name: Gate
+        run: python ci/lint_gate.py --root . --require-base

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -4667,6 +4667,11 @@ class DoublewordProvider:
         _s35_op_id = getattr(context, "op_id", "?") or "?"
         _s35_model = self._model or "(unspecified)"
         _s35_stage_t0 = time.monotonic()
+        #: Set when the first stream chunk arrives; stays None if the stream
+        #: never produced one. Declared HERE with the rest of this method's
+        #: Slice-35 telemetry so the read far below is a plain `is not None`
+        #: rather than an `in dir()` interrogation no static tool can verify.
+        _s35_stream_t0 = None
 
         # Gap #7: discover MCP tools for prompt injection
         _mcp_tools = None
@@ -5641,7 +5646,16 @@ class DoublewordProvider:
                                                     "STAGE_RT_HTTP_POST",
                                                     op_id=_s35_op_id,
                                                     model_id=_s35_model,
-                                                    duration_ms=float(_ttft_ms),
+                                                    # `_ttft_ms` was bound
+                                                    # nowhere in this file —
+                                                    # a typo for the value
+                                                    # computed 29 lines above
+                                                    # and already used twice.
+                                                    # Every execution raised
+                                                    # NameError, so this stage
+                                                    # was never recorded.
+                                                    duration_ms=float(
+                                                        _pure_ttft_ms),
                                                 )
                                                 # Reset stream-consume timer
                                                 # to start AT first chunk.
@@ -5894,9 +5908,14 @@ class DoublewordProvider:
             _s35_dp.record_stage(
                 "STAGE_RT_STREAM_CONSUME",
                 op_id=_s35_op_id, model_id=_s35_model,
+                # Bound only once a first chunk arrives. INITIALISED at the
+                # top of this method rather than interrogated with `in dir()`
+                # — correct at runtime, and unverifiable by any static tool,
+                # which is how two genuine undefined names in this repo's
+                # front door survived ten days inside blanket handlers.
                 duration_ms=(
                     (time.monotonic() - _s35_stream_t0) * 1000.0
-                ) if "_s35_stream_t0" in dir() else 0.0,
+                ) if _s35_stream_t0 is not None else 0.0,
             )
         except Exception:  # noqa: BLE001
             pass

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -3402,6 +3402,16 @@ class GovernedOrchestrator:
     async def _run_pipeline(self, ctx: OperationContext) -> OperationContext:
         """Internal pipeline logic -- phases 1 through 8."""
 
+        #: Bound for real at the VALIDATE seam far below, and READ above it by
+        #: the re-plan block on a later retry pass. Initialised here because
+        #: the read guarded itself with `if 'validation' in dir()` — correct
+        #: at runtime and invisible to every static tool, which is how two
+        #: genuine undefined names in this repo's front door survived ten days
+        #: inside blanket handlers. A name that may be unbound is INITIALISED,
+        #: never interrogated. Not reset per retry: the re-plan block wants
+        #: the PREVIOUS pass's verdict, which is exactly what persists.
+        validation = None
+
         # A1-T4 — hop 5/5 (accept): the GOAL enters the governed FSM at
         # CLASSIFY. The fifth + final breadcrumb; the five ordered [A1Trace]
         # lines in a soak's stdout are the A1 milestone proof.
@@ -7505,8 +7515,10 @@ class GovernedOrchestrator:
                     #       INSUFFICIENT_EVIDENCE / DISABLED / FAILED.
                     _replan_text = ""
                     try:
-                        _fc = validation.failure_class or "" if 'validation' in dir() else ""
-                        _em = validation.short_summary or "" if 'validation' in dir() else ""
+                        _fc = (validation.failure_class or ""
+                               ) if validation is not None else ""
+                        _em = (validation.short_summary or ""
+                               ) if validation is not None else ""
                         _attempt_num = self._config.max_generate_retries - generate_retries_remaining + 1
                         # Stage 1 — structural falsification (proactive)
                         try:

--- a/backend/core/ouroboros/governance/phase_runners/generate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/generate_runner.py
@@ -2253,8 +2253,24 @@ class GENERATERunner(PhaseRunner):
                 try:
                     from backend.core.ouroboros.governance.self_evolution import DynamicRePlanner
                     _attempt_num = orch._config.max_generate_retries - generate_retries_remaining + 1
-                    _fc = validation.failure_class or "" if 'validation' in dir() else ""
-                    _em = validation.short_summary or "" if 'validation' in dir() else ""
+                    # NO VALIDATION VERDICT EXISTS IN THIS SCOPE.
+                    #
+                    # `validation` has no binding anywhere in `run()`; it was
+                    # carried over from the inline orchestrator twin, where it
+                    # IS bound (at the VALIDATE seam). The `in dir()` guard
+                    # therefore always evaluated False here, so these were
+                    # always "" — and this is the SHIPPING path
+                    # (`JARVIS_PHASE_RUNNER_GATE_EXTRACTED`). Dynamic
+                    # re-planning has been reasoning from empty failure
+                    # context on every real op.
+                    #
+                    # Made explicit rather than left as a guard that looks
+                    # like it might sometimes fire. Wiring a real verdict
+                    # through to this seam is a behavioural change with its
+                    # own design question — which verdict, from which
+                    # attempt — and is deliberately NOT invented here.
+                    _fc = ""
+                    _em = ""
                     _replan = DynamicRePlanner.suggest_replan(_fc, _em, _attempt_num)
                     if _replan:
                         _replan_text = DynamicRePlanner.format_for_prompt(_replan)

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -5449,6 +5449,30 @@ def _jprime_inflight_guard():
                 pass
 
 
+@dataclass(frozen=True)
+class _AdmissionTicket:
+    """What the local-admission gate granted, carried to the seam that settles it.
+
+    FROZEN and PASSED, never closed over. The two fields previously lived as
+    locals of :meth:`PrimeProvider.generate` while their only consumer was
+    ``_generate_raw``, nested inside the SIBLING method ``_generate_impl`` --
+    so every settle call raised NameError into an ``except Exception: pass``
+    and the VRAM reservation was never handed back early.
+
+    Both fields default to ``None`` because admission is best-effort: when the
+    gate is disabled or its probe degraded, there is genuinely nothing to
+    settle, and a ticket that said otherwise would make the ledger record a
+    load it never admitted."""
+
+    brain_id: Optional[str] = None
+    reservation_id: Optional[str] = None
+
+    @property
+    def settleable(self) -> bool:
+        """Is there anything for the ledger to learn from or hand back?"""
+        return bool(self.brain_id) or bool(self.reservation_id)
+
+
 class PrimeProvider:
     """CandidateProvider adapter wrapping PrimeClient.generate().
 
@@ -5539,15 +5563,30 @@ class PrimeProvider:
         18 GB model load and the 37 ms voice path.
         """
         _adm = None
-        # Bound HERE, not inside the try below: `_generate_raw` closes over
-        # this name, and a lazily-bound name read from a closure becomes a
-        # bare NameError the moment the binding block raises early — a fault
-        # on the dispatch path that reads as a generation failure rather than
-        # as the telemetry wiring it actually is (PR #70386's class).
+        # THE CLOSURE THESE WERE WRITTEN FOR DOES NOT EXIST.
+        #
+        # The previous comments here recorded the right technique for the
+        # wrong topology: "`_generate_raw` closes over this name", and a
+        # one-slot cell so the closure would see an id assigned after it was
+        # defined. `_generate_raw` is nested inside `_generate_impl`
+        # (5627..6153), a SIBLING method — not inside this one (5516..5624).
+        # There is no closure, so both names resolved to nothing and every
+        # `record_load_outcome` / `release_reservation` call in that function
+        # raised NameError into an `except Exception: pass`.
+        #
+        # The cost was not telemetry. `release_reservation` hands back the
+        # soft VRAM claim; its own comment says the ledger self-heals "only
+        # after a settle window during which every other worker is throttled
+        # by memory this one has definitively stopped wanting". So the claim
+        # was never returned early, and local admission throttled workers
+        # against bytes nobody was using.
+        #
+        # A value that must cross a call boundary travels ALONG it. The
+        # reservation id is known here (assigned below, before the dispatch
+        # at the end of this method), so the one-slot cell has nothing left
+        # to solve and the ticket is frozen.
         _brain_for_adm: Optional[str] = None
-        # A one-slot cell rather than a bare name: `_generate_raw` closes over
-        # it and must see the id assigned AFTER the closure was defined.
-        _adm_reservation: list = [None]
+        _adm_reservation_id: Optional[str] = None
         try:
             from backend.core.ouroboros.governance import (
                 local_model_admission as _lma,
@@ -5583,7 +5622,7 @@ class PrimeProvider:
             _adm = await _lma.assess_async(
                 weight_bytes=_weight_bytes, model_id=_brain_for_adm,
             )
-            _adm_reservation[0] = getattr(_adm, "reservation_id", None)
+            _adm_reservation_id = getattr(_adm, "reservation_id", None)
             if not _adm.proceeds:
                 _lma.report(_adm, what="J-Prime generation")
                 logger.warning("[PrimeProvider] %s %s",
@@ -5622,6 +5661,10 @@ class PrimeProvider:
         with _jprime_inflight_guard():
             return await self._generate_impl(
                 context, deadline, repair_context, temperature=temperature,
+                admission=_AdmissionTicket(
+                    brain_id=_brain_for_adm,
+                    reservation_id=_adm_reservation_id,
+                ),
             )
 
     async def _generate_impl(
@@ -5631,8 +5674,15 @@ class PrimeProvider:
         repair_context: Optional[Any] = None,
         *,
         temperature: Optional[float] = None,
+        admission: "Optional[_AdmissionTicket]" = None,
     ) -> GenerationResult:
         """Generate code candidates via PrimeClient with optional tool-call loop.
+
+        ``admission`` carries what the local-admission gate granted in
+        :meth:`generate`, because the seam that settles it (``_generate_raw``)
+        lives in THIS method's scope and cannot see that one's locals. Default
+        ``None`` keeps every other caller — there are none today, and this
+        keeps it that way — byte-identical and unsettled.
 
         ``temperature`` (Adaptive Epistemic Feedback Matrix, T2): optional sampling
         override threaded by ``RepairEngine`` to lower temperature when the SAME
@@ -5834,13 +5884,18 @@ class PrimeProvider:
                     from backend.core.ouroboros.governance import (
                         local_model_admission as _lma_out,
                     )
-                    _lma_out.record_load_outcome(
-                        _brain_for_adm, ok=False, error=_load_err)
-                    # Hand back the soft claim on the failure path too. The
-                    # ledger self-heals if we don't, but only after a settle
-                    # window during which every other worker is throttled by
-                    # memory this one has definitively stopped wanting.
-                    _lma_out.release_reservation(_adm_reservation[0])
+                    # `admission` is this method's parameter, closed over
+                    # legitimately. The names that used to be here belonged to
+                    # `generate`'s scope and resolved to nothing.
+                    if admission is not None:
+                        _lma_out.record_load_outcome(
+                            admission.brain_id, ok=False, error=_load_err)
+                        # Hand back the soft claim on the failure path too.
+                        # The ledger self-heals if we don't, but only after a
+                        # settle window during which every other worker is
+                        # throttled by memory this one has definitively
+                        # stopped wanting.
+                        _lma_out.release_reservation(admission.reservation_id)
                 except Exception:  # noqa: BLE001 — telemetry never masks a fault
                     pass
                 raise
@@ -5848,11 +5903,12 @@ class PrimeProvider:
                 from backend.core.ouroboros.governance import (
                     local_model_admission as _lma_out,
                 )
-                _lma_out.record_load_outcome(_brain_for_adm, ok=True)
-                # The allocation is now resident and visible to the OS probe;
-                # continuing to subtract it would double-count one set of
-                # bytes against every subsequent worker.
-                _lma_out.release_reservation(_adm_reservation[0])
+                if admission is not None:
+                    _lma_out.record_load_outcome(admission.brain_id, ok=True)
+                    # The allocation is now resident and visible to the OS
+                    # probe; continuing to subtract it would double-count one
+                    # set of bytes against every subsequent worker.
+                    _lma_out.release_reservation(admission.reservation_id)
             except Exception:  # noqa: BLE001
                 pass
             _last_response[0] = resp

--- a/ci/lint_gate.py
+++ b/ci/lint_gate.py
@@ -1,0 +1,471 @@
+"""Undefined-name gating: whole-package where it is clean, differential everywhere else.
+
+WHY THIS EXISTS
+---------------
+`ci-cd-pipeline.yml` runs `flake8 backend/ ... || true`. The result is
+discarded, so an undefined name has never failed a build. Two shipped in the
+operator's front door and were invisible for ten days: `thin_client` used a
+`logger` it never defined (bare `ov` could not cold-boot the organism), and
+`ov._client_extra_bindings` did the same and discarded the ENTIRE extra
+key-binding set. Both were swallowed by blanket `except Exception` handlers.
+
+`|| true` cannot simply be removed: the repository carries ~812 undefined-name
+findings, the bulk of them in vendored `venv/` and in `core/quarantine`. A gate
+that cannot pass is a gate somebody disables, so there are two, and each is
+honest about its own scope:
+
+**Whole-package** (:func:`package_findings`) for packages already at zero. It
+proves a clean package stays clean.
+
+**Differential** (:func:`differential_findings`) for everywhere else. It
+reports only findings on lines this branch actually touched, so legacy debt
+never fails a build and no NEW undefined name can land. This is the surface
+that would have caught both incidents on the commit that introduced them.
+
+WHAT IT DELIBERATELY DOES NOT DO
+--------------------------------
+It does not flag names that are only ever used in ANNOTATIONS of a module
+carrying `from __future__ import annotations`, nor names inside quoted
+annotations. Those are never evaluated at runtime, and 16 of the 24 findings
+in this repo's governance + battle_test packages are exactly that. Reporting
+them would push people to add runtime imports for names that currently cost
+nothing — trading zero cost for import time and circular-import risk, which is
+worse than the thing being fixed.
+
+BLINDNESS IS NOT A PASS
+-----------------------
+If the base ref cannot be resolved (a shallow CI checkout, a detached HEAD),
+the differential gate cannot see the change surface. It says so and, under
+``--require-base``, FAILS rather than reporting success — the same discipline
+`JARVIS_PTY_TESTS_REQUIRED` applies to terminal-dependent tests. Reporting a
+skip as a pass is the failure mode this whole module exists to end.
+
+Stdlib + pyflakes only. Python 3.9+.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+#: Base ref the differential gate diffs against. Overridable so a fork, a
+#: release branch or a local experiment can gate against its own trunk.
+BASE_REF_ENV = "JARVIS_LINT_GATE_BASE_REF"
+DEFAULT_BASE_REF = "origin/main"
+
+#: Packages held to whole-package cleanliness. Extend as packages reach zero;
+#: never trim to make a red build green — that is what the differential gate
+#: is for.
+CLEAN_PACKAGES_ENV = "JARVIS_LINT_GATE_CLEAN_PACKAGES"
+DEFAULT_CLEAN_PACKAGES: Tuple[str, ...] = (
+    "backend/core/ouroboros/cli",
+    # Both reached zero in this change; locking that in is the whole point of
+    # a ratchet. Scanned RECURSIVELY — a top-level-only sweep missed
+    # `phase_runners/generate_runner.py`, where the same `validation` defect
+    # sat on the SHIPPING path.
+    "backend/core/ouroboros/governance",
+    "backend/core/ouroboros/battle_test",
+)
+
+#: Paths the differential gate ignores even when a diff touches them.
+#: Vendored and quarantined trees are not this repository's code.
+EXCLUDE_ENV = "JARVIS_LINT_GATE_EXCLUDE"
+DEFAULT_EXCLUDES: Tuple[str, ...] = (
+    "/venv/",
+    "/site-packages/",
+    "/node_modules/",
+    "/.worktrees/",
+    "backend/core/quarantine/",
+    # iCloud/Finder duplicate artifacts ("foo 2.py"). Not authored code: they
+    # are byte-copies the sync layer left behind, several carry syntax errors,
+    # and the progress board already counts them as dark. Excluded here so a
+    # sync artifact can never fail a build; they want deleting, not linting.
+    " 2.py",
+)
+
+
+def _env_list(var: str, defaults: Sequence[str]) -> Tuple[str, ...]:
+    """Defaults PLUS environment additions. Never fewer.
+
+    Extend-only for the same reason every other knob in this codebase is: a
+    list an env var could empty is a gate a typo silently disarms."""
+    out = list(defaults)
+    try:
+        raw = str(os.environ.get(var, "") or "")
+        for piece in raw.replace(",", " ").split():
+            piece = piece.strip()
+            if piece and piece not in out:
+                out.append(piece)
+    except Exception:  # noqa: BLE001
+        pass
+    return tuple(out)
+
+
+def base_ref() -> str:
+    return str(os.environ.get(BASE_REF_ENV, "") or DEFAULT_BASE_REF).strip()
+
+
+def clean_packages() -> Tuple[str, ...]:
+    return _env_list(CLEAN_PACKAGES_ENV, DEFAULT_CLEAN_PACKAGES)
+
+
+def excludes() -> Tuple[str, ...]:
+    return _env_list(EXCLUDE_ENV, DEFAULT_EXCLUDES)
+
+
+def is_excluded(path: str) -> bool:
+    norm = "/" + str(path).replace("\\", "/").lstrip("/")
+    return any(frag in norm for frag in excludes())
+
+
+# ---------------------------------------------------------------------------
+# Finding
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    lineno: int
+    name: str
+    inert: bool = False
+
+    def render(self) -> str:
+        return f"{self.path}:{self.lineno}: undefined name '{self.name}'"
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+
+def _annotation_lines(tree: ast.AST) -> Set[int]:
+    """Line numbers occupied by annotation expressions.
+
+    Annotations in a module with `from __future__ import annotations` are
+    never evaluated, so an undefined name there cannot raise."""
+    lines: Set[int] = set()
+
+    def mark(node: Optional[ast.AST]) -> None:
+        if node is None:
+            return
+        for sub in ast.walk(node):
+            ln = getattr(sub, "lineno", None)
+            if ln is not None:
+                lines.add(ln)
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            mark(node.returns)
+            args = node.args
+            every = list(args.args) + list(args.kwonlyargs)
+            every += list(getattr(args, "posonlyargs", []) or [])
+            for arg in every:
+                mark(arg.annotation)
+            if args.vararg is not None:
+                mark(args.vararg.annotation)
+            if args.kwarg is not None:
+                mark(args.kwarg.annotation)
+        elif isinstance(node, ast.AnnAssign):
+            mark(node.annotation)
+    return lines
+
+
+def _quoted_annotation_lines(tree: ast.AST) -> Set[int]:
+    """Lines whose ANNOTATION is itself a string literal — never evaluated.
+
+    `def f(x: "Thing")` is inert even without the future import. Missing that
+    mis-classified `verify_gate.py` in the first pass of this analysis.
+
+    SCOPED TO ANNOTATION POSITIONS ONLY. An earlier draft marked every line
+    containing any string constant, which silently suppressed a REAL finding:
+    `orchestrator.py`'s `_fc = validation.failure_class ... if 'validation'
+    in dir() else ""` carries string literals, so the line was ruled inert and
+    the undefined `validation` disappeared from the report. A detector whose
+    false-negatives scale with how many strings a line happens to contain is
+    worse than no detector, because it reports clean."""
+    lines: Set[int] = set()
+
+    def mark_if_quoted(node: Optional[ast.AST]) -> None:
+        if node is None:
+            return
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                ln = getattr(sub, "lineno", None)
+                if ln is not None:
+                    lines.add(ln)
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            mark_if_quoted(node.returns)
+            args = node.args
+            every = list(args.args) + list(args.kwonlyargs)
+            every += list(getattr(args, "posonlyargs", []) or [])
+            for arg in every:
+                mark_if_quoted(arg.annotation)
+            if args.vararg is not None:
+                mark_if_quoted(args.vararg.annotation)
+            if args.kwarg is not None:
+                mark_if_quoted(args.kwarg.annotation)
+        elif isinstance(node, ast.AnnAssign):
+            mark_if_quoted(node.annotation)
+    return lines
+
+
+def undefined_names(path: Path) -> List[Finding]:
+    """Every undefined name in *path*, each marked inert or real. NEVER raises.
+
+    A file that cannot be parsed yields a synthetic finding rather than
+    silence: a syntax error is strictly worse than an undefined name, and a
+    linter that skipped it would be reporting clean on a file that cannot
+    even import."""
+    try:
+        from pyflakes import checker as pyflakes_checker
+        from pyflakes import messages as pyflakes_messages
+    except Exception:  # noqa: BLE001 — caller decides whether that is fatal
+        return []
+
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+    except Exception as exc:  # noqa: BLE001
+        return [Finding(str(path), 0, f"<unreadable: {exc}>")]
+
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        return [Finding(str(path), int(exc.lineno or 0), "<syntax error>")]
+    except Exception as exc:  # noqa: BLE001
+        return [Finding(str(path), 0, f"<unparseable: {exc}>")]
+
+    try:
+        check = pyflakes_checker.Checker(tree, filename=str(path))
+        raw = [
+            (int(m.lineno), str(m.message % m.message_args))
+            for m in check.messages
+            if isinstance(m, pyflakes_messages.UndefinedName)
+        ]
+    except Exception as exc:  # noqa: BLE001
+        return [Finding(str(path), 0, f"<check failed: {exc}>")]
+
+    future = any(
+        isinstance(n, ast.ImportFrom) and n.module == "__future__"
+        and any(a.name == "annotations" for a in n.names)
+        for n in ast.walk(tree)
+    )
+    ann = _annotation_lines(tree)
+    strann = _quoted_annotation_lines(tree)
+
+    out: List[Finding] = []
+    for lineno, msg in raw:
+        name = msg.split("'")[1] if "'" in msg else msg
+        inert = (lineno in ann and future) or (lineno in strann)
+        out.append(Finding(str(path), lineno, name, inert=inert))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Git surface
+# ---------------------------------------------------------------------------
+
+
+class BaseRefUnavailable(RuntimeError):
+    """The change surface cannot be computed, so nothing can be gated."""
+
+
+def _git(args: Sequence[str], cwd: Path) -> str:
+    proc = subprocess.run(
+        ["git", *args], cwd=str(cwd),
+        capture_output=True, text=True, timeout=120,
+    )
+    if proc.returncode != 0:
+        raise BaseRefUnavailable(
+            f"git {' '.join(args)} failed: {proc.stderr.strip()[:200]}"
+        )
+    return proc.stdout
+
+
+def changed_lines(
+    root: Path, ref: Optional[str] = None,
+) -> Dict[str, Set[int]]:
+    """``{path: {added-or-modified line numbers}}`` for this branch.
+
+    Untracked files count in full: a brand-new file is entirely new surface,
+    and the incident that motivated this gate could just as easily have
+    arrived in one. Deleted files are absent by construction — there is
+    nothing left to lint."""
+    ref = ref or base_ref()
+    try:
+        merge_base = _git(["merge-base", ref, "HEAD"], root).strip()
+    except BaseRefUnavailable:
+        raise
+    if not merge_base:
+        raise BaseRefUnavailable(f"no merge-base with {ref!r}")
+
+    out: Dict[str, Set[int]] = {}
+    diff = _git(
+        ["diff", "--unified=0", "--no-color", "--diff-filter=ACMR",
+         merge_base, "--"], root,
+    )
+    current: Optional[str] = None
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            current = line[6:].strip()
+            continue
+        if line.startswith("@@") and current:
+            # @@ -old,cnt +new,cnt @@
+            try:
+                plus = line.split("+", 1)[1].split(" ", 1)[0]
+                start_s, _, count_s = plus.partition(",")
+                start = int(start_s)
+                count = int(count_s) if count_s else 1
+            except Exception:  # noqa: BLE001 — a malformed hunk header
+                continue
+            if count > 0:
+                out.setdefault(current, set()).update(
+                    range(start, start + count)
+                )
+
+    # Untracked files: whole-file surface.
+    try:
+        untracked = _git(
+            ["ls-files", "--others", "--exclude-standard"], root,
+        ).split()
+    except BaseRefUnavailable:
+        untracked = []
+    for rel in untracked:
+        if not rel.endswith(".py"):
+            continue
+        try:
+            n = len((root / rel).read_text(
+                encoding="utf-8", errors="replace").splitlines())
+        except Exception:  # noqa: BLE001
+            continue
+        out.setdefault(rel, set()).update(range(1, n + 1))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Gates
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GateResult:
+    findings: List[Finding] = field(default_factory=list)
+    scanned_files: int = 0
+    blind: Optional[str] = None          # why the gate could not see
+
+    @property
+    def ok(self) -> bool:
+        return not self.findings and self.blind is None
+
+
+def package_findings(root: Path, packages: Optional[Sequence[str]] = None) -> GateResult:
+    """Whole-package gate over packages already at zero."""
+    res = GateResult()
+    for pkg in (packages if packages is not None else clean_packages()):
+        base = root / pkg
+        if not base.is_dir():
+            continue
+        # RECURSIVE. `glob("*.py")` missed `phase_runners/generate_runner.py`
+        # entirely — the file carrying this defect class on the shipping path.
+        for path in sorted(base.rglob("*.py")):
+            if is_excluded(str(path)):
+                continue
+            res.scanned_files += 1
+            res.findings.extend(f for f in undefined_names(path) if not f.inert)
+    return res
+
+
+def differential_findings(
+    root: Path, ref: Optional[str] = None,
+) -> GateResult:
+    """Gate ONLY the lines this branch touched."""
+    res = GateResult()
+    try:
+        touched = changed_lines(root, ref)
+    except BaseRefUnavailable as exc:
+        res.blind = str(exc)
+        return res
+
+    for rel, lines in sorted(touched.items()):
+        if not rel.endswith(".py") or is_excluded(rel):
+            continue
+        path = root / rel
+        if not path.is_file():
+            continue
+        res.scanned_files += 1
+        for finding in undefined_names(path):
+            if finding.inert:
+                continue
+            # A syntax/read failure has no meaningful line to intersect, so it
+            # is reported whenever the file was touched at all.
+            if finding.lineno == 0 or finding.lineno in lines:
+                res.findings.append(finding)
+    return res
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="lint_gate",
+        description="Fail on NEW undefined names without failing on legacy ones.",
+    )
+    parser.add_argument("--base", default=None,
+                        help=f"base ref (default ${BASE_REF_ENV} or {DEFAULT_BASE_REF})")
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument("--require-base", action="store_true",
+                        help="treat an unresolvable base ref as FAILURE, not a skip")
+    parser.add_argument("--packages-only", action="store_true")
+    parser.add_argument("--differential-only", action="store_true")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    root = Path(args.root).resolve()
+    failed = False
+
+    if not args.differential_only:
+        pkg = package_findings(root)
+        if pkg.findings:
+            failed = True
+            print(f"✗ whole-package gate: {len(pkg.findings)} undefined name(s)")
+            for f in pkg.findings:
+                print(f"    {f.render()}")
+        else:
+            print(f"✓ whole-package gate clean ({pkg.scanned_files} file(s))")
+
+    if not args.packages_only:
+        dif = differential_findings(root, args.base)
+        if dif.blind is not None:
+            msg = f"differential gate is BLIND: {dif.blind}"
+            if args.require_base:
+                print(f"✗ {msg}")
+                print("    --require-base is set, so this runner is expected to "
+                      "resolve the base ref. A gate that cannot see the change "
+                      "surface must not report success.")
+                failed = True
+            else:
+                print(f"⚠ {msg} — skipping (pass --require-base to make this fatal)")
+        elif dif.findings:
+            failed = True
+            print(f"✗ differential gate: {len(dif.findings)} NEW undefined name(s) "
+                  f"on changed lines")
+            for f in dif.findings:
+                print(f"    {f.render()}")
+        else:
+            print(f"✓ differential gate clean "
+                  f"({dif.scanned_files} changed file(s))")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/ci/ov-surface-suites.txt
+++ b/ci/ov-surface-suites.txt
@@ -18,3 +18,4 @@ tests/governance/test_quota_taxonomy.py
 tests/governance/test_cognition_lanes.py
 tests/governance/test_dw_priority_tier.py
 tests/governance/test_dw_temporal_veto.py
+tests/ci/test_lint_gate.py

--- a/tests/ci/test_lint_gate.py
+++ b/tests/ci/test_lint_gate.py
@@ -1,0 +1,210 @@
+"""The gate that would have caught both cockpit incidents on the commit that made them.
+
+`ci-cd-pipeline.yml` runs `flake8 backend/ ... || true`; the result is
+discarded, so an undefined name has never failed a build. Two shipped in the
+operator's front door and stayed invisible for ten days.
+
+`|| true` cannot simply be removed — ~812 undefined-name findings exist, most
+in vendored `venv/` and `core/quarantine` — so the gate is differential: it
+reports only findings on lines the branch actually touched. Legacy debt never
+fails a build; a NEW undefined name cannot land.
+
+Every test here builds a REAL git repository in a tmp dir. A differential gate
+tested against a mocked diff would be testing the mock.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pyflakes", reason="pyflakes gates this suite")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from ci import lint_gate  # noqa: E402
+
+
+def _git(args, cwd):
+    return subprocess.run(["git", *args], cwd=str(cwd),
+                          capture_output=True, text=True, check=True)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A real repo with a `main` carrying one pre-existing undefined name."""
+    _git(["init", "-q", "-b", "main"], tmp_path)
+    _git(["config", "user.email", "t@t"], tmp_path)
+    _git(["config", "user.name", "t"], tmp_path)
+    legacy = tmp_path / "legacy.py"
+    legacy.write_text(
+        "def old():\n"
+        "    return already_undefined_on_main\n",
+        encoding="utf-8",
+    )
+    _git(["add", "legacy.py"], tmp_path)
+    _git(["commit", "-qm", "base"], tmp_path)
+    _git(["checkout", "-q", "-b", "feature"], tmp_path)
+    return tmp_path
+
+
+class TestDifferential:
+    def test_a_new_undefined_name_on_a_changed_line_fails(self, repo):
+        (repo / "new.py").write_text(
+            "def f():\n    return brand_new_typo\n", encoding="utf-8")
+        _git(["add", "new.py"], repo)
+        _git(["commit", "-qm", "add"], repo)
+        res = lint_gate.differential_findings(repo, ref="main")
+        assert [f.name for f in res.findings] == ["brand_new_typo"]
+        assert not res.ok
+
+    def test_legacy_findings_on_untouched_lines_are_ignored(self, repo):
+        """The whole point: existing debt must never fail someone else's build."""
+        legacy = repo / "legacy.py"
+        legacy.write_text(
+            legacy.read_text(encoding="utf-8") + "\n\ndef added():\n    return 1\n",
+            encoding="utf-8")
+        _git(["add", "legacy.py"], repo)
+        _git(["commit", "-qm", "touch"], repo)
+        res = lint_gate.differential_findings(repo, ref="main")
+        assert res.ok, f"legacy debt leaked into the gate: {res.findings}"
+
+    def test_a_new_defect_in_a_legacy_file_still_fails(self, repo):
+        """Touching a dirty file does not grant amnesty for new lines in it."""
+        legacy = repo / "legacy.py"
+        legacy.write_text(
+            legacy.read_text(encoding="utf-8")
+            + "\n\ndef added():\n    return another_new_typo\n",
+            encoding="utf-8")
+        _git(["add", "legacy.py"], repo)
+        _git(["commit", "-qm", "touch"], repo)
+        res = lint_gate.differential_findings(repo, ref="main")
+        assert [f.name for f in res.findings] == ["another_new_typo"]
+
+    def test_untracked_files_are_gated_in_full(self, repo):
+        """A brand-new file is entirely new surface, committed or not."""
+        (repo / "fresh.py").write_text(
+            "def f():\n    return untracked_typo\n", encoding="utf-8")
+        res = lint_gate.differential_findings(repo, ref="main")
+        assert any(f.name == "untracked_typo" for f in res.findings)
+
+    def test_deleted_files_are_not_linted(self, repo):
+        (repo / "legacy.py").unlink()
+        _git(["add", "-A"], repo)
+        _git(["commit", "-qm", "rm"], repo)
+        res = lint_gate.differential_findings(repo, ref="main")
+        assert res.ok
+
+
+class TestInertNamesAreNotReported:
+    """16 of this repo's 24 findings are annotations that never evaluate.
+
+    Reporting them would push people to add runtime imports for names that
+    currently cost nothing — trading zero cost for import time and
+    circular-import risk. That is worse than the thing being fixed."""
+
+    def test_annotation_under_future_import_is_inert(self, repo):
+        (repo / "ann.py").write_text(
+            "from __future__ import annotations\n\n"
+            "def f() -> NeverImported:\n    return None\n",
+            encoding="utf-8")
+        res = lint_gate.differential_findings(repo, ref="main")
+        assert res.ok, f"inert annotation reported: {res.findings}"
+
+    def test_quoted_annotation_is_inert_even_without_the_future_import(self, repo):
+        """A string annotation is a string. Missing this mis-classified
+        `verify_gate.py` in the first pass of this analysis."""
+        (repo / "q.py").write_text(
+            'def f(x: "NeverImported") -> None:\n    return None\n',
+            encoding="utf-8")
+        res = lint_gate.differential_findings(repo, ref="main")
+        assert res.ok, f"quoted annotation reported: {res.findings}"
+
+    def test_an_annotation_name_used_in_EXECUTABLE_position_is_still_reported(
+        self, repo,
+    ):
+        """Inertness is a property of the POSITION, never of the name."""
+        (repo / "x.py").write_text(
+            "from __future__ import annotations\n\n"
+            "def f() -> Thing:\n"
+            "    return Thing()\n",           # executable — real NameError
+            encoding="utf-8")
+        res = lint_gate.differential_findings(repo, ref="main")
+        assert [f.name for f in res.findings] == ["Thing"]
+
+
+class TestBlindnessIsNotAPass:
+    def test_an_unresolvable_base_ref_is_reported_not_swallowed(self, repo):
+        res = lint_gate.differential_findings(repo, ref="no/such/ref")
+        assert res.blind is not None
+        assert not res.ok, "a gate that cannot see must not report success"
+
+    def test_require_base_turns_blindness_into_failure(self, repo, monkeypatch):
+        monkeypatch.chdir(repo)
+        rc = lint_gate.main(
+            ["--root", str(repo), "--base", "no/such/ref",
+             "--differential-only", "--require-base"])
+        assert rc == 1
+
+    def test_without_require_base_blindness_is_a_loud_skip(self, repo, capsys):
+        rc = lint_gate.main(
+            ["--root", str(repo), "--base", "no/such/ref", "--differential-only"])
+        assert rc == 0
+        assert "BLIND" in capsys.readouterr().out
+
+
+class TestResilience:
+    def test_a_syntax_error_is_a_finding_not_silence(self, repo):
+        (repo / "broken.py").write_text("def f(:\n", encoding="utf-8")
+        res = lint_gate.differential_findings(repo, ref="main")
+        assert any("syntax" in f.name for f in res.findings)
+
+    def test_excluded_trees_are_never_gated(self, repo, monkeypatch):
+        vendored = repo / "backend" / "venv" / "lib"
+        vendored.mkdir(parents=True)
+        (vendored / "v.py").write_text(
+            "def f():\n    return vendored_typo\n", encoding="utf-8")
+        res = lint_gate.differential_findings(repo, ref="main")
+        assert res.ok, f"vendored code leaked in: {res.findings}"
+
+    def test_exclusions_extend_and_cannot_be_emptied(self, monkeypatch):
+        monkeypatch.setenv(lint_gate.EXCLUDE_ENV, "")
+        assert lint_gate.DEFAULT_EXCLUDES[0] in lint_gate.excludes()
+        monkeypatch.setenv(lint_gate.EXCLUDE_ENV, "/extra/")
+        got = lint_gate.excludes()
+        assert "/extra/" in got
+        assert lint_gate.DEFAULT_EXCLUDES[0] in got
+
+    def test_undefined_names_never_raises_on_a_missing_file(self, tmp_path):
+        assert lint_gate.undefined_names(tmp_path / "nope.py")
+
+    def test_non_python_changes_are_ignored(self, repo):
+        (repo / "README.md").write_text("# hi\n", encoding="utf-8")
+        _git(["add", "README.md"], repo)
+        _git(["commit", "-qm", "docs"], repo)
+        res = lint_gate.differential_findings(repo, ref="main")
+        assert res.ok
+
+
+class TestPackageGate:
+    def test_a_clean_package_stays_clean(self, repo):
+        pkg = repo / "pkg"
+        pkg.mkdir()
+        (pkg / "a.py").write_text("x = 1\n", encoding="utf-8")
+        res = lint_gate.package_findings(repo, packages=["pkg"])
+        assert res.ok and res.scanned_files == 1
+
+    def test_a_regression_in_a_clean_package_fails(self, repo):
+        pkg = repo / "pkg"
+        pkg.mkdir()
+        (pkg / "a.py").write_text("def f():\n    return oops\n", encoding="utf-8")
+        res = lint_gate.package_findings(repo, packages=["pkg"])
+        assert [f.name for f in res.findings] == ["oops"]
+
+    def test_a_missing_package_is_not_a_silent_pass_for_the_others(self, repo):
+        pkg = repo / "pkg"
+        pkg.mkdir()
+        (pkg / "a.py").write_text("def f():\n    return oops\n", encoding="utf-8")
+        res = lint_gate.package_findings(repo, packages=["nope", "pkg"])
+        assert [f.name for f in res.findings] == ["oops"]

--- a/tests/cli/test_cli_undefined_names.py
+++ b/tests/cli/test_cli_undefined_names.py
@@ -33,37 +33,47 @@ says so, because a gate that cannot pass is a gate somebody disables.
 from __future__ import annotations
 
 import ast
+import sys
 from pathlib import Path
 
 import pytest
 
-pyflakes_checker = pytest.importorskip(
-    "pyflakes.checker",
+pytest.importorskip(
+    "pyflakes",
     reason="pyflakes is declared in ci/requirements-ov-surface.txt; a runner "
            "without it cannot enforce this gate",
 )
-from pyflakes import messages as pyflakes_messages  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+# ONE analyzer, shared with the differential gate. This file previously
+# carried its own pyflakes wrapper, and a second opinion about what counts as
+# an undefined name is how the two would eventually disagree about a build.
+from ci.lint_gate import undefined_names as _undefined_names_shared  # noqa: E402
 
 #: The package this gate covers. Chosen because it is at zero today and it is
 #: what an operator runs.
 GATED = Path("backend/core/ouroboros/cli")
 
-#: Packages knowingly NOT covered, with their counts at the time this gate
-#: landed. Named so nobody reads a passing run as a repo-wide clean bill.
+#: Packages knowingly NOT covered. Named so nobody reads a passing run as a
+#: repo-wide clean bill.
+#:
+#: `governance` and `battle_test` USED to be here (16 and 8 findings). Both
+#: reached zero and were promoted into `ci.lint_gate.DEFAULT_CLEAN_PACKAGES`,
+#: which is now the ratchet of record. What remains ungated is the rest of the
+#: repository — ~812 findings dominated by vendored `venv/` and
+#: `core/quarantine/`, held by the DIFFERENTIAL gate instead.
 UNGATED_KNOWN = {
-    "backend/core/ouroboros/governance": 16,
-    "backend/core/ouroboros/battle_test": 8,
+    "backend/core/quarantine": "excluded — quarantined by name",
+    "backend/api": "differential gate only",
 }
 
 
 def _undefined_names(path: Path):
-    src = path.read_text(encoding="utf-8", errors="replace")
-    tree = ast.parse(src, filename=str(path))
-    check = pyflakes_checker.Checker(tree, filename=str(path))
+    """Real (non-inert) findings only — delegated to the shared analyzer."""
     return [
-        (m.lineno, m.message % m.message_args)
-        for m in check.messages
-        if isinstance(m, pyflakes_messages.UndefinedName)
+        (f.lineno, f"undefined name '{f.name}'")
+        for f in _undefined_names_shared(path)
+        if not f.inert
     ]
 
 
@@ -89,13 +99,13 @@ def test_cli_package_has_no_undefined_names():
     )
 
 
-def test_the_gate_can_actually_fail():
+def test_the_gate_can_actually_fail(tmp_path):
     """Guards the guard. A detector that cannot fire proves nothing."""
-    tree = ast.parse("def f():\n    return no_such_name\n", filename="<probe>")
-    check = pyflakes_checker.Checker(tree, filename="<probe>")
-    found = [m for m in check.messages
-             if isinstance(m, pyflakes_messages.UndefinedName)]
-    assert found, "pyflakes did not flag an obviously undefined name"
+    probe = tmp_path / "probe.py"
+    probe.write_text("def f():\n    return no_such_name\n", encoding="utf-8")
+    assert _undefined_names(probe), (
+        "the shared analyzer did not flag an obviously undefined name"
+    )
 
 
 def test_ungated_packages_are_named_not_forgotten():
@@ -107,4 +117,17 @@ def test_ungated_packages_are_named_not_forgotten():
         assert (_repo_root() / pkg).is_dir(), (
             f"{pkg} is named as ungated but does not exist — this note has "
             "gone stale and would mislead the next reader"
+        )
+
+    # And the converse: anything claimed CLEAN must actually be gated, or the
+    # ratchet is a comment rather than a mechanism.
+    import sys as _sys
+    _sys.path.insert(0, str(_repo_root()))
+    from ci.lint_gate import DEFAULT_CLEAN_PACKAGES
+    assert str(GATED) in DEFAULT_CLEAN_PACKAGES, (
+        "this file gates cli/, so cli/ must be in the shared ratchet too"
+    )
+    for pkg in DEFAULT_CLEAN_PACKAGES:
+        assert pkg not in UNGATED_KNOWN, (
+            f"{pkg} is claimed both gated and ungated"
         )

--- a/tests/governance/test_a1_emit_probe.py
+++ b/tests/governance/test_a1_emit_probe.py
@@ -42,11 +42,27 @@ def _probe_lines(caplog):
     ]
 
 
+# LEVELS MOVED, MESSAGES DID NOT (PR #70529).
+#
+# `a1_trace` no longer buys operator visibility with severity. In-scope probe
+# lines are INFO carrying `operator=True` (which reaches the terminal in BOTH
+# presentation modes — WARNING never did once COCKPIT was raised to ERROR);
+# out-of-scope sensor lines are DEBUG and stay in `debug.log`, where every
+# auditor reads them. The message TEXT is byte-identical, so these assertions
+# are unchanged apart from the capture level.
+#
+# This file was missed when the contract changed — its sibling
+# `test_a1_trace_breadcrumbs.py` was updated and this one was not, so four
+# tests went red on `main`. Capturing at DEBUG covers every level the module
+# can now emit, which is what a test of MESSAGE CONTENT should have done from
+# the start.
+
+
 # --- (a) emit-then-ingest -> ordered probe --------------------------------
 
 
 def test_emit_then_ingest_records_ordered_probe(caplog):
-    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+    with caplog.at_level(logging.DEBUG, logger=a1_trace.logger.name):
         a1_trace.emit_probe("g-1", source="roadmap")
         a1_trace.probe_ingest_order("g-1")
     lines = _probe_lines(caplog)
@@ -63,7 +79,7 @@ def test_emit_then_ingest_records_ordered_probe(caplog):
 
 
 def test_ingest_without_emit_logs_missing(caplog):
-    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+    with caplog.at_level(logging.DEBUG, logger=a1_trace.logger.name):
         # No prior emit_probe for this goal — the sensor-op / Run-#17 mode.
         a1_trace.probe_ingest_order("g-sensor")
     lines = _probe_lines(caplog)
@@ -79,7 +95,7 @@ def test_ingest_without_emit_logs_missing(caplog):
 
 def test_orchestrator_off_is_captured(caplog, monkeypatch):
     monkeypatch.setenv("JARVIS_ROADMAP_ORCHESTRATOR_ENABLED", "false")
-    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+    with caplog.at_level(logging.DEBUG, logger=a1_trace.logger.name):
         a1_trace.emit_probe("g-2", source="roadmap")
     lines = _probe_lines(caplog)
     assert any("orchestrator_enabled=False" in m for m in lines), lines
@@ -87,7 +103,7 @@ def test_orchestrator_off_is_captured(caplog, monkeypatch):
 
 def test_orchestrator_on_is_captured(caplog, monkeypatch):
     monkeypatch.setenv("JARVIS_ROADMAP_ORCHESTRATOR_ENABLED", "true")
-    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+    with caplog.at_level(logging.DEBUG, logger=a1_trace.logger.name):
         a1_trace.emit_probe("g-3", source="roadmap")
     lines = _probe_lines(caplog)
     assert any("orchestrator_enabled=True" in m for m in lines), lines
@@ -117,7 +133,7 @@ def test_emit_probe_returns_none_observe_only():
 
 def test_gated_off_emits_no_probe_lines(caplog, monkeypatch):
     monkeypatch.setenv("JARVIS_A1_EMIT_PROBE_ENABLED", "false")
-    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+    with caplog.at_level(logging.DEBUG, logger=a1_trace.logger.name):
         a1_trace.emit_probe("g-5", source="roadmap")
         a1_trace.probe_ingest_order("g-5")
     assert not _probe_lines(caplog)
@@ -127,7 +143,7 @@ def test_master_trace_off_also_silences_probe(caplog, monkeypatch):
     # The probe rides the same surface; killing the master A1Trace flag
     # also silences the probe (defence in depth).
     monkeypatch.setenv("JARVIS_A1_TRACE_ENABLED", "false")
-    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+    with caplog.at_level(logging.DEBUG, logger=a1_trace.logger.name):
         a1_trace.emit_probe("g-6", source="roadmap")
         a1_trace.probe_ingest_order("g-6")
     assert not _probe_lines(caplog)

--- a/tests/governance/test_prime_admission_ticket.py
+++ b/tests/governance/test_prime_admission_ticket.py
@@ -1,0 +1,105 @@
+"""The admission claim must reach the seam that settles it.
+
+`PrimeProvider.generate` ran local-model admission and bound two locals:
+`_brain_for_adm` and a one-slot cell `_adm_reservation`. Their only consumer
+is `_generate_raw`, which is nested inside `_generate_impl` — a SIBLING
+method (5627..6153), not inside `generate` (5516..5624). There was no
+closure, so every `record_load_outcome` / `release_reservation` call raised
+`NameError` into an `except Exception: pass`.
+
+The comments recorded the right technique for the wrong topology: "a one-slot
+cell rather than a bare name: `_generate_raw` closes over it", and
+`_brain_for_adm` was pre-initialised specifically to avoid "a bare NameError
+the moment the binding block raises early". Correct defensive reasoning,
+applied in a scope the consumer cannot see.
+
+The cost was not telemetry. `release_reservation` hands back the soft VRAM
+claim, and its own comment says the ledger self-heals "only after a settle
+window during which every other worker is throttled by memory this one has
+definitively stopped wanting". So the claim was never returned early and
+local admission throttled workers against bytes nobody was using.
+
+A value that must cross a call boundary travels ALONG it.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+import backend.core.ouroboros.governance.providers as providers
+
+
+class TestTicket:
+    def test_is_frozen(self):
+        t = providers._AdmissionTicket(brain_id="b", reservation_id="r")
+        with pytest.raises(Exception):
+            t.brain_id = "other"  # type: ignore[misc]
+
+    def test_defaults_are_empty_and_unsettleable(self):
+        """Admission is best-effort. A ticket that claimed otherwise would
+        make the ledger record a load it never admitted."""
+        t = providers._AdmissionTicket()
+        assert t.brain_id is None and t.reservation_id is None
+        assert t.settleable is False
+
+    @pytest.mark.parametrize("kw", [
+        {"brain_id": "b"},
+        {"reservation_id": "r"},
+        {"brain_id": "b", "reservation_id": "r"},
+    ])
+    def test_settleable_when_either_half_is_present(self, kw):
+        assert providers._AdmissionTicket(**kw).settleable is True
+
+
+class TestItTravelsAlongTheCall:
+    """The wiring pin. `_generate_impl` accepting a ticket nobody passes
+    would be the wired-but-inert shape this repo names most often."""
+
+    def test_generate_impl_accepts_the_ticket(self):
+        sig = inspect.signature(providers.PrimeProvider._generate_impl)
+        assert "admission" in sig.parameters
+        assert sig.parameters["admission"].default is None, (
+            "a required parameter would break any caller that has no "
+            "admission to hand over"
+        )
+
+    def test_generate_passes_it(self):
+        """Structural, because driving the real `generate` needs a live
+        client. The call site is what regressed; the call site is pinned."""
+        src = inspect.getsource(providers.PrimeProvider.generate)
+        assert "_generate_impl(" in src
+        assert "admission=_AdmissionTicket(" in src, (
+            "generate() must hand the ticket to _generate_impl — without it "
+            "the settle seam is unreachable again"
+        )
+
+    def test_the_dead_cross_scope_names_are_gone(self):
+        """`_generate_raw` may not reference names from `generate`'s scope."""
+        src = inspect.getsource(providers.PrimeProvider._generate_impl)
+        assert "_adm_reservation[0]" not in src
+        assert "record_load_outcome(\n                        _brain_for_adm" not in src
+
+    def test_the_settle_seam_reads_the_ticket(self):
+        src = inspect.getsource(providers.PrimeProvider._generate_impl)
+        assert "admission.brain_id" in src
+        assert "admission.reservation_id" in src
+
+    def test_the_settle_seam_is_guarded_against_no_ticket(self):
+        """No admission taken means nothing to settle — not a crash."""
+        src = inspect.getsource(providers.PrimeProvider._generate_impl)
+        assert "if admission is not None:" in src
+
+
+def test_no_undefined_names_remain_in_the_generation_path():
+    """The measurement that opened this: four executable-position findings in
+    `providers.py`, all of them these two names."""
+    pytest.importorskip("pyflakes")
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    from ci.lint_gate import undefined_names
+
+    path = Path(inspect.getfile(providers))
+    real = [f for f in undefined_names(path) if not f.inert]
+    assert not real, f"executable-position undefined names remain: {real}"


### PR DESCRIPTION
## The measurement changed the plan

Of the 24 findings in `governance` + `battle_test`, **16 are inert** — names in annotation position in a module carrying `from __future__ import annotations` (never evaluated), plus one quoted annotation.

That includes **every name the blueprint asked me to build lazy dependency proxies for**: `aiohttp`, `FailoverTier` (not `FailoverTimer`), `BrainSelectionResult` (not `BrainContext`), `ToolCall`, `OperatorDecision`. Giving those runtime imports would trade **zero cost** for import time and circular-import risk — machinery for a non-problem, and strictly worse than leaving them alone. **They are left alone**, and the gate is taught not to report them.

| class | count |
|---|---|
| inert — annotation + `__future__` | 15 |
| inert — quoted annotation | 1 |
| **real** | **8** (→ 5 distinct defects) |

## The real ones — none was a missing import

**`providers.py` ×4.** `generate` (5516–5624) bound `_brain_for_adm` and a one-slot `_adm_reservation` cell. Their only consumer is `_generate_raw`, nested inside `_generate_impl` (5627–6153) — a **sibling** method. The comments recorded the right technique for the wrong topology (*"`_generate_raw` closes over it"*), and `_brain_for_adm` was pre-initialised specifically to avoid *"a bare NameError"*. Correct defensive reasoning, in a scope the consumer cannot see.

The cost wasn't telemetry. `release_reservation` hands back the soft VRAM claim, and its own comment says the ledger self-heals *"only after a settle window during which every other worker is throttled by memory this one has definitively stopped wanting."* Fixed with a frozen `_AdmissionTicket` that travels **along** the call.

**`doubleword_provider.py` `_ttft_ms`** — bound nowhere. A typo for `_pure_ttft_ms`, computed 29 lines above and already used twice. `STAGE_RT_HTTP_POST` was never recorded.

**`generate_runner.py` `validation` ×2 — the shipping path.** `validation` has no store anywhere in `run()`; it was carried from the inline orchestrator twin where it *is* bound. So the `in dir()` guard **always** evaluated False and **dynamic re-planning has been reasoning from empty failure context on every real op.** Made explicit rather than left as a guard that looks like it might fire. Wiring a real verdict through is a behavioural change with its own design question, and is deliberately not invented here.

**The `in dir()` guards** (orchestrator ×2, doubleword ×1) — runtime-safe, unverifiable by any static tool. A name that may be unbound is **initialised**, not interrogated.

## The gate

`ci-cd-pipeline.yml` runs `flake8 backend/ ... || true` — **the result is discarded**, which is why two NameErrors in the front door survived ten days. It can't simply be removed: ~812 findings exist, mostly vendored `venv/` and `core/quarantine`. So there are two, each honest about its scope:

- **Differential** — findings only on lines this branch touched. Legacy debt never fails a build; a new undefined name cannot land. *This would have caught both incidents on the commit that made them.*
- **Whole-package ratchet** — **1,412 files** across `cli` + `governance` + `battle_test`, all at zero. **Recursive**: a top-level-only sweep missed `phase_runners/generate_runner.py` entirely — exactly where this defect sat on the shipping path.

**Blindness is not a pass.** An unresolvable base ref *fails* under `--require-base` (CI sets it, with `fetch-depth: 0`) rather than reporting success.

19 hermetic tests build real git repos — a differential gate tested against a mocked diff would be testing the mock.

## Two of my own errors, caught by tests not review

1. My inert classifier first marked **any line containing any string literal** as a quoted annotation — which silently suppressed the real `validation` findings. Scoped to annotation positions only, with the reason recorded in the code.
2. **`test_a1_emit_probe.py` was red on `main`** — I missed it when PR #70529 moved `a1_trace`'s levels; I updated its sibling `test_a1_trace_breadcrumbs.py` and not this one. Four tests. Fixed here.

## Evidence

- Real findings across all three packages: **8 → 0**. Inert: 16, untouched by design.
- `ov surface` CI set: **471 passed**.
- Baselined against `main`: the 9 remaining failures in the wider governance sweep (`graduation_orchestrator` archive pins, topology AST pin, `execution_graph_progress_bridge` env-dependent defaults) are **identical on `main`** — 9 failed / 123 passed both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI gate that blocks new undefined names and fixes five real runtime NameErrors in `governance`. This stops silent failures on the generation path and ensures future diffs cannot introduce undefined names.

- `providers.py`: introduce frozen `_AdmissionTicket` and pass it to `_generate_impl`; use it to record load outcomes and release VRAM reservations on both success and failure (old: unresolved cross-scope names masked by blanket handlers; new: reservations are settled early, reducing worker throttling).
- `doubleword_provider.py`: fix `_ttft_ms` → `_pure_ttft_ms` so `STAGE_RT_HTTP_POST` records; initialize `_s35_stream_t0` and replace `in dir()` with an `is not None` check.
- `orchestrator.py`: initialize `validation = None` and replace `in dir()` guards with `is not None`.
- `phase_runners/generate_runner.py`: make the empty validation context explicit (`_fc = ""`, `_em = ""`) instead of a guard that never fires; no re-planning behavior invented here.
- Gate: add `ci/lint_gate.py` and `.github/workflows/lint-gate.yml`. Differential gate flags undefined names only on changed lines; whole-package ratchet holds `backend/core/ouroboros/cli`, `backend/core/ouroboros/governance`, and `backend/core/ouroboros/battle_test` at zero. Excludes vendored/quarantined trees. Ignores annotation-only names under `from __future__ import annotations` and quoted annotations. Fails when the base ref is unreadable with `--require-base`.

**Review and rollout notes**

- CI now fails on new undefined names; developers can run `python ci/lint_gate.py --root .` locally. Use a non-shallow clone or omit `--require-base` when testing locally.
- No API changes. Runtime effects are limited to correct stage telemetry and timely VRAM reservation release.

<sup>Written for commit a0d05b8dc93385f5c09ff0bb955fcd99a075aa2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

