### PR TITLE
fix: Oracle readiness is a method on one surface and a property on another

### DIFF
--- a/backend/core/ouroboros/governance/context_expander.py
+++ b/backend/core/ouroboros/governance/context_expander.py
@@ -94,6 +94,10 @@ class ContextExpander:
         # ── P3: Cross-session dialogue injection ──────────────────────────
         # Inject past reasoning dialogues for the same domain so the model
         # has context from previous operations on similar tasks.
+        from backend.core.ouroboros.oracle_adapter import (  # noqa: PLC0415
+            oracle_is_ready as _oracle_is_ready,
+        )
+
         if self._dialogue_store is not None:
             try:
                 from backend.core.ouroboros.governance.entropy_calculator import extract_domain_key
@@ -114,7 +118,13 @@ class ContextExpander:
             except Exception:
                 pass
 
-        if self._oracle is None or not self._oracle.is_ready():
+        # `is_ready` is a METHOD on TheOracle and a @property on both oracle
+        # adapters. This line spelled it as a method, so every operation that
+        # received an adapter raised `TypeError: 'bool' object is not callable`
+        # into the CONTEXT_EXPANSION runner's `except Exception` and continued
+        # with UNEXPANDED context — silently, on every op, until a live soak
+        # produced the traceback pointing here.
+        if not _oracle_is_ready(self._oracle):
             logger.info("[ContextExpander] Oracle not ready \u2014 using blind baseline")
             return self._inject_skill_instructions(ctx)
 

--- a/backend/core/ouroboros/native_integration.py
+++ b/backend/core/ouroboros/native_integration.py
@@ -15549,9 +15549,24 @@ class GoalDecomposer:
             # Validate oracle connection if present
             if self._oracle:
                 try:
-                    # Attempt a simple query to validate oracle
-                    if hasattr(self._oracle, 'is_ready'):
-                        await self._oracle.is_ready()
+                    # Attempt a simple query to validate oracle.
+                    #
+                    # This AWAITED the result, and no `is_ready` in this
+                    # codebase is async — so it raised on every path that had
+                    # one: `TypeError: object bool can't be used in 'await'`
+                    # for TheOracle's method, and `'bool' object is not
+                    # callable` for an adapter's property. Both were swallowed
+                    # by the handler below, so "Oracle validation" has never
+                    # validated anything. The shared resolver settles the
+                    # method-vs-property split and is sync by contract.
+                    from backend.core.ouroboros.oracle_adapter import (  # noqa: PLC0415
+                        oracle_is_ready as _oracle_is_ready,
+                    )
+                    if not _oracle_is_ready(self._oracle):
+                        logger.info(
+                            "[GoalDecomposer] Oracle present but not ready "
+                            "— proceeding (decomposition degrades, never blocks)"
+                        )
                 except Exception as e:
                     logger.warning(f"[GoalDecomposer] Oracle validation failed: {e}")
 

--- a/backend/core/ouroboros/oracle_adapter.py
+++ b/backend/core/ouroboros/oracle_adapter.py
@@ -28,6 +28,7 @@ gate), ``AsyncOracleProxy`` (Slice 112), ``oracle_ipc.process_isolation_enabled`
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import os
 from typing import Any, Optional
@@ -42,6 +43,83 @@ def _env_truthy(name: str) -> bool:
         return (os.environ.get(name, "") or "").strip().lower() in _TRUTHY
     except Exception:  # noqa: BLE001
         return False
+
+
+def oracle_is_ready(oracle: Any) -> bool:
+    """Is *oracle* ready? Total across BOTH oracle surfaces. NEVER raises.
+
+    THE SPLIT THIS RESOLVES
+    -----------------------
+    ``is_ready`` is a METHOD on :class:`TheOracle` and a ``@property`` on both
+    adapters in this module. A consumer holding "an oracle" cannot know which
+    it received, and writing either spelling is wrong half the time:
+
+      * ``oracle.is_ready()`` on an adapter  -> ``TypeError: 'bool' object is
+        not callable``
+      * ``oracle.is_ready`` on TheOracle     -> a bound method, which is
+        ALWAYS truthy: silently "ready" forever
+
+    That first failure ran in production on every operation, swallowed by
+    ``except Exception`` in the CONTEXT_EXPANSION runner, until a live soak on
+    2026-08-18 produced the traceback (`context_expander.py:117`). A second
+    consumer, ``native_integration``, additionally ``await``ed the result —
+    and no ``is_ready`` anywhere in this codebase is async.
+
+    NEITHER SURFACE IS CHANGED, deliberately. Both spellings are pinned by
+    tests on their own type — ``test_oracle_deferred_boot`` asserts
+    ``o.is_ready() is False`` and ``test_slice112_oracle_ipc`` asserts
+    ``proxy.is_ready is False`` — so unifying the protocol would break
+    whichever side lost. The split is real and per-type; what was missing is a
+    reader that survives it.
+
+    Resolution order, and why each degenerate case answers as it does:
+
+    * ``None`` -> ``False``. No oracle is not a ready oracle.
+    * a plain ``bool`` attribute (property already evaluated) -> its value.
+    * a CALLABLE -> called; a non-bool result is coerced with ``bool()``.
+    * a coroutine came back -> closed and treated as UNKNOWN. This resolver is
+      sync by contract because no async ``is_ready`` exists; leaving the
+      coroutine unawaited would emit a "never awaited" warning and leak.
+    * the attribute is ABSENT -> ``True``, mirroring the adapters' own
+      documented fallback ("if the Oracle exposes no OracleReadiness
+      primitive, assume ready"). A duck-typed oracle without the probe is the
+      legacy shape, and treating it as permanently unready would silently
+      disable context expansion — the very outcome this function exists to
+      end.
+    * anything RAISES -> ``True``, for the same reason: a readiness probe that
+      fails must not be the thing that disables the feature it guards.
+    """
+    if oracle is None:
+        return False
+    try:
+        probe = getattr(oracle, "is_ready")
+    except Exception:  # noqa: BLE001 — a hostile __getattr__
+        return True
+    except AttributeError:  # pragma: no cover — defensive, covered above
+        return True
+    if probe is None:
+        return True
+    if isinstance(probe, bool):
+        return probe
+    if callable(probe):
+        try:
+            value = probe()
+        except Exception:  # noqa: BLE001 — a failing probe is not a verdict
+            return True
+        if inspect.iscoroutine(value):
+            try:
+                value.close()
+            except Exception:  # noqa: BLE001
+                pass
+            return True
+        try:
+            return bool(value)
+        except Exception:  # noqa: BLE001
+            return True
+    try:
+        return bool(probe)
+    except Exception:  # noqa: BLE001
+        return True
 
 
 class InProcessOracleAdapter:

--- a/tests/governance/test_oracle_readiness_protocol.py
+++ b/tests/governance/test_oracle_readiness_protocol.py
@@ -1,0 +1,170 @@
+"""`is_ready` is a method on one oracle and a property on another.
+
+CAUGHT BY A LIVE SOAK, not by review. `context_expander.py:117` spelled it as
+a method::
+
+    if self._oracle is None or not self._oracle.is_ready():
+    TypeError: 'bool' object is not callable
+
+Production injects an `InProcessOracleAdapter`, whose `is_ready` is a
+`@property`. So EVERY operation raised there, the CONTEXT_EXPANSION runner's
+`except Exception` swallowed it, and generation proceeded with UNEXPANDED
+context — silently, for as long as the adapter has existed. The only visible
+symptom was one warning naming a type and no site, which is why the earlier
+fix in this session was to make that handler carry `exc_info`; the traceback
+it produced is what located this.
+
+A third site had the same split in a third spelling: `native_integration`
+`await`ed the result, and no `is_ready` in this codebase is async.
+
+NEITHER SURFACE IS CHANGED. Both spellings are pinned by tests on their own
+type — `test_oracle_deferred_boot.py:148` asserts `o.is_ready() is False`,
+`test_slice112_oracle_ipc.py` asserts `proxy.is_ready is False` — so unifying
+the protocol would break whichever side lost. The split is real and per-type.
+What was missing is a reader that survives it.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.oracle_adapter import oracle_is_ready
+
+
+def _root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+class TestTotality:
+    def test_none_is_not_ready(self):
+        """No oracle is not a ready oracle."""
+        assert oracle_is_ready(None) is False
+
+    def test_method_surface_theoracle_shape(self):
+        class _M:
+            def is_ready(self): return True
+        class _MF:
+            def is_ready(self): return False
+        assert oracle_is_ready(_M()) is True
+        assert oracle_is_ready(_MF()) is False
+
+    def test_property_surface_adapter_shape(self):
+        """The shape that produced the production TypeError."""
+        class _P:
+            @property
+            def is_ready(self): return True
+        class _PF:
+            @property
+            def is_ready(self): return False
+        assert oracle_is_ready(_P()) is True
+        assert oracle_is_ready(_PF()) is False
+
+    def test_absent_attribute_assumes_ready(self):
+        """Mirrors the adapters' own documented fallback.
+
+        Treating a probe-less legacy oracle as permanently unready would
+        silently disable context expansion — the outcome this resolver exists
+        to end."""
+        class _Bare: pass
+        assert oracle_is_ready(_Bare()) is True
+
+    def test_a_raising_probe_is_not_a_verdict(self):
+        class _Boom:
+            @property
+            def is_ready(self): raise RuntimeError("probe exploded")
+        assert oracle_is_ready(_Boom()) is True
+
+    def test_a_raising_method_is_not_a_verdict(self):
+        class _Boom:
+            def is_ready(self): raise RuntimeError("probe exploded")
+        assert oracle_is_ready(_Boom()) is True
+
+    def test_a_coroutine_is_closed_not_leaked(self):
+        """No `is_ready` here is async, so an awaitable is UNKNOWN — and must
+        not leave a 'coroutine was never awaited' warning behind."""
+        class _Async:
+            async def is_ready(self): return False
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            assert oracle_is_ready(_Async()) is True
+
+    def test_non_bool_values_are_coerced(self):
+        class _Str:
+            is_ready = "yes"
+        class _Empty:
+            is_ready = ""
+        assert oracle_is_ready(_Str()) is True
+        assert oracle_is_ready(_Empty()) is False
+
+    def test_a_hostile_getattr_never_raises(self):
+        class _Hostile:
+            def __getattr__(self, name): raise RuntimeError("no attributes here")
+        assert oracle_is_ready(_Hostile()) is True
+
+
+class TestRealSurfacesBothResolve:
+    """The two shipped implementations, through one reader."""
+
+    def test_in_process_adapter_property_resolves(self):
+        from backend.core.ouroboros.oracle_adapter import InProcessOracleAdapter
+        assert isinstance(
+            inspect.getattr_static(InProcessOracleAdapter, "is_ready"), property
+        ), "adapter surface changed — this test's premise is stale"
+
+    def test_theoracle_method_surface_is_unchanged(self):
+        """Pinned so a future 'unification' cannot silently break
+        `test_oracle_deferred_boot`, which asserts `o.is_ready() is False`."""
+        src = (_root() / "backend/core/ouroboros/oracle.py").read_text(
+            encoding="utf-8")
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.FunctionDef) and node.name == "is_ready"
+                    and node.lineno > 4600):
+                decs = [getattr(d, "id", getattr(d, "attr", "")) for d in node.decorator_list]
+                assert "property" not in decs, (
+                    "TheOracle.is_ready became a property — "
+                    "test_oracle_deferred_boot asserts it is callable"
+                )
+                return
+        pytest.skip("TheOracle.is_ready not found at the expected location")
+
+
+class TestConsumersUseTheReader:
+    """Wiring pins. A resolver nobody calls is the defect it replaced."""
+
+    @pytest.mark.parametrize("rel", [
+        "backend/core/ouroboros/governance/context_expander.py",
+        "backend/core/ouroboros/native_integration.py",
+    ])
+    def test_consumer_uses_the_resolver(self, rel):
+        src = (_root() / rel).read_text(encoding="utf-8")
+        assert "_oracle_is_ready(" in src, f"{rel} must use the shared reader"
+
+    @pytest.mark.parametrize("rel", [
+        "backend/core/ouroboros/governance/context_expander.py",
+        "backend/core/ouroboros/native_integration.py",
+    ])
+    def test_no_consumer_calls_is_ready_directly(self, rel):
+        """AST, not substring — the comments here legitimately mention the
+        old spelling, and a substring check cannot tell code from prose about
+        code."""
+        tree = ast.parse((_root() / rel).read_text(encoding="utf-8"))
+        offenders = [
+            getattr(n, "lineno", "?") for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "is_ready"
+        ]
+        assert not offenders, (
+            f"{rel} calls .is_ready() directly at {offenders}; it is a "
+            "@property on the adapters and will raise TypeError"
+        )
+
+    def test_native_integration_no_longer_awaits_a_bool(self):
+        src = (_root() / "backend/core/ouroboros/native_integration.py").read_text(
+            encoding="utf-8")
+        assert "await self._oracle.is_ready()" not in src


### PR DESCRIPTION
**Found by a live soak** — which is the only reason it was fixable. The runner-parity fix earlier in this session gave the CONTEXT_EXPANSION handler `exc_info`; a bounded run then produced the traceback the message alone could never carry:

```
File "context_expander.py", line 117, in expand
    if self._oracle is None or not self._oracle.is_ready():
TypeError: 'bool' object is not callable
```

## The split

`TheOracle.is_ready` is a **method**. `InProcessOracleAdapter.is_ready` and `IsolatedOracleAdapter.is_ready` are **`@property`**.

Production injects an adapter, so line 117 raised on **every operation**, the runner's `except Exception` swallowed it, and generation proceeded with **UNEXPANDED context** — silently, for as long as the adapter has existed.

A consumer holding "an oracle" cannot know which it received, and either spelling is wrong half the time:

| spelling | on an adapter | on TheOracle |
|---|---|---|
| `oracle.is_ready()` | **TypeError** (loud — what happened) | correct |
| `oracle.is_ready` | correct | bound method → **always truthy**, silently "ready" forever |

**A third site** had the same split in a third spelling: `native_integration:15554` **`await`ed** the result. No `is_ready` in this codebase is async, so "Oracle validation" raised on every path that had an oracle and has never validated anything — swallowed by its own handler.

## Why neither surface is changed

Both spellings are **pinned by tests on their own type**:

- `test_oracle_deferred_boot.py:148` — `assert o.is_ready() is False` (method)
- `test_slice112_oracle_ipc.py` — `assert proxy.is_ready is False` (property, 6+ assertions)

Unifying the protocol breaks whichever side loses. The split is real and per-type. What was missing is a **reader that survives it**, not a protocol change — and there's a safety asymmetry that settles the direction anyway: getting it wrong toward "method" fails **loudly** (TypeError), toward "property" fails **silently** (always-truthy bound method).

## The reader

`oracle_adapter.oracle_is_ready` is total, and each degenerate case answers the way it does for a stated reason:

| input | result | why |
|---|---|---|
| `None` | `False` | no oracle is not a ready oracle |
| bool attribute | its value | property already evaluated |
| callable | called, coerced | the `TheOracle` shape |
| coroutine returned | **closed**, `True` | no async `is_ready` exists; leaving it unawaited would leak and warn |
| attribute **absent** | `True` | mirrors the adapters' own documented fallback — treating a probe-less legacy oracle as permanently unready would silently disable context expansion, the exact outcome this ends |
| probe **raises** | `True` | a failing readiness probe must not be the thing that disables the feature it guards |

Consumer pins are **AST-based, not substring**: the comments at both sites legitimately mention the old spelling, and a substring check cannot tell code from prose about code.

## Evidence

- Reproduced the production shape (property-bearing oracle): **`TypeError` before, `expand()` completes after.**
- 16 new tests; `ov surface` CI set **471 passed**; lint gate 1,412 files clean.
- Baselined the 13 failures in `test_oracle_deferred_boot` — **identical on `main`** (13 failed / 140 passed both ways), source-text assertions about `_boot_oracle`, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes oracle readiness checks by adding a safe reader that handles both method and property surfaces. This prevents the silent disablement of context expansion and the broken validation path in `native_integration`.

- Introduces `oracle_is_ready(oracle)` in `backend/core/ouroboros/oracle_adapter.py`: synchronous, total, and non-raising across None, bool property, callable method, coroutine return (closed), missing attribute, and exceptions.
- Updates `context_expander.expand` and `native_integration.initialize` to use `_oracle_is_ready(...)`. Removes the incorrect `await` and logs when an oracle is present but not ready; decomposition degrades but never blocks.
- Leaves existing surfaces unchanged to satisfy pinned tests on both types; adds `tests/governance/test_oracle_readiness_protocol.py` to cover resolver behavior, consumer usage, and API shapes.
- Behavior change: previously, adapters raised a swallowed `TypeError` and context ran unexpanded; now readiness resolves correctly, so context expansion runs when appropriate.

<sup>Written for commit 04262b1459383c7978ed0d422e46d27968de29d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

