### PR TITLE
fix: A path is not an identity, a default is not a switch, and the verdict was always on the context

### DIFF
--- a/backend/core/ouroboros/governance/background_agent_pool.py
+++ b/backend/core/ouroboros/governance/background_agent_pool.py
@@ -1418,8 +1418,19 @@ class BackgroundAgentPool:
                                     "provider_route", "",
                                 ) or "background"
                             )
-                            _s195_model_id = _s195_get_topology().model_for_route(
-                                _s195_route,
+                            # Phase 10 Slice 5a deletion-side: the v1
+                            # `model_for_route` is yaml-direct and blind to the
+                            # v2 catalog. `model_for_route_unified` is a drop-in
+                            # superset — same signature, same return type, and
+                            # it DELEGATES to v1 whenever
+                            # `JARVIS_TOPOLOGY_SENTINEL_ENABLED` is off, so the
+                            # legacy path stays byte-identical. This call site
+                            # survived the migration and was the last v1 caller
+                            # in production `governance/`.
+                            _s195_model_id = (
+                                _s195_get_topology().model_for_route_unified(
+                                    _s195_route,
+                                )
                             )
                         except Exception:  # noqa: BLE001
                             _s195_model_id = None

--- a/backend/core/ouroboros/governance/cleanup_invariants.py
+++ b/backend/core/ouroboros/governance/cleanup_invariants.py
@@ -70,9 +70,49 @@ _EXPECTED_ARCHIVE_PATHS: tuple = (
 # Repo-relative paths where the modules MUST NOT live post-cleanup
 # (regression catch — if a refactor accidentally restores them).
 _FORBIDDEN_PRODUCTION_PATHS: tuple = (
-    "backend/core/ouroboros/governance/graduation_orchestrator.py",
     "backend/core/ouroboros/governance/graduation_tracker.py",
 )
+
+#: (archive, production) pairs judged by IDENTITY rather than by path.
+#:
+#: A PATH IS A PROXY, AND THIS ONE STOPPED MATCHING THE PROPERTY.
+#: `graduation_orchestrator.py` was banned by path. Slice 132 (#69347) and
+#: Slice 136 (#69351) then created a genuinely different module at that path —
+#: the Cognitive Graduation Matrix, 312 lines exposing `graduate` /
+#: `graduate_all` / `GraduationOutcome`, against the archived module's 1,137
+#: lines exposing `GraduationOrchestrator` / `GraduationPhase` /
+#: `EphemeralUsageTracker`. Zero symbol overlap; only the NAME is shared, and
+#: `phase9_orchestrator.py` already documents the two as distinct.
+#:
+#: So this pin reported a §32.5 violation nobody committed, on every run, for
+#: months. The property §32.5 actually protects is "the archived
+#: implementation has not come back" — which is about CODE, not a filename.
+#: The archived symbol set is read FROM THE ARCHIVE at validation time, so
+#: amending the archive keeps the check honest without editing this list.
+_ARCHIVE_IDENTITY_PAIRS: tuple = (
+    (
+        "archive/legacy/graduation_orchestrator_2026_04_06.py",
+        "backend/core/ouroboros/governance/graduation_orchestrator.py",
+    ),
+)
+
+
+def _top_level_symbols(path: "Path") -> set:
+    """Top-level class/function names a module defines. NEVER raises.
+
+    An unparseable or unreadable file yields an empty set, and the caller
+    treats an empty ARCHIVE set as "cannot judge" rather than as "clean" —
+    a comparison that passes because it read nothing is a vacuous pass."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except Exception:  # noqa: BLE001 — a pin must never raise
+        return set()
+    return {
+        node.name for node in tree.body
+        if isinstance(
+            node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef),
+        )
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -243,6 +283,29 @@ def _validate_archive_provenance(
                 f"forbidden production path re-introduced: "
                 f"{rel} (archived per §32.5; remove and "
                 f"replace with M10 substrate)"
+            )
+
+    # IDENTITY, not path — see `_ARCHIVE_IDENTITY_PAIRS`. An absent
+    # production file is the strongest pass; a present one must share no
+    # top-level symbol with the archived implementation.
+    for archived_rel, production_rel in _ARCHIVE_IDENTITY_PAIRS:
+        production = root / production_rel
+        if not production.exists():
+            continue
+        archived_syms = _top_level_symbols(root / archived_rel)
+        if not archived_syms:
+            # Cannot judge: say so rather than pass vacuously.
+            violations.append(
+                f"archive unreadable for identity check: {archived_rel} — "
+                f"cannot prove {production_rel} is not a resurrection"
+            )
+            continue
+        overlap = archived_syms & _top_level_symbols(production)
+        if overlap:
+            violations.append(
+                f"archived implementation resurrected at "
+                f"{production_rel}: shares {sorted(overlap)} with "
+                f"{archived_rel} (§32.5)"
             )
 
     # Ensure provenance README exists so future operators know

--- a/backend/core/ouroboros/governance/execution_graph_progress_bridge.py
+++ b/backend/core/ouroboros/governance/execution_graph_progress_bridge.py
@@ -822,9 +822,33 @@ def register_shipped_invariants() -> list:
         "execution_graph_progress_bridge.py"
     )
 
-    def _validate_master_default_false(
+    def _validate_master_switch_honors_explicit_off(
         tree: "ast.Module", source: str,  # noqa: ARG001
     ) -> tuple:
+        """A GRADUATED flag must still be switchable OFF.
+
+        THIS PIN OUTLIVED ITS OWN PREMISE. It was
+        ``master_default_false`` and AST-asserted that
+        ``master_enabled()`` contained ``if raw == "": return False`` —
+        the §33.1 pre-graduation contract. The capability GRADUATED on
+        2026-07-24 (#70086, cockpit agentic-visibility: observability-
+        only, zero authority) and the function now returns True on an
+        empty string, exactly as its docstring says. The pin kept
+        asserting the retired state and failed on every run.
+
+        A pin whose premise expired is not deleted here — the property
+        that still matters is that graduation did not weld the switch
+        shut. So it now asserts the POST-graduation guarantee: the
+        function must consult a truthiness set, which is what makes an
+        explicit ``0`` / ``false`` turn the bridge off. §33.1's real
+        subject is operator control, and that survives graduation even
+        though the default does not.
+
+        Note the DEFAULT itself is deliberately NOT re-asserted here.
+        `tests/governance/test_agentic_cockpit_visibility.py` owns that
+        claim; two files asserting one default is precisely how this
+        one came to contradict the code it guards.
+        """
         violations: list = []
         target_func = None
         for node in ast.walk(tree):
@@ -837,44 +861,19 @@ def register_shipped_invariants() -> list:
         if target_func is None:
             violations.append("master_enabled() missing")
             return tuple(violations)
-        empty_returns_false = False
+        honors_off = False
         for sub in ast.walk(target_func):
-            if not isinstance(sub, ast.If):
-                continue
-            for cmp_node in ast.walk(sub.test):
-                if not isinstance(cmp_node, ast.Compare):
-                    continue
-                if not cmp_node.ops or not isinstance(
-                    cmp_node.ops[0], ast.Eq,
-                ):
-                    continue
-                operand_empty = False
-                for operand in (
-                    cmp_node.left, *cmp_node.comparators,
-                ):
-                    if (
-                        isinstance(operand, ast.Constant)
-                        and operand.value == ""
-                    ):
-                        operand_empty = True
-                        break
-                if not operand_empty:
-                    continue
-                for stmt in sub.body:
-                    if isinstance(stmt, ast.Return) and (
-                        isinstance(stmt.value, ast.Constant)
-                        and stmt.value.value is False
-                    ):
-                        empty_returns_false = True
-                        break
-                if empty_returns_false:
-                    break
-            if empty_returns_false:
+            # `raw in _TRUTHY` (or any membership test) is the shape
+            # that lets an explicit falsy value return False.
+            if isinstance(sub, ast.Compare) and any(
+                isinstance(op, ast.In) for op in sub.ops
+            ):
+                honors_off = True
                 break
-        if not empty_returns_false:
+        if not honors_off:
             violations.append(
-                "master_enabled() MUST return False on "
-                "empty env-var string per §33.1"
+                "master_enabled() MUST consult a truthiness set so an "
+                "explicit off value can disable a GRADUATED flag"
             )
         return tuple(violations)
 
@@ -1163,14 +1162,15 @@ def register_shipped_invariants() -> list:
         ShippedCodeInvariant(
             invariant_name=(
                 "execution_graph_progress_bridge_"
-                "master_default_false"
+                "master_switch_honors_explicit_off"
             ),
             target_file=target,
             description=(
-                "Phase 3 A2 — §33.1 master flag stays "
-                "default-FALSE."
+                "Graduated 2026-07-24 (#70086): the default moved to "
+                "TRUE, so the surviving guarantee is that an explicit "
+                "off value still disables the bridge."
             ),
-            validate=_validate_master_default_false,
+            validate=_validate_master_switch_honors_explicit_off,
         ),
         ShippedCodeInvariant(
             invariant_name=(

--- a/backend/core/ouroboros/governance/op_context.py
+++ b/backend/core/ouroboros/governance/op_context.py
@@ -365,6 +365,70 @@ class ValidationResult:
     adapter_names_run: Tuple[str, ...] = ()      # e.g. ("python",) or ("python", "cpp")
 
 
+#: Cap on the summary handed to the re-planner. The field's own comment
+#: promises "<=300 chars"; a promise nothing enforces is a promise, and an
+#: unbounded string reaches a prompt.
+REPLAN_SUMMARY_MAX_CHARS: int = 300
+
+
+def replan_inputs(validation: Any) -> Tuple[str, str]:
+    """``(failure_class, short_summary)`` for the dynamic re-planner.
+
+    THE ONE READER, because there are two callers and they have already
+    drifted once. `generate_runner.run()` — the SHIPPING path — referenced a
+    bare `validation` that has no binding anywhere in its scope, guarded by
+    `if 'validation' in dir()`. The guard therefore always evaluated False and
+    re-planning ran on empty inputs on every real op, while the inline
+    orchestrator twin read a real verdict. One helper, both call sites.
+
+    NO NEW VERDICT TYPE. :class:`ValidationResult` is already frozen, already
+    carries exactly these two fields, and is already carried on
+    :class:`OperationContext` — `advance()` uses ``dataclasses.replace``, so a
+    verdict set at VALIDATE survives into a GENERATE retry, which is precisely
+    the "previous attempt's verdict" the re-planner wants. Defining a parallel
+    dataclass would be a second spelling of a value that already exists.
+
+    TOTAL BY CONSTRUCTION — every degenerate input maps to a defined state,
+    because the re-planner must degrade rather than fly blind or raise:
+
+    * ``None`` — no VALIDATE has run yet (the first GENERATE attempt, or an
+      op that failed before validation). Returns ``("", "")``: the honest
+      "no evidence" state, which `DynamicRePlanner` already tolerates.
+    * **evaluator crashed / verdict never set** — indistinguishable from the
+      above at this seam, and deliberately so. Both mean "no verdict
+      exists"; inventing a third state would be claiming knowledge about WHY
+      that this reader does not have.
+    * **foreign or malformed object** — read by ``getattr`` with defaults, so
+      a duck-typed stand-in (tests, a future verdict type) works and a
+      missing attribute degrades instead of raising.
+    * **non-string fields** — coerced with ``str()``. A failure_class that
+      arrived as an enum or ``None`` must not put ``"None"`` into a prompt,
+      so falsy values normalise to ``""``.
+    * **oversized summary** — truncated to :data:`REPLAN_SUMMARY_MAX_CHARS`.
+
+    NEVER raises."""
+    if validation is None:
+        return ("", "")
+    try:
+        raw_fc = getattr(validation, "failure_class", None)
+        raw_em = getattr(validation, "short_summary", None)
+    except Exception:  # noqa: BLE001 — a hostile property must not break GENERATE
+        return ("", "")
+
+    def _clean(value: Any, limit: Optional[int] = None) -> str:
+        if not value:
+            return ""
+        try:
+            out = str(value).strip()
+        except Exception:  # noqa: BLE001
+            return ""
+        if limit is not None and len(out) > limit:
+            out = out[:limit]
+        return out
+
+    return (_clean(raw_fc), _clean(raw_em, REPLAN_SUMMARY_MAX_CHARS))
+
+
 @dataclass(frozen=True)
 class ApprovalDecision:
     """Context-embedded approval decision.

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -7515,10 +7515,19 @@ class GovernedOrchestrator:
                     #       INSUFFICIENT_EVIDENCE / DISABLED / FAILED.
                     _replan_text = ""
                     try:
-                        _fc = (validation.failure_class or ""
-                               ) if validation is not None else ""
-                        _em = (validation.short_summary or ""
-                               ) if validation is not None else ""
+                        # ONE READER, shared with `generate_runner` — the
+                        # two call sites have already drifted once, which is
+                        # how the shipping path spent months re-planning on
+                        # empty inputs while this twin read a real verdict.
+                        # Prefers the context (which VALIDATE publishes and
+                        # `advance()` carries forward) and falls back to this
+                        # scope's local, so neither source can go stale.
+                        from backend.core.ouroboros.governance.op_context import (  # noqa: E501,PLC0415
+                            replan_inputs as _replan_inputs,
+                        )
+                        _fc, _em = _replan_inputs(
+                            getattr(ctx, "validation", None) or validation
+                        )
                         _attempt_num = self._config.max_generate_retries - generate_retries_remaining + 1
                         # Stage 1 — structural falsification (proactive)
                         try:

--- a/backend/core/ouroboros/governance/phase_runners/generate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/generate_runner.py
@@ -399,6 +399,9 @@ class GENERATERunner(PhaseRunner):
         self._consciousness_bridge = consciousness_bridge
 
     async def run(self, ctx: OperationContext) -> PhaseResult:
+        from backend.core.ouroboros.governance.op_context import (  # noqa: PLC0415
+            replan_inputs as _replan_inputs,
+        )
         orch = self._orchestrator
         _serpent = self._serpent
         _consciousness_bridge = self._consciousness_bridge
@@ -2253,24 +2256,28 @@ class GENERATERunner(PhaseRunner):
                 try:
                     from backend.core.ouroboros.governance.self_evolution import DynamicRePlanner
                     _attempt_num = orch._config.max_generate_retries - generate_retries_remaining + 1
-                    # NO VALIDATION VERDICT EXISTS IN THIS SCOPE.
+                    # THE VERDICT WAS ALWAYS REACHABLE — from `ctx`, not from
+                    # a local. `validation` has no binding anywhere in
+                    # `run()`; it was carried over from the inline
+                    # orchestrator twin, where it IS bound at the VALIDATE
+                    # seam. The `in dir()` guard therefore always evaluated
+                    # False, and dynamic re-planning ran on empty failure
+                    # context on every real op of the SHIPPING path.
                     #
-                    # `validation` has no binding anywhere in `run()`; it was
-                    # carried over from the inline orchestrator twin, where it
-                    # IS bound (at the VALIDATE seam). The `in dir()` guard
-                    # therefore always evaluated False here, so these were
-                    # always "" — and this is the SHIPPING path
-                    # (`JARVIS_PHASE_RUNNER_GATE_EXTRACTED`). Dynamic
-                    # re-planning has been reasoning from empty failure
-                    # context on every real op.
+                    # `validate_runner` publishes the verdict with
+                    # `ctx.advance(GATE, validation=best_validation)`, and
+                    # `advance()` uses `dataclasses.replace` — so every field
+                    # not explicitly overridden carries forward, and a verdict
+                    # set at VALIDATE survives into the next GENERATE attempt.
+                    # That is exactly the "previous pass's verdict" this block
+                    # wants, and it needed no new machinery to obtain.
                     #
-                    # Made explicit rather than left as a guard that looks
-                    # like it might sometimes fire. Wiring a real verdict
-                    # through to this seam is a behavioural change with its
-                    # own design question — which verdict, from which
-                    # attempt — and is deliberately NOT invented here.
-                    _fc = ""
-                    _em = ""
+                    # `replan_inputs` is TOTAL: a missing verdict (first
+                    # attempt, or an evaluator that never produced one) yields
+                    # ("", "") — the same honest no-evidence state this code
+                    # already degraded to, now reached deliberately instead of
+                    # by accident.
+                    _fc, _em = _replan_inputs(getattr(ctx, "validation", None))
                     _replan = DynamicRePlanner.suggest_replan(_fc, _em, _attempt_num)
                     if _replan:
                         _replan_text = DynamicRePlanner.format_for_prompt(_replan)

--- a/tests/governance/test_cleanup_arc_slice1.py
+++ b/tests/governance/test_cleanup_arc_slice1.py
@@ -39,10 +39,51 @@ _EXPECTED_ARCHIVE_PATHS = (
 )
 
 _FORBIDDEN_PRODUCTION_PATHS = (
-    "backend/core/ouroboros/governance/graduation_orchestrator.py",
     "backend/core/ouroboros/governance/graduation_tracker.py",
     "tests/governance/test_graduation_orchestrator.py",
 )
+
+#: archive -> the production path its implementation must never return to.
+#:
+#: WHY THIS REPLACED A PATH BAN FOR `graduation_orchestrator`
+#: ---------------------------------------------------------
+#: The original pin forbade the PATH. Slice 132 (#69347) and Slice 136
+#: (#69351) then created a genuinely DIFFERENT module at that path — the
+#: Cognitive Graduation Matrix, 312 lines exposing `graduate` /
+#: `graduate_all` / `GraduationOutcome`, against the archived module's 1,137
+#: lines exposing `GraduationOrchestrator` / `GraduationPhase` /
+#: `EphemeralUsageTracker`. ZERO symbol overlap; only the name is shared, and
+#: `phase9_orchestrator.py` already documents the two as distinct ("different
+#: scope", "graduation_orchestrator_archived_only").
+#:
+#: So the pin failed for a module it was never written about. A path is a
+#: PROXY for the property that matters — "the archived implementation has not
+#: come back" — and a proxy that cannot tell one module from another reports a
+#: violation nobody committed. The check below tests IDENTITY instead, and
+#: derives the archived symbol set FROM THE ARCHIVE at test time, so it stays
+#: correct if the archive is ever amended.
+_ARCHIVE_IDENTITY_PAIRS = (
+    (
+        "archive/legacy/graduation_orchestrator_2026_04_06.py",
+        "backend/core/ouroboros/governance/graduation_orchestrator.py",
+    ),
+)
+
+
+def _top_level_symbols(path: Path) -> set:
+    """Top-level class/function names defined by a module. NEVER raises."""
+    import ast as _ast
+    try:
+        tree = _ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except Exception:  # noqa: BLE001 — unparseable proves nothing either way
+        return set()
+    return {
+        node.name for node in tree.body
+        if isinstance(
+            node,
+            (_ast.ClassDef, _ast.FunctionDef, _ast.AsyncFunctionDef),
+        )
+    }
 
 
 @pytest.mark.parametrize("rel_path", _EXPECTED_ARCHIVE_PATHS)
@@ -71,6 +112,40 @@ def test_forbidden_production_path_absent(rel_path):
     )
 
 
+@pytest.mark.parametrize(
+    "archived_rel,production_rel", _ARCHIVE_IDENTITY_PAIRS,
+)
+def test_archived_implementation_is_not_resurrected(
+    archived_rel, production_rel,
+):
+    """The ARCHIVED CODE must not return — a reused name is not a relapse.
+
+    An absent production path is the strongest possible pass. When one does
+    exist, it must share no top-level symbol with the archived module: that is
+    what distinguishes "someone restored the retired implementation" from
+    "a later slice reused a good name for different code"."""
+    root = _repo_root()
+    production = root / production_rel
+    if not production.exists():
+        return                      # nothing there at all — strongest pass
+
+    archived = root / archived_rel
+    assert archived.exists(), (
+        f"archive missing: {archived_rel} — the pin cannot judge a "
+        "resurrection without the thing it is comparing against"
+    )
+    archived_syms = _top_level_symbols(archived)
+    assert archived_syms, (
+        f"no symbols parsed from {archived_rel}; the comparison would pass "
+        "vacuously and prove nothing"
+    )
+    overlap = archived_syms & _top_level_symbols(production)
+    assert not overlap, (
+        f"archived implementation resurrected at {production_rel}: "
+        f"shares {sorted(overlap)} with {archived_rel}"
+    )
+
+
 def test_archive_readme_exists():
     readme = _repo_root() / "archive" / "legacy" / "README.md"
     assert readme.exists()
@@ -90,13 +165,11 @@ def test_archived_module_not_importable_via_production_path():
     """The archived modules MUST NOT be importable via their
     original dotted production path. Any importer that tried
     would get ImportError."""
-    spec = importlib.util.find_spec(
-        "backend.core.ouroboros.governance.graduation_orchestrator",
-    )
-    assert spec is None, (
-        "graduation_orchestrator still importable from "
-        "production path — archive may have failed"
-    )
+    # `graduation_orchestrator` is DELIBERATELY importable again: a different
+    # module (Slice 132/136) took the name. Its identity — not its
+    # importability — is what `test_archived_implementation_is_not_resurrected`
+    # guards. Asserting un-importability here would forbid a name rather than
+    # an implementation.
     spec = importlib.util.find_spec(
         "backend.core.ouroboros.governance.graduation_tracker",
     )
@@ -182,7 +255,11 @@ def test_cleanup_pins_pass_validation():
     ]
     assert not cleanup_violations, (
         "cleanup pin violations: " + "; ".join(
-            f"{v.invariant_name}: {v.violation}"
+            # `.detail` — `InvariantViolation` has no `.violation`. This
+            # f-string is only evaluated WHEN violations exist, so the
+            # AttributeError replaced the report at the one moment it
+            # mattered: a diagnostic that fails precisely when it is needed.
+            f"{v.invariant_name}: {v.detail}"
             for v in cleanup_violations
         )
     )

--- a/tests/governance/test_phase_3_a2_execution_graph_progress_bridge.py
+++ b/tests/governance/test_phase_3_a2_execution_graph_progress_bridge.py
@@ -28,7 +28,7 @@ Pinned coverage (~38 tests):
     oversized-file
   * 7 AST pins clean (parametrized) + each fires on
     synthetic regression:
-      - master_default_false
+      - master_switch_honors_explicit_off
       - authority_asymmetry
       - read_only (synthetic regression: forbid mutation)
       - composes_canonical_tracker
@@ -92,14 +92,28 @@ def tmp_ledger(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_master_default_false(monkeypatch):
-    monkeypatch.delenv(
-        "JARVIS_EXEC_GRAPH_BRIDGE_ENABLED", raising=False,
-    )
+def test_master_switch_honors_explicit_off(monkeypatch):
+    """A GRADUATED flag must still be switchable off.
+
+    WAS `test_master_default_false`. The bridge graduated on 2026-07-24
+    (#70086) and `master_enabled()` returns True on an empty env var, exactly
+    as its docstring states. This file kept asserting the pre-graduation
+    default while `tests/governance/test_agentic_cockpit_visibility.py:124`
+    asserted the graduated one — TWO test files holding opposite contracts
+    for one flag, which is how four tests sat red.
+
+    The DEFAULT is deliberately not re-asserted here; that claim has an owner.
+    Two files asserting one default is what produced the contradiction. What
+    this file owns is the SWITCH: graduation moved the default, and must not
+    have welded the flag on."""
     from backend.core.ouroboros.governance.execution_graph_progress_bridge import (  # noqa: E501
         master_enabled,
     )
-    assert master_enabled() is False
+    for off in ("0", "false", "no", "off"):
+        monkeypatch.setenv("JARVIS_EXEC_GRAPH_BRIDGE_ENABLED", off)
+        assert master_enabled() is False, off
+    monkeypatch.setenv("JARVIS_EXEC_GRAPH_BRIDGE_ENABLED", "1")
+    assert master_enabled() is True
 
 
 def test_verbose_default_false(monkeypatch):
@@ -184,8 +198,11 @@ def test_should_emit_defensive():
 def test_recorder_noop_when_master_off(
     monkeypatch, tmp_ledger,
 ):
-    monkeypatch.delenv(
-        "JARVIS_EXEC_GRAPH_BRIDGE_ENABLED", raising=False,
+    # EXPLICIT off. Expressing a state by OMISSION is the defect: this read
+    # "off" from the default, so it broke the day the capability graduated
+    # even though the off-behaviour it tests never changed.
+    monkeypatch.setenv(
+        "JARVIS_EXEC_GRAPH_BRIDGE_ENABLED", "0",
     )
     from backend.core.ouroboros.governance.execution_graph_progress_bridge import (  # noqa: E501
         record_graph_event,
@@ -398,7 +415,7 @@ def test_read_missing_ledger_returns_empty(tmp_path):
 
 @pytest.mark.parametrize(
     "pin_name", [
-        "execution_graph_progress_bridge_master_default_false",  # noqa: E501
+        "execution_graph_progress_bridge_master_switch_honors_explicit_off",  # noqa: E501
         "execution_graph_progress_bridge_authority_asymmetry",
         "execution_graph_progress_bridge_read_only",
         (
@@ -660,8 +677,9 @@ def test_singleton_lifecycle(monkeypatch):
 async def test_start_default_bridge_master_off(
     monkeypatch,
 ):
-    monkeypatch.delenv(
-        "JARVIS_EXEC_GRAPH_BRIDGE_ENABLED", raising=False,
+    # EXPLICIT off — see `test_recorder_noop_when_master_off`.
+    monkeypatch.setenv(
+        "JARVIS_EXEC_GRAPH_BRIDGE_ENABLED", "0",
     )
     from backend.core.ouroboros.governance.execution_graph_progress_bridge import (  # noqa: E501
         start_default_bridge,

--- a/tests/governance/test_replan_verdict_wiring.py
+++ b/tests/governance/test_replan_verdict_wiring.py
@@ -1,0 +1,171 @@
+"""The re-planner reasons from the verdict, on BOTH paths.
+
+`generate_runner.run()` — the SHIPPING path
+(`JARVIS_PHASE_RUNNER_GATE_EXTRACTED`) — read a bare `validation` that has no
+binding anywhere in its scope, guarded by `if 'validation' in dir()`. The
+guard therefore always evaluated False, and dynamic re-planning ran on empty
+failure context on every real op, while the inline orchestrator twin read a
+real verdict. Runner parity, again.
+
+NO NEW VERDICT TYPE WAS DEFINED. `ValidationResult` is already frozen, already
+carries `failure_class` + `short_summary`, and is already on
+`OperationContext`. `advance()` uses `dataclasses.replace`, so a verdict set
+at VALIDATE carries forward into the next GENERATE attempt — which is exactly
+the "previous pass's verdict" the re-planner wants. A parallel dataclass would
+have been a second spelling of a value that already existed.
+
+`replan_inputs` is total: every degenerate input maps to a defined state,
+because a re-planner must degrade rather than fly blind or raise.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.op_context import (
+    REPLAN_SUMMARY_MAX_CHARS,
+    ValidationResult,
+    replan_inputs,
+)
+
+
+def _verdict(**kw) -> ValidationResult:
+    base = dict(passed=False, best_candidate=None,
+                validation_duration_s=0.0, error="e")
+    base.update(kw)
+    return ValidationResult(**base)
+
+
+class TestTotality:
+    def test_a_real_verdict_reaches_the_replanner(self):
+        assert replan_inputs(
+            _verdict(failure_class="test", short_summary="2 tests failed")
+        ) == ("test", "2 tests failed")
+
+    def test_no_verdict_is_the_honest_empty_state(self):
+        """First GENERATE attempt: nothing has validated yet."""
+        assert replan_inputs(None) == ("", "")
+
+    def test_a_crashed_evaluator_is_indistinguishable_and_deliberately_so(self):
+        """Both mean 'no verdict exists'. Inventing a third state would claim
+        knowledge about WHY that this reader does not have."""
+        assert replan_inputs(None) == ("", "")
+
+    def test_falsy_fields_never_become_the_string_None(self):
+        """A `None` failure_class must not put "None" into a prompt."""
+        assert replan_inputs(_verdict()) == ("", "")
+
+    def test_a_hostile_object_degrades_instead_of_raising(self):
+        class _Hostile:
+            @property
+            def failure_class(self):
+                raise RuntimeError("boom")
+
+        assert replan_inputs(_Hostile()) == ("", "")
+
+    def test_a_duck_typed_verdict_is_accepted(self):
+        """Tests and any future verdict type work without inheritance."""
+        class _Duck:
+            failure_class = "build"
+            short_summary = "compile error"
+        assert replan_inputs(_Duck()) == ("build", "compile error")
+
+    def test_an_oversized_summary_is_truncated(self):
+        """The field's own comment promises <=300 chars; nothing enforced it,
+        and this string reaches a prompt."""
+        _, em = replan_inputs(_verdict(short_summary="x" * 5000))
+        assert len(em) == REPLAN_SUMMARY_MAX_CHARS
+
+    def test_non_string_fields_are_coerced(self):
+        class _Enum:
+            def __str__(self): return "infra"
+        class _Odd:
+            failure_class = _Enum()
+            short_summary = 12345
+        assert replan_inputs(_Odd()) == ("infra", "12345")
+
+    def test_whitespace_only_summary_normalises_to_empty(self):
+        assert replan_inputs(_verdict(short_summary="   \n ")) == ("", "")
+
+
+class TestTheVerdictCanActuallyReachGenerate:
+    def test_advance_carries_validation_forward(self):
+        """The load-bearing assumption: a verdict set at VALIDATE survives
+        into the next GENERATE attempt. If `advance()` ever stopped carrying
+        fields forward, the wiring below would silently go empty again."""
+        import dataclasses
+        from backend.core.ouroboros.governance.op_context import OperationContext
+        src = inspect.getsource(OperationContext.advance)
+        assert "dataclasses.replace" in src or "replace(" in src, (
+            "advance() must carry unspecified fields forward, or a verdict "
+            "set at VALIDATE cannot reach a GENERATE retry"
+        )
+        assert dataclasses is not None
+
+    def test_validate_runner_publishes_the_verdict_onto_the_context(self):
+        path = (Path(__file__).resolve().parents[2]
+                / "backend/core/ouroboros/governance/phase_runners"
+                / "validate_runner.py")
+        src = path.read_text(encoding="utf-8")
+        assert "validation=best_validation" in src, (
+            "VALIDATE must publish the verdict onto the context, or GENERATE "
+            "has nothing to read"
+        )
+
+
+class TestBothPathsUseTheOneReader:
+    """The drift that caused this: two call sites, one of them wrong."""
+
+    @pytest.mark.parametrize("rel", [
+        "backend/core/ouroboros/governance/phase_runners/generate_runner.py",
+        "backend/core/ouroboros/governance/orchestrator.py",
+    ])
+    def test_call_site_uses_replan_inputs(self, rel):
+        src = (Path(__file__).resolve().parents[2] / rel).read_text(
+            encoding="utf-8")
+        assert "_replan_inputs(" in src, f"{rel} must use the shared reader"
+
+    @pytest.mark.parametrize("rel", [
+        "backend/core/ouroboros/governance/phase_runners/generate_runner.py",
+        "backend/core/ouroboros/governance/orchestrator.py",
+    ])
+    def test_the_dir_guard_is_gone(self, rel):
+        """AST, not substring.
+
+        A substring check flagged the COMMENT that documents the removed
+        guard — a detector that cannot tell code from prose about code. The
+        same correction the lint gate needed when it mistook any line with a
+        string literal for a quoted annotation."""
+        tree = ast.parse(
+            (Path(__file__).resolve().parents[2] / rel).read_text(
+                encoding="utf-8")
+        )
+        offenders = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Compare):
+                continue
+            if not any(isinstance(op, ast.In) for op in node.ops):
+                continue
+            for cmp_to in node.comparators:
+                if (isinstance(cmp_to, ast.Call)
+                        and isinstance(cmp_to.func, ast.Name)
+                        and cmp_to.func.id == "dir"):
+                    offenders.append(getattr(node, "lineno", "?"))
+        assert not offenders, (
+            f"{rel} still interrogates the scope with `in dir()` at lines "
+            f"{offenders} instead of reading the context — the idiom no "
+            "static tool can verify"
+        )
+
+    def test_generate_runner_has_no_undefined_names(self):
+        pytest.importorskip("pyflakes")
+        import sys
+        root = Path(__file__).resolve().parents[2]
+        sys.path.insert(0, str(root))
+        from ci.lint_gate import undefined_names
+        path = (root / "backend/core/ouroboros/governance/phase_runners"
+                / "generate_runner.py")
+        assert not [f for f in undefined_names(path) if not f.inert]

--- a/tests/governance/test_slice_5b_consolidation_graduation.py
+++ b/tests/governance/test_slice_5b_consolidation_graduation.py
@@ -48,12 +48,44 @@ def test_slice1_archived_files_exist():
 
 
 def test_slice1_production_paths_absent():
+    """The THIRD copy of this check, and the same proxy defect in all of them.
+
+    A path ban asks "is this filename in use", when §32.5 protects "has the
+    archived IMPLEMENTATION come back". Slice 132 (#69347) / Slice 136
+    (#69351) put a genuinely different module at
+    `governance/graduation_orchestrator.py` — 312 lines exposing `graduate` /
+    `graduate_all` / `GraduationOutcome`, against the archive's 1,137 exposing
+    `GraduationOrchestrator` / `GraduationPhase` / `EphemeralUsageTracker`.
+    Zero symbol overlap; only the name is shared.
+
+    The two paths that are genuinely still absent keep the cheap check. The
+    reused name is judged by identity, delegated to the ONE authority
+    (`cleanup_invariants`) rather than re-implemented a fourth time."""
     for rel in (
-        "backend/core/ouroboros/governance/graduation_orchestrator.py",  # noqa: E501
         "backend/core/ouroboros/governance/graduation_tracker.py",
         "tests/governance/test_graduation_orchestrator.py",
     ):
         assert not (_repo_root() / rel).exists()
+
+    from backend.core.ouroboros.governance.cleanup_invariants import (
+        _ARCHIVE_IDENTITY_PAIRS,
+        _top_level_symbols,
+    )
+    root = _repo_root()
+    for archived_rel, production_rel in _ARCHIVE_IDENTITY_PAIRS:
+        production = root / production_rel
+        if not production.exists():
+            continue
+        archived_syms = _top_level_symbols(root / archived_rel)
+        assert archived_syms, (
+            f"archive unreadable: {archived_rel} — the comparison would pass "
+            "vacuously"
+        )
+        overlap = archived_syms & _top_level_symbols(production)
+        assert not overlap, (
+            f"archived implementation resurrected at {production_rel}: "
+            f"shares {sorted(overlap)}"
+        )
 
 
 def test_slice1_archive_readme_present():
@@ -348,7 +380,12 @@ def test_consolidation_arc_all_pins_pass_validation():
     assert not relevant, (
         "consolidation-arc pin violations: "
         + "; ".join(
-            f"{v.invariant_name}: {v.violation}"
+            # `.detail` — `InvariantViolation` has no `.violation`. The
+            # SECOND copy of this bug; the first was in
+            # `test_cleanup_arc_slice1.py`. This f-string is only evaluated
+            # WHEN violations exist, so the AttributeError replaced the
+            # report at the one moment it mattered.
+            f"{v.invariant_name}: {v.detail}"
             for v in relevant
         )
     )


### PR DESCRIPTION
Of the 9 governance failures, **one was a code defect.** The other eight were pins and tests still asserting states the code had legitimately left — three of them the *same* stale assertion copied into three files.

## The one real defect

`background_agent_pool.py:1421` called the v1 `model_for_route()` — the last v1 caller in production `governance/`. `model_for_route_unified()` is a drop-in superset: same signature, and it **delegates to v1** whenever the sentinel is off, so the legacy path stays byte-identical.

## 4 stale — the bridge default

The capability **graduated to default-TRUE on 2026-07-24 (#70086)**, recorded in its own docstring. `test_agentic_cockpit_visibility.py:124` asserts the graduated default and **passes**; this file asserted the retired one and **failed**. Two test files, opposite contracts, one flag.

Three of them expressed "off" by **omission** — and that's the real defect: *a test that reads a state from the default breaks the day the default moves, even though the behaviour it tests never changed.* Now explicit (`setenv "0"`).

The default is **no longer asserted here at all** — it has an owner, and two owners is what produced the contradiction. The §33.1 pin is **repurposed rather than deleted**: a graduated flag must still be switchable off, which is the guarantee that survives graduation.

## 3 stale — the path ban, in three files

§32.5 archived a 1,137-line module exposing `GraduationOrchestrator` / `GraduationPhase` / `EphemeralUsageTracker`. Slices 132 (#69347) and 136 (#69351) then created a genuinely different **312-line** module at that path exposing `graduate` / `graduate_all` / `GraduationOutcome`. **Zero symbol overlap** — only the name is shared, and `phase9_orchestrator.py` already documents the two as distinct.

A path ban asks *"is this filename in use"* when §32.5 protects *"has the archived **implementation** come back"*. A proxy that cannot tell one module from another, reporting a violation nobody committed, on every run, for months.

All three now judge **identity**, deriving the archived symbol set **from the archive** so the check follows if the archive is amended. An unreadable archive is reported as "cannot judge", never as clean.

## 2 diagnostics that broke exactly when needed

`v.violation` on `InvariantViolation`, which has `.detail` — in **two** files. The f-string is only evaluated *when violations exist*, so an `AttributeError` replaced the report at the one moment it mattered. The second copy was found by the orphan sweep.

## The re-plan verdict — it was always reachable

`generate_runner.run()` (the **shipping** path) read a bare `validation` with no binding in its scope, guarded by `if 'validation' in dir()`. The guard always evaluated False, so **dynamic re-planning ran on empty failure context on every real op** while the inline twin read a real verdict.

**No new verdict type was defined.** `ValidationResult` is already frozen, already carries `failure_class` + `short_summary`, and is already on `OperationContext`. `validate_runner` publishes it via `ctx.advance(GATE, validation=...)`, and `advance()` uses `dataclasses.replace` — so it survives into the next GENERATE attempt, which is exactly the "previous pass's verdict" this block wants.

A parallel dataclass would have been a second spelling of a value that already existed, and an async protocol would be ceremony around a synchronous field read. What was missing was a **reader**, not a **protocol**.

`op_context.replan_inputs` is one reader for both call sites (they have drifted once already) and total by construction:

| input | result |
|---|---|
| no verdict (first attempt) | `("", "")` |
| crashed evaluator | indistinguishable, **deliberately** — a third state would claim knowledge this reader lacks |
| hostile property | degrades, never raises |
| duck-typed verdict | accepted |
| non-string / falsy fields | coerced; never puts `"None"` in a prompt |
| oversized summary | truncated to the 300 chars the field's comment promised and nothing enforced |

## Evidence

- The 9 original failures → **1 remaining** (see below); 131 passed.
- `ov surface` CI set: **471 passed**. Lint gate: 1,412 files clean.
- Orphan sweep found the **third** path-ban copy and the **second** `.violation` bug — and caught my own error: the first `in dir()` regression test matched a *substring* and flagged the comment documenting the removed guard. Now AST-based.

## The 9th — not mine to decide

`coherence_auditor_no_authority_imports_primitive` fires because the CuriosityProducerBridge arc (`094a7c4e22`) added `from ...curiosity_producer_bridge import feed_recurrence_drift` to a module pinned **pure-stdlib** ("must NEVER reach into governance modules"). Pre-existing, different arc, file outside this change set.

Two options, and both are governance calls rather than mechanical fixes:
1. **Narrow the pin** — its name says "no *authority* imports" but it bans *all* `backend.`/`governance` imports. Weakens a deliberately-strict safety invariant.
2. **Route through an injected sink** — matches this repo's own §33 producer-bridge pattern, and keeps the auditor uncapturable by what it audits.

I'd recommend (2), but it changes a working feature's wiring and I'm not making that call unilaterally.

Also still red and unrelated: `test_slice4_excluded_verbs_no_match` (`'budget'` verb leaked into the registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes one real defect and aligns governance pins/tests with graduated defaults and archive semantics. Dynamic re-planning now reads the actual validation verdict instead of always running with empty context.

**Key changes**
- Dynamic re-planning verdict wiring: adds `op_context.replan_inputs()` and uses it in both `generate_runner` and `orchestrator`. Behavior: when a `ValidationResult` is present on `ctx`, the re-planner now receives `(failure_class, short_summary)`; otherwise it gets `("", "")`. Coerces non-strings and truncates summary to `REPLAN_SUMMARY_MAX_CHARS` (300).
- Background agent pool: switches `model_for_route(...)` to `model_for_route_unified(...)`. Delegates to v1 when the sentinel is off, so legacy behavior remains byte-identical; v2-aware when on.
- Archive pins: replace filename path-bans with identity-based checks derived from the archive’s symbol set; unreadable archive yields “cannot judge” (not a false clean).
- Progress-bridge graduation: repurposes the pin from asserting a default to asserting that an explicit off value disables the bridge; renames pin to `execution_graph_progress_bridge_master_switch_honors_explicit_off`. Tests stop expressing “off” by omission and set `JARVIS_EXEC_GRAPH_BRIDGE_ENABLED="0"` explicitly.
- Diagnostics: fix `.violation` to `.detail` when rendering `InvariantViolation`s so failures report instead of raising.

**Review notes**
- Validate that `DynamicRePlanner` suggestions now reflect real verdicts on the extracted runner path; prompts may change due to populated inputs.
- Confirm archive identity checks match intent (no overlap of top-level symbols) and that failure mode (“cannot judge”) is acceptable for unreadable archives.
- Known out-of-scope red remains: `coherence_auditor_no_authority_imports_primitive` (governance decision needed) and `test_slice4_excluded_verbs_no_match`.

<sup>Written for commit 15271ebfcf4b92a77054fb9f1cbbc6f54b6bcec7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

