### PR TITLE
feat(local-tier): Concurrency derived from measured physics, and a cockpit that only claims what it measured

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4954,16 +4954,56 @@ class BattleTestHarness:
                         breaker = get_claude_circuit_breaker().snapshot()
                         economic = int(
                             breaker.get("consecutive_economic_failures") or 0)
+                        econ: dict = {}
                         if economic > 0 or str(
                             breaker.get("state") or "").lower() == "open":
-                            payload["economic"] = {
-                                "claude": {
-                                    "state": breaker.get("state"),
-                                    "consecutive_economic_failures": economic,
-                                    "recovery_window_s": breaker.get(
-                                        "effective_recovery_window_s"),
-                                }
+                            econ["claude"] = {
+                                "state": breaker.get("state"),
+                                "consecutive_economic_failures": economic,
+                                "recovery_window_s": breaker.get(
+                                    "effective_recovery_window_s"),
                             }
+                        # EVERY LANE, FROM THE AUTHORITATIVE CLASSIFIER.
+                        #
+                        # This block used to consult the CLAUDE circuit breaker
+                        # alone and emit a single "claude" key, so Doubleword —
+                        # the lane actually refusing with 402 — was never
+                        # represented. The cockpit then held `any_exhausted`
+                        # true with an empty economic map and rendered its own
+                        # contradiction: "a runway is reported dry but no
+                        # provider row shows it".
+                        #
+                        # `economic_state.economic_view` is the classifier that
+                        # already knows (its table handles Doubleword's 402 and
+                        # Anthropic's 400 + "credit balance" alike), and it is
+                        # the same function the banner's renderer consumes. One
+                        # source, every lane.
+                        try:
+                            from backend.core.ouroboros.governance.economic_state import (  # noqa: E501
+                                economic_view,
+                            )
+                            for _name in sorted(set(providers) | set(econ)):
+                                try:
+                                    _view = economic_view(_name)
+                                except Exception:  # noqa: BLE001
+                                    continue
+                                if not isinstance(_view, dict):
+                                    continue
+                                _state = str(_view.get("state") or "").lower()
+                                _dead = (_state == "economic"
+                                         or bool(_view.get("hard_open")))
+                                # A LAPSED verdict still carries what was last
+                                # known; the renderer decides how to say so.
+                                _stale = bool(_view.get("stale_clock")
+                                              and _view.get("reason"))
+                                if _dead or _stale:
+                                    econ.setdefault(_name, {}).update(_view)
+                                if _dead:
+                                    payload["any_exhausted"] = True
+                        except Exception:  # noqa: BLE001
+                            pass
+                        if econ:
+                            payload["economic"] = econ
                             # An economically dead lane IS an exhausted runway,
                             # whatever the rate-limit bucket says. Without this
                             # the banner keeps its cheerful token count and the

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4891,6 +4891,7 @@ class BattleTestHarness:
                         "phase_detail": snap.phase_detail,
                         "cost_spent_usd": snap.cost_spent_usd,
                         "cost_budget_usd": snap.cost_budget_usd,
+                        "cost_budget_basis": snap.cost_budget_basis,
                         "idle_elapsed_s": snap.idle_elapsed_s,
                         "primary_op_id": snap.primary_op_id,
                         "route": snap.route,

--- a/backend/core/ouroboros/battle_test/status_line.py
+++ b/backend/core/ouroboros/battle_test/status_line.py
@@ -110,6 +110,11 @@ class StatusSnapshot:
     # Cost
     cost_spent_usd: float = 0.0
     cost_budget_usd: float = 0.0
+    #: WHY the budget is what it is — e.g. "observed — 98 sessions,
+    #: p95=$0.24 x3". A ceiling without its basis is indistinguishable from
+    #: an arbitrary constant, which is how an operator ends up asking where
+    #: their own number came from.
+    cost_budget_basis: str = ""
     # Idle window
     idle_elapsed_s: float = 0.0
     idle_timeout_s: float = 0.0
@@ -338,6 +343,7 @@ class StatusLineBuilder:
         """
         phase, phase_detail = self._sample_phase_and_detail()
         cost_spent, cost_budget = self._sample_cost()
+        cost_basis = self._sample_cost_basis()
         idle_elapsed, idle_timeout = self._sample_idle()
         primary_op, extra_ops = self._sample_ops()
         route, provider, model = self._sample_route_and_provider(primary_op)
@@ -363,6 +369,7 @@ class StatusLineBuilder:
             phase_detail=phase_detail,
             cost_spent_usd=cost_spent,
             cost_budget_usd=cost_budget,
+            cost_budget_basis=cost_basis,
             idle_elapsed_s=idle_elapsed,
             idle_timeout_s=idle_timeout,
             primary_op_id=primary_op,
@@ -437,6 +444,20 @@ class StatusLineBuilder:
         except Exception:  # noqa: BLE001
             budget = 0.0
         return (spent, budget)
+
+    def _sample_cost_basis(self) -> str:
+        """The basis the spawner recorded for this session's ceiling.
+
+        Read from the environment rather than re-derived: the basis belongs to
+        the decision that set the cap. Re-deriving would sample a different
+        set of sessions and could explain the number with evidence that did
+        not produce it. NEVER raises.
+        """
+        try:
+            return str(os.environ.get(
+                "OUROBOROS_BATTLE_COST_CAP_BASIS", "") or "").strip()
+        except Exception:  # noqa: BLE001
+            return ""
 
     def _sample_idle(self) -> tuple:
         if self._idle is None:

--- a/backend/core/ouroboros/cli/boot_progress.py
+++ b/backend/core/ouroboros/cli/boot_progress.py
@@ -192,6 +192,9 @@ class Progress:
     stages: Tuple[BootStage, ...] = DEFAULT_STAGES
     log_path: str = ""
     expected_s: Optional[float] = None
+    #: Log size when this wait began. Everything before it belongs to a
+    #: PREVIOUS boot and must not count toward this one.
+    log_origin: int = 0
     _reached: int = 0
     _high_water: float = 0.0
     _last_stage_at: float = 0.0
@@ -329,25 +332,49 @@ class Progress:
             return f"waking · {int(elapsed)}s"
 
 
-def read_log_tail(path: str, *, max_bytes: int = 65536) -> str:
-    """Last *max_bytes* of the daemon log, or "". NEVER raises.
+def log_size(path: str) -> int:
+    """Current size of the daemon log, or 0. NEVER raises."""
+    try:
+        return os.path.getsize(path) if path and os.path.exists(path) else 0
+    except Exception:  # noqa: BLE001
+        return 0
 
-    Bounded because the log reaches tens of megabytes; a boot's markers are
-    always in the tail, and reading the whole file every poll would make the
-    progress indicator the slowest thing in the boot.
+
+def read_log_tail(path: str, *, since: int = 0, max_bytes: int = 65536) -> str:
+    """Log bytes written AFTER *since*, capped at *max_bytes*. NEVER raises.
+
+    `since` is load-bearing, not an optimisation. The daemon log is APPEND-ONLY
+    ACROSS RUNS, so its tail already contains every boot marker from every
+    previous boot. Reading it unanchored made a fresh wait match all seven
+    stages on its first poll and render 97% instantly — a bar that is
+    complete before the work starts, which is worse than no bar at all.
+    Anchoring at the size observed when the wait began means only THIS boot's
+    output can advance it.
+
+    Still bounded: the log reaches tens of megabytes, and reading it whole on
+    every poll would make the progress indicator the slowest thing in the boot.
     """
     try:
         if not path or not os.path.exists(path):
             return ""
         size = os.path.getsize(path)
+        start = max(0, int(since))
+        if size <= start:
+            return ""                      # nothing new since the wait began
+        start = max(start, size - max_bytes)
         with open(path, "rb") as fh:
-            if size > max_bytes:
-                fh.seek(size - max_bytes)
+            fh.seek(start)
             return fh.read().decode("utf-8", "replace")
     except Exception:  # noqa: BLE001
         return ""
 
 
 def make_progress(log_path: str = "") -> Progress:
-    """A Progress primed with this machine's measured boot history."""
-    return Progress(log_path=log_path, expected_s=expected_boot_s())
+    """A Progress primed with this machine's history AND anchored to now.
+
+    The anchor is taken at construction, which is the moment the wait starts —
+    any later and markers from the boot's own first milliseconds would be
+    skipped; any earlier and the previous boot's tail would be counted.
+    """
+    return Progress(log_path=log_path, expected_s=expected_boot_s(),
+                    log_origin=log_size(log_path))

--- a/backend/core/ouroboros/cli/boot_progress.py
+++ b/backend/core/ouroboros/cli/boot_progress.py
@@ -196,6 +196,9 @@ class Progress:
     _high_water: float = 0.0
     _last_stage_at: float = 0.0
     _seen: set = field(default_factory=set)
+    #: Elapsed-at-arrival for each stage reached IN THIS BOOT. The basis for
+    #: projecting the rest when no cross-boot history exists yet.
+    _stage_times: List[float] = field(default_factory=list)
 
     def observe_log(self, text: str, *, now: float) -> None:
         """Fold in whatever the daemon has written so far. NEVER raises."""
@@ -208,8 +211,50 @@ class Progress:
                     if i + 1 > self._reached:
                         self._reached = i + 1
                         self._last_stage_at = now
+                        self._stage_times.append(float(now))
         except Exception:  # noqa: BLE001
             pass
+
+    def _projected_total_s(self, elapsed: float) -> Optional[float]:
+        """Expected total boot time, projected from THIS boot's own cadence.
+
+        The first boots on a machine have no history, so `expected_s` is None
+        and the bar could only move when a marker landed — it sat frozen at
+        one percentage between stages, which is what the operator sees as a
+        hang. But a boot in progress is already evidence about itself: if four
+        stages arrived over twelve seconds, the remaining three will plausibly
+        take about nine more.
+
+        This is measurement, not a constant — it adapts to a slow disk, a cold
+        page cache or a loaded machine, and it needs no prior run. Requires
+        TWO arrivals so there is an actual interval to average; one timestamp
+        is a point, not a rate.
+        """
+        try:
+            if self._reached <= 0 or not self._stage_times:
+                return None
+            # Rate measured FROM THE START OF THE WAIT, not between arrivals.
+            #
+            # The interval form needed two distinct timestamps and returned
+            # nothing when several markers landed in the same poll — which is
+            # the common case on a fast boot, since the client reads the log
+            # tail every quarter second and a burst of stages can complete
+            # between two reads. Anchoring on t=0 makes a single arrival
+            # sufficient: two stages reached by second four is two seconds a
+            # stage, and that is a rate, not a point.
+            last = float(self._stage_times[-1])
+            if last <= 0:
+                return None
+            per_stage = last / float(self._reached)
+            if per_stage <= 0:
+                return None
+            projected = per_stage * float(len(self.stages))
+            # Never project a finish already in the past: a boot running long
+            # has disproved its own estimate, and an ETA of "0s left" that
+            # keeps not arriving is worse than no ETA.
+            return max(elapsed, projected)
+        except Exception:  # noqa: BLE001
+            return None
 
     @property
     def stage_label(self) -> str:
@@ -229,9 +274,15 @@ class Progress:
             if self._reached > 0:
                 done = sum(s.weight for s in self.stages[:self._reached])
                 evidence = done / total_w
+            # Cross-boot history is the better estimator when it exists (more
+            # samples, and it already knows how this machine behaves). Within
+            # -boot projection is the fallback that makes a FIRST boot move.
+            horizon = self.expected_s
+            if not horizon or horizon <= 0:
+                horizon = self._projected_total_s(elapsed)
             estimate = None
-            if self.expected_s and self.expected_s > 0:
-                estimate = elapsed / self.expected_s
+            if horizon and horizon > 0:
+                estimate = elapsed / horizon
 
             if evidence is None and estimate is None:
                 return None
@@ -268,8 +319,9 @@ class Progress:
                 parts.append(f"{int(frac * 100):3d}%")
             parts.append(self.stage_label)
             parts.append(f"{int(elapsed)}s")
-            if frac is not None and self.expected_s and frac > 0.02:
-                remaining = max(0.0, self.expected_s - elapsed)
+            horizon = self.expected_s or self._projected_total_s(elapsed)
+            if frac is not None and horizon and frac > 0.02:
+                remaining = max(0.0, horizon - elapsed)
                 if remaining >= 1.0:
                     parts.append(f"~{int(remaining)}s left")
             return "  ".join(parts)

--- a/backend/core/ouroboros/cli/boot_progress.py
+++ b/backend/core/ouroboros/cli/boot_progress.py
@@ -1,0 +1,301 @@
+"""What the organism is actually doing while you wait for it.
+
+THE DEFECT THIS REPLACES
+------------------------
+The cold-boot wait printed a fresh line every five seconds::
+
+    ⎿ organism waking · 0s
+    ⎿ organism waking · 5s
+    ⎿ organism waking · 10s
+    ⎿ organism waking · 15s
+    ⎿ organism waking · 21s
+    ⎿ organism waking · 27s
+
+Six lines that say one thing: time is passing. They do not say what stage the
+boot reached, whether it is progressing or wedged, or how much longer it will
+take — and the repetition itself reads as a stall, which is the opposite of
+the reassurance a wait indicator exists to give.
+
+TWO SOURCES OF TRUTH, IN PRIORITY ORDER
+---------------------------------------
+1. **EVIDENCE — stages actually reached.** The daemon already writes its boot
+   to `.jarvis/logs/ov-daemon.log`; the client already knows that path (the
+   failure message points at it). Watching it costs one tail per poll and
+   yields REAL progress: preflight passed, socket bound, session opened,
+   sensors armed. This is measurement, not animation.
+
+2. **ESTIMATE — how long this usually takes.** Boot durations are recorded to
+   a small ledger and the median of past boots gives an expected duration.
+   Exactly the pattern `session_economics.derived_cost_cap` uses for money:
+   the operator's own history, not a constant somebody guessed.
+
+Evidence outranks estimate. When both exist the bar interpolates smoothly
+between confirmed stages using elapsed time, so it moves continuously without
+ever claiming a stage that has not happened.
+
+THREE HONESTY RULES
+-------------------
+* **Never regress.** A percentage that goes backwards destroys the one thing a
+  progress bar is for. Monotonic by construction.
+* **Never reach 100% before the socket is live.** The last few percent are
+  reserved for the event that actually matters. A bar that sits at 100% while
+  nothing happens is worse than no bar.
+* **Degrade to elapsed-only rather than lie.** No history and no matched
+  markers means no percentage — just the stage and the clock. A log format
+  change therefore costs the bar, never its correctness.
+
+Python 3.9+, stdlib only. Never raises: a progress indicator that can break a
+boot is not worth having.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.BootProgress")
+
+ENABLED_ENV = "JARVIS_OV_BOOT_PROGRESS_ENABLED"
+HISTORY_ENV = "JARVIS_OV_BOOT_HISTORY_PATH"
+MAX_SAMPLES_ENV = "JARVIS_OV_BOOT_HISTORY_MAX"
+CEILING_ENV = "JARVIS_OV_BOOT_PROGRESS_CEILING"
+
+_TRUTHY = ("1", "true", "yes", "on")
+_DEFAULT_HISTORY = os.path.join(".jarvis", "boot_durations.json")
+
+
+def boot_progress_enabled() -> bool:
+    """Master gate. Default ON. OFF restores the plain elapsed breadcrumb."""
+    try:
+        return os.environ.get(ENABLED_ENV, "1").strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def history_path() -> str:
+    try:
+        return os.environ.get(HISTORY_ENV, "") or _DEFAULT_HISTORY
+    except Exception:  # noqa: BLE001
+        return _DEFAULT_HISTORY
+
+
+def max_samples() -> int:
+    """Boot durations retained. Default 40 — enough for a stable median,
+    short enough that a machine that got faster is reflected within days."""
+    try:
+        return max(3, int(os.environ.get(MAX_SAMPLES_ENV, "40")))
+    except (TypeError, ValueError):
+        return 40
+
+
+def progress_ceiling() -> float:
+    """The highest fraction shown before the socket is confirmed live.
+
+    Default 0.97. The remaining 3% belongs to the event that actually
+    matters; a bar that sits at 100% while nothing happens has told the
+    operator the boot finished when it has not."""
+    try:
+        v = float(os.environ.get(CEILING_ENV, "0.97"))
+        return min(0.99, max(0.50, v))
+    except (TypeError, ValueError):
+        return 0.97
+
+
+@dataclass(frozen=True)
+class BootStage:
+    """One observable milestone, and the log marker that proves it."""
+
+    key: str
+    label: str
+    marker: str          # substring that appears in the daemon log
+    weight: float = 1.0  # relative share of the boot this stage represents
+
+
+#: The stages, in order. Weights are ROUGH SHARES, not durations: the ETA
+#: comes from measured history, so these only decide how the bar distributes
+#: itself between confirmed milestones.
+#:
+#: Markers are substrings of log lines the daemon already writes. That is a
+#: coupling to log text, which is why an unmatched table degrades to
+#: elapsed-only rather than to a wrong number — see `Progress.fraction`.
+DEFAULT_STAGES: Tuple[BootStage, ...] = (
+    BootStage("preflight", "preflight", "[AegisPreflight]", 1.0),
+    BootStage("credentials", "credentials", "[CredentialBootstrap]", 0.5),
+    BootStage("aegis", "aegis serving", "[AegisDaemon] serving on", 1.5),
+    BootStage("ready", "aegis ready", "daemon ready at", 0.5),
+    BootStage("session", "session open", "session=bt-", 1.0),
+    BootStage("status", "cockpit wired", "StatusLineBuilder registered", 1.5),
+    BootStage("sensors", "sensors arming", "IntakeLayer", 2.0),
+)
+
+
+def observed_boot_durations(path: Optional[str] = None) -> List[float]:
+    """Durations of past successful boots, seconds. NEVER raises."""
+    try:
+        p = path or history_path()
+        if not os.path.exists(p):
+            return []
+        with open(p, encoding="utf-8") as fh:
+            data = json.load(fh)
+        out = [float(x) for x in (data.get("durations") or [])
+               if isinstance(x, (int, float)) and 0.0 < float(x) < 3600.0]
+        return out
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def record_boot_duration(seconds: float, path: Optional[str] = None) -> None:
+    """Append one SUCCESSFUL boot duration. NEVER raises.
+
+    Only successes are recorded. A failed or abandoned boot has no duration —
+    folding one in would teach the estimator that boots take as long as the
+    operator's patience, which is the number it exists to replace.
+    """
+    try:
+        if not (0.0 < float(seconds) < 3600.0):
+            return
+        p = path or history_path()
+        rows = observed_boot_durations(p)
+        rows.append(float(seconds))
+        rows = rows[-max_samples():]
+        d = os.path.dirname(os.path.abspath(p))
+        if d:
+            os.makedirs(d, exist_ok=True)
+        tmp = p + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump({"schema_version": "1.0", "durations": rows}, fh)
+        os.replace(tmp, p)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def expected_boot_s(path: Optional[str] = None) -> Optional[float]:
+    """Median of observed boots, or None when nothing has been measured.
+
+    None rather than a default: an invented expectation produces a confident
+    percentage with nothing behind it, and the operator cannot tell the
+    difference. No history means no bar.
+    """
+    rows = sorted(observed_boot_durations(path))
+    if len(rows) < 3:
+        return None
+    return rows[len(rows) // 2]
+
+
+@dataclass
+class Progress:
+    """Mutable boot state. One instance per wait."""
+
+    stages: Tuple[BootStage, ...] = DEFAULT_STAGES
+    log_path: str = ""
+    expected_s: Optional[float] = None
+    _reached: int = 0
+    _high_water: float = 0.0
+    _last_stage_at: float = 0.0
+    _seen: set = field(default_factory=set)
+
+    def observe_log(self, text: str, *, now: float) -> None:
+        """Fold in whatever the daemon has written so far. NEVER raises."""
+        try:
+            for i, st in enumerate(self.stages):
+                if st.key in self._seen:
+                    continue
+                if st.marker and st.marker in text:
+                    self._seen.add(st.key)
+                    if i + 1 > self._reached:
+                        self._reached = i + 1
+                        self._last_stage_at = now
+        except Exception:  # noqa: BLE001
+            pass
+
+    @property
+    def stage_label(self) -> str:
+        if self._reached <= 0:
+            return "igniting"
+        return self.stages[min(self._reached, len(self.stages)) - 1].label
+
+    def fraction(self, elapsed: float) -> Optional[float]:
+        """Best honest estimate of completion, or None. NEVER decreases.
+
+        Returns None when there is neither evidence nor history — the honest
+        rendering of "I don't know how far along this is" is no number at all.
+        """
+        try:
+            total_w = sum(s.weight for s in self.stages) or 1.0
+            evidence = None
+            if self._reached > 0:
+                done = sum(s.weight for s in self.stages[:self._reached])
+                evidence = done / total_w
+            estimate = None
+            if self.expected_s and self.expected_s > 0:
+                estimate = elapsed / self.expected_s
+
+            if evidence is None and estimate is None:
+                return None
+            if evidence is None:
+                value = estimate
+            elif estimate is None:
+                value = evidence
+            else:
+                # Evidence sets the floor; the estimate may only interpolate
+                # ABOVE it, and never past the next unconfirmed stage. That is
+                # what keeps the bar moving between milestones without ever
+                # claiming one that has not happened.
+                nxt = (sum(s.weight for s in self.stages[:self._reached + 1])
+                       / total_w) if self._reached < len(self.stages) else 1.0
+                value = max(evidence, min(estimate, nxt))
+
+            value = min(progress_ceiling(), max(0.0, float(value)))
+            # MONOTONIC. A bar that goes backwards destroys the only thing it
+            # is for, and both inputs can legitimately fall (history reloads,
+            # a marker arrives late).
+            self._high_water = max(self._high_water, value)
+            return self._high_water
+        except Exception:  # noqa: BLE001
+            return None
+
+    def render(self, elapsed: float, *, width: int = 18) -> str:
+        """One line. Bar + stage + clock + ETA when known. NEVER raises."""
+        try:
+            frac = self.fraction(elapsed)
+            parts = []
+            if frac is not None:
+                filled = int(round(frac * width))
+                parts.append("[" + "█" * filled + "·" * (width - filled) + "]")
+                parts.append(f"{int(frac * 100):3d}%")
+            parts.append(self.stage_label)
+            parts.append(f"{int(elapsed)}s")
+            if frac is not None and self.expected_s and frac > 0.02:
+                remaining = max(0.0, self.expected_s - elapsed)
+                if remaining >= 1.0:
+                    parts.append(f"~{int(remaining)}s left")
+            return "  ".join(parts)
+        except Exception:  # noqa: BLE001
+            return f"waking · {int(elapsed)}s"
+
+
+def read_log_tail(path: str, *, max_bytes: int = 65536) -> str:
+    """Last *max_bytes* of the daemon log, or "". NEVER raises.
+
+    Bounded because the log reaches tens of megabytes; a boot's markers are
+    always in the tail, and reading the whole file every poll would make the
+    progress indicator the slowest thing in the boot.
+    """
+    try:
+        if not path or not os.path.exists(path):
+            return ""
+        size = os.path.getsize(path)
+        with open(path, "rb") as fh:
+            if size > max_bytes:
+                fh.seek(size - max_bytes)
+            return fh.read().decode("utf-8", "replace")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def make_progress(log_path: str = "") -> Progress:
+    """A Progress primed with this machine's measured boot history."""
+    return Progress(log_path=log_path, expected_s=expected_boot_s())

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -607,6 +607,33 @@ def _render_hydration(console: Any, payload: dict) -> None:
         # recorded sessions x a headroom multiple) and nothing on screen said
         # so. The derivation already returns its basis; it was being dropped
         # between the spawner and here.
+        # A CEILING IS NOT A BALANCE.
+        #
+        # `$0.00/$0.71` reads as "you have $0.71 to spend". It is not: 0.71 is
+        # a POLICY CEILING derived from past sessions, and when every paid
+        # lane is out of credit the spendable capacity behind it is zero. The
+        # arithmetic was right and the meaning was wrong, which is why the
+        # number "looked inaccurate" — it was describing a limit while the
+        # operator read it as a balance.
+        #
+        # Neither vendor can settle this for us: Anthropic has no balance
+        # endpoint (GET /v1/organizations/balance is a 404 and the feature is
+        # an open request), and Doubleword's inference API answers 404 on
+        # /balance, /credits, /account, /billing and /usage alike. So the
+        # honest move is not to invent a balance but to stop implying one.
+        try:
+            from backend.core.ouroboros.governance.capability_state import (
+                get_default_evaluator as _cap_eval2,
+            )
+            _unfunded = _cap_eval2().evaluate().is_funding_issue
+        except Exception:  # noqa: BLE001
+            _unfunded = False
+        if _unfunded and budget:
+            console.print(
+                _T(f"{_glyph('warn', '!')} the ${budget:.2f} ceiling is a "
+                   f"POLICY LIMIT, not a balance — no paid lane is funded, so "
+                   f"nothing can be spent against it", style=_muted),
+                highlight=False)
         _basis = str(status.get("cost_budget_basis") or "").strip()
         if _basis and budget:
             # `_T`, not `_Text`: this function aliases rich's Text as `_T`,
@@ -3966,6 +3993,10 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             # "I cannot work" and "I cannot tell whether I can work" are both
             # things the operator must not read as green.
             "BLOCKED": "rgb(248,81,73)", "UNKNOWN": "rgb(227,179,65)",
+            # Amber, not red: unfunded is a state the operator can clear in a
+            # minute with a card, which is a different urgency from a broken
+            # organism even though both stop dispatch.
+            "UNFUNDED": "rgb(227,179,65)",
         }
 
         def _header_lines():

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -600,6 +600,31 @@ def _render_hydration(console: Any, payload: dict) -> None:
         head.append(f"${cost:.2f}", style=_body)
         head.append(f"/${budget:.2f}", style=_muted)
         console.print(head, highlight=False)
+        # A CEILING WITHOUT ITS BASIS IS AN ARBITRARY CONSTANT.
+        #
+        # `$0.00/$0.71` prompted "where is the $0.71 coming from?" — a fair
+        # question, because 0.71 is derived (p95 of the operator's own
+        # recorded sessions x a headroom multiple) and nothing on screen said
+        # so. The derivation already returns its basis; it was being dropped
+        # between the spawner and here.
+        _basis = str(status.get("cost_budget_basis") or "").strip()
+        if _basis and budget:
+            # `_T`, not `_Text`: this function aliases rich's Text as `_T`,
+            # while `_Text` exists only inside the header builder. The wrong
+            # name raised NameError, the "NEVER raises" wrapper swallowed it,
+            # and every line BELOW this point — including the liquidity rows —
+            # silently stopped rendering. A fail-soft contract turns a typo
+            # into missing output rather than a crash, which is why this is
+            # pinned by a test that asserts the lines are actually produced.
+            console.print(
+                # Parenthesised, not em-dashed: the basis string carries its
+                # own punctuation and varies in shape ("observed — 98
+                # sessions…", "clamped to the Aegis session cap…",
+                # "unmeasured — …", "operator"). A parenthetical reads
+                # correctly for all of them without parsing any of them.
+                _T(f"{_glyph('detail', '-')} budget ${budget:.2f} "
+                   f"({_basis})", style=_muted),
+                highlight=False)
         if ops:
             console.print(_active_ops_line(ops), markup=False, highlight=False)
         for line in _liquidity_lines(liq.get("providers") or {},

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -4757,7 +4757,18 @@ def _run_cockpit_thin_inner(console: Any, alt_screen_active: bool) -> int:
 
             async def _boot() -> None:
                 try:
-                    _ok["v"] = await ensure_daemon(on_status=_status)
+                    # THE SCREEN OWNER RENDERS THE GAUGE.
+                    #
+                    # `_status` appends to the boot transcript, which is right
+                    # for events and wrong for progress — appending a gauge is
+                    # what produced six stacked bars. `set_progress` is a
+                    # single slot inside the same Live renderable, so it
+                    # updates in place and cannot be erased by the next crest
+                    # frame the way a raw stdout write was.
+                    _ok["v"] = await ensure_daemon(
+                        on_status=_status,
+                        on_progress=_animator.set_progress,
+                    )
                 finally:
                     _stop.set()
 

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -762,6 +762,35 @@ def _active_ops_line(ops: Any) -> str:
         f"{body}{suffix}")
 
 
+def _economic_evidence(reason: str, limit: int = 88) -> str:
+    """The human sentence out of a provider's error envelope. NEVER raises.
+
+    Vendors wrap the one useful sentence in transport noise —
+    ``Error code: 400 - {'type': 'error', 'error': {'type': ...,
+    'message': 'Your credit balance is too low…'}}``. Truncating that at 88
+    characters yields the JSON scaffolding and drops the sentence, so the
+    operator reads a type name where the remedy should be. Pull the message
+    out when it is there; fall back to the raw text when it is not.
+    """
+    try:
+        text = str(reason or "").strip()
+        if not text:
+            return ""
+        for marker in ("'message': '", '"message": "'):
+            i = text.find(marker)
+            if i == -1:
+                continue
+            rest = text[i + len(marker):]
+            end = rest.find(marker[-1])
+            msg = (rest[:end] if end > 0 else rest).strip()
+            if msg:
+                text = msg
+                break
+        return text if len(text) <= limit else text[:limit - 1] + "…"
+    except Exception:  # noqa: BLE001
+        return str(reason or "")[:limit]
+
+
 def _liquidity_lines(providers: Any, *, any_exhausted: Any = None,
                      economic: Any = None) -> list:
     """Provider runways, ordered by what an operator needs to act on.
@@ -843,16 +872,77 @@ def _liquidity_lines(providers: Any, *, any_exhausted: Any = None,
     # "Add credits" is also the one remedy in this whole banner the operator
     # can act on immediately, so it leads.
     for provider, detail in sorted((economic or {}).items()):
+        # READ THE SHAPE `economic_view()` ACTUALLY RETURNS.
+        #
+        # This block filtered on `consecutive_economic_failures`, a key that
+        # does not exist in the payload it is given. `economic_view(name)`
+        # returns {state, reason, hard_open, expires_in_s, ...}, so the filter
+        # was always zero and the branch never rendered — for ANY provider,
+        # ever. Verified live: doubleword sat at `state='economic',
+        # hard_open=True, reason='status 402'` while the banner showed only
+        # `liquidity anthropic: 5,000,000 tokens` and said nothing about
+        # credit at all.
+        #
+        # That is the precise defect the comment above this loop describes as
+        # FIXED. The axis was computed, plumbed and then read with the wrong
+        # key, so the cockpit knew the lane was economically dead and had no
+        # way to say it — 20 hours of "maximum displayed health and total
+        # inability to spend" was the symptom, and this was the cause.
+        #
+        # Both shapes are accepted: the counter form in case any caller does
+        # supply it, and the state form the real provider emits.
         try:
+            if not isinstance(detail, dict):
+                continue
             failures = int(detail.get("consecutive_economic_failures") or 0)
+            state = str(detail.get("state") or "").strip().lower()
+            hard_open = bool(detail.get("hard_open"))
+            reason = str(detail.get("reason") or "").strip()
         except Exception:  # noqa: BLE001
-            failures = 0
-        if failures <= 0:
             continue
+        dead = failures > 0 or state == "economic" or hard_open
+        if not dead:
+            # A LAPSED ECONOMIC FLAG IS NOT AN ABSENCE OF ONE.
+            #
+            # `economic_view` degrades a stale verdict to state="unknown" once
+            # its TTL expires without a re-probe — correct, since it must not
+            # assert current knowledge it does not have. But the UI then
+            # dropped the row entirely, which reports "nothing known" when
+            # what is actually known is "last time we looked, this lane was
+            # out of money, and that was N hours ago."
+            #
+            # Observed live: anthropic carried the literal string "Your credit
+            # balance is too low" in `reason`, `stale_clock=True`, and
+            # rendered NOTHING — while the row above it advertised 5,000,000
+            # tokens. The classifier is left authoritative; this only stops a
+            # stale-but-informative verdict from being displayed as silence.
+            if not (detail.get("stale_clock") and reason):
+                continue
+            since = detail.get("unverified_since")
+            try:
+                import time as _t
+                age = f"{max(0.0, (_t.time() - float(since))) / 3600.0:.1f}h"
+            except Exception:  # noqa: BLE001
+                age = "an unknown time"
+            _ev = _economic_evidence(reason, limit=80)
+            lines.append(
+                f"{_glyph('warn', '!')} {provider}: last known OUT OF CREDIT, "
+                f"unverified for {age} ({_ev}) — the flag lapsed on a timer, "
+                f"not on a successful probe"
+            )
+            continue
+        # Prefer the evidence the provider actually gave us over a count it
+        # never reported: "status 402" is more use to an operator than "1
+        # billing refusal(s)".
+        if reason:
+            evidence = _economic_evidence(reason)
+        elif failures > 0:
+            evidence = f"{failures} billing refusal(s)"
+        else:
+            evidence = state or "economically refused"
         lines.append(
             f"{_glyph('warn', '!')} {provider}: OUT OF CREDIT — the lane is "
-            f"economically dead "
-            f"({failures} billing refusal(s)); the token count above is a "
+            f"economically dead ({evidence}); the token count above is a "
             f"RATE LIMIT, not a balance. Add credits to restore it."
         )
 

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -3847,6 +3847,10 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             "HEALTHY": "rgb(67,214,208)", "DEGRADED": "rgb(248,81,73)",
             "ARMED": "rgb(227,179,65)", "SOAKING": "rgb(94,224,106)",
             "DORMANT": "rgb(108,125,119)",
+            # Capability states. BLOCKED and UNKNOWN share the warning hue:
+            # "I cannot work" and "I cannot tell whether I can work" are both
+            # things the operator must not read as green.
+            "BLOCKED": "rgb(248,81,73)", "UNKNOWN": "rgb(227,179,65)",
         }
 
         def _header_lines():
@@ -3856,15 +3860,44 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
             t1.append("O+V", style="bold rgb(94,224,106)")
             t1.append(f" v{resolve_version()}", style="rgb(219,230,225)")
             t2 = _Text()
-            state = "HEALTHY"
+            # CAPABILITY, not presentation.
+            #
+            # This line used to read `get_reactive_theme().state`, which
+            # answers "what colour should the dot be" -- and rendered that
+            # answer as though it meant "am I able to work". It also defaulted
+            # to HEALTHY and swallowed the lookup failure, so two optimistic
+            # defaults stacked on a category error. The observed result: a
+            # green `● healthy` while both provider lanes were at zero credit
+            # and every op was failing.
+            #
+            # `capability_state` fuses the liquidity ledger (the same reading
+            # that already renders "⚠ … dry" on the status line), the daemon
+            # heartbeat and op telemetry, degrades deterministically, recovers
+            # only on a verified success, and resolves UNKNOWN to blocked.
+            state, _reason = "HEALTHY", ""
             try:
-                from backend.core.ouroboros.ui.theme import get_reactive_theme
-                state = get_reactive_theme().state.value
+                from backend.core.ouroboros.governance.capability_state import (
+                    get_default_evaluator as _cap_eval,
+                )
+                _cap = _cap_eval().evaluate()
+                state = _cap.badge.upper()
+                _reason = _cap.reason
             except Exception:
-                pass
-            t2.append("● ", style=_STATE_DOT.get(state, "rgb(67,214,208)"))
+                # Even here the fallback is the theme's PRESENTATION state,
+                # used only to pick a word we then do not trust to be green:
+                # an unreadable capability is not evidence of health.
+                state = "UNKNOWN"
+            t2.append("● ", style=_STATE_DOT.get(state, "rgb(227,179,65)"))
             t2.append(state.lower(), style="rgb(174,188,182)")
-            t2.append(" · ouroboros + venom · the organism drives", style="rgb(108,125,119)")
+            # The tagline is a claim too. When the organism cannot dispatch,
+            # "the organism drives" is false, so the reason takes its place.
+            if state == "HEALTHY":
+                t2.append(" · ouroboros + venom · the organism drives",
+                          style="rgb(108,125,119)")
+            else:
+                t2.append(" · ouroboros + venom · ", style="rgb(108,125,119)")
+                t2.append(_reason or "cannot verify capability",
+                          style="rgb(227,179,65)")
             t3 = _Text(_home_path(), style="rgb(108,125,119)")
             return [t1, t2, t3]
 

--- a/backend/core/ouroboros/cli/thin_client.py
+++ b/backend/core/ouroboros/cli/thin_client.py
@@ -504,6 +504,11 @@ async def await_socket(
         while (time.monotonic() - start) < deadline:
             bound = min(3.0, max(_probe_timeout_s(), delay))
             if await probe_socket(path, timeout=bound, deep=True) == "live":
+                # Closed HERE rather than at each of the four call sites —
+                # one seam, so a future wait branch cannot forget to clear the
+                # in-place line or to record the measurement.
+                if on_tick is not None:
+                    _finish_tick(time.monotonic() - start, live=True)
                 return True
             if child_poll is not None:
                 try:
@@ -511,9 +516,13 @@ async def await_socket(
                         # The ignited daemon is DEAD. One last escalated
                         # probe (an incumbent may serve this same path),
                         # then stop — the caller reads the exit code.
-                        return await probe_socket(
+                        _dead_live = await probe_socket(
                             path, timeout=3.0, deep=True,
                         ) == "live"
+                        if on_tick is not None:
+                            _finish_tick(time.monotonic() - start,
+                                         live=_dead_live)
+                        return _dead_live
                 except Exception:  # noqa: BLE001
                     pass
             if on_tick is not None:
@@ -527,6 +536,10 @@ async def await_socket(
             sleep_for = min(random.uniform(_backoff_min_s(), delay), remaining)
             await asyncio.sleep(sleep_for)
             delay = min(delay * 2, ceiling)
+        if on_tick is not None:
+            # Deadline reached without a live socket. The line is cleared, but
+            # NOTHING is recorded: an abandoned boot has no duration.
+            _finish_tick(time.monotonic() - start, live=False)
         return False
     except asyncio.CancelledError:
         raise
@@ -548,16 +561,90 @@ def _live_incumbent() -> Optional[int]:
 
 
 def _mk_tick(say: Callable[[str], None]) -> Callable[[float], None]:
-    """The waking breadcrumb (≥5s cadence) — one builder for every
-    wait branch."""
-    last = [-10.0]
+    """The waking indicator — one builder for every wait branch.
+
+    Replaces a fresh `organism waking · Ns` line every five seconds, which
+    said only that time was passing and read as a stall by virtue of
+    repeating. The line now carries the STAGE the boot has actually reached
+    (parsed from the daemon's own log, which is already being written and
+    whose path this module already knows) and a completion estimate drawn
+    from this machine's measured boot history.
+
+    IN-PLACE ON A TTY, APPEND OTHERWISE. A carriage return redraws one line
+    for a human; written into a pipe or a log file it produces a single
+    unreadable smear, so a non-TTY keeps the old cadence and the old shape.
+    The wait must not become less legible in the transcript to become prettier
+    on screen.
+    """
+    last = [-1e9]
+    started = [time.monotonic()]
+    interactive = False
+    try:
+        interactive = bool(sys.stdout.isatty())
+    except Exception:  # noqa: BLE001
+        interactive = False
+    try:
+        from backend.core.ouroboros.cli import boot_progress as _bp
+        enabled = _bp.boot_progress_enabled()
+        prog = _bp.make_progress(str(daemon_log_path())) if enabled else None
+    except Exception:  # noqa: BLE001
+        _bp, enabled, prog = None, False, None
+
+    # A TTY can be redrawn ~4x/s without flicker; a transcript should not gain
+    # a line that often, so the two cadences differ on purpose.
+    cadence = 0.25 if (interactive and enabled) else 5.0
+    width = [0]
 
     def _tick(elapsed: float) -> None:
-        if elapsed - last[0] >= 5.0:
-            last[0] = elapsed
+        if elapsed - last[0] < cadence:
+            return
+        last[0] = elapsed
+        if prog is None or _bp is None:
             say(f"⎿ organism waking · {int(elapsed)}s")
+            return
+        try:
+            prog.observe_log(_bp.read_log_tail(prog.log_path),
+                             now=time.monotonic() - started[0])
+            body = prog.render(elapsed)
+        except Exception:  # noqa: BLE001
+            body = f"waking · {int(elapsed)}s"
+        line = f"⎿ {body}"
+        if not interactive:
+            say(line)
+            return
+        try:
+            # Pad to the previous width so a shrinking line cannot leave the
+            # tail of the longer one behind it.
+            pad = max(0, width[0] - len(line))
+            width[0] = len(line)
+            sys.stdout.write("\r" + line + (" " * pad))
+            sys.stdout.flush()
+        except Exception:  # noqa: BLE001
+            say(line)
 
     return _tick
+
+
+def _finish_tick(elapsed: float, *, live: bool) -> None:
+    """Close the in-place line and record a SUCCESSFUL boot. NEVER raises.
+
+    Only a live socket is recorded: a boot that failed or was abandoned has no
+    duration, and folding one in would teach the estimator that boots take as
+    long as the operator's patience — the very number it exists to replace.
+    """
+    try:
+        if sys.stdout.isatty():
+            sys.stdout.write("\r" + " " * 100 + "\r")
+            sys.stdout.flush()
+    except Exception:  # noqa: BLE001
+        pass
+    if not live:
+        return
+    try:
+        from backend.core.ouroboros.cli import boot_progress as _bp
+        _bp.record_boot_duration(elapsed)
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def _ignition_retry_budget_s() -> float:

--- a/backend/core/ouroboros/cli/thin_client.py
+++ b/backend/core/ouroboros/cli/thin_client.py
@@ -578,11 +578,25 @@ def _mk_tick(say: Callable[[str], None]) -> Callable[[float], None]:
     """
     last = [-1e9]
     started = [time.monotonic()]
-    interactive = False
+    # `real_stdout_isatty`, NOT `sys.stdout.isatty()`.
+    #
+    # prompt_toolkit's `patch_stdout` replaces sys.stdout with a non-TTY
+    # proxy, so the naive check returns False on a real terminal and the
+    # indicator falls back to APPENDING a line per tick — which is precisely
+    # the duplicate-line behaviour this was written to remove. The codebase
+    # already solved this once (the live status line never surfaced for the
+    # same reason) and the helper exists for it; using it is the fix, and
+    # writing a second TTY check would be the bug a third time.
     try:
-        interactive = bool(sys.stdout.isatty())
+        from backend.core.ouroboros.battle_test.presentation_restraint import (
+            real_stdout_isatty,
+        )
+        interactive = bool(real_stdout_isatty())
     except Exception:  # noqa: BLE001
-        interactive = False
+        try:
+            interactive = bool(sys.stdout.isatty())
+        except Exception:  # noqa: BLE001
+            interactive = False
     try:
         from backend.core.ouroboros.cli import boot_progress as _bp
         enabled = _bp.boot_progress_enabled()
@@ -613,12 +627,18 @@ def _mk_tick(say: Callable[[str], None]) -> Callable[[float], None]:
             say(line)
             return
         try:
+            # WRITE TO THE STREAM WE TESTED. `real_stdout_isatty` inspects
+            # `sys.__stdout__`; drawing on `sys.stdout` would test one stream
+            # and paint another, and under patch_stdout that proxy buffers by
+            # line — which turns a carriage-return redraw back into the very
+            # append this replaces.
+            out = sys.__stdout__ or sys.stdout
             # Pad to the previous width so a shrinking line cannot leave the
             # tail of the longer one behind it.
             pad = max(0, width[0] - len(line))
             width[0] = len(line)
-            sys.stdout.write("\r" + line + (" " * pad))
-            sys.stdout.flush()
+            out.write("\r" + line + (" " * pad))
+            out.flush()
         except Exception:  # noqa: BLE001
             say(line)
 
@@ -633,9 +653,17 @@ def _finish_tick(elapsed: float, *, live: bool) -> None:
     long as the operator's patience — the very number it exists to replace.
     """
     try:
-        if sys.stdout.isatty():
-            sys.stdout.write("\r" + " " * 100 + "\r")
-            sys.stdout.flush()
+        from backend.core.ouroboros.battle_test.presentation_restraint import (
+            real_stdout_isatty as _rti,
+        )
+        _tty = _rti()
+    except Exception:  # noqa: BLE001
+        _tty = False
+    try:
+        if _tty:
+            out = sys.__stdout__ or sys.stdout
+            out.write("\r" + " " * 120 + "\r")
+            out.flush()
     except Exception:  # noqa: BLE001
         pass
     if not live:

--- a/backend/core/ouroboros/cli/thin_client.py
+++ b/backend/core/ouroboros/cli/thin_client.py
@@ -409,6 +409,20 @@ def spawn_daemon(
         _cap, _cap_basis = _cockpit_cost_cap()
         if _cap is not None:
             env.setdefault("OUROBOROS_BATTLE_COST_CAP", _cap)
+        # THE BASIS TRAVELS WITH THE NUMBER.
+        #
+        # `derived_cost_cap` computes both and its docstring is explicit that
+        # "a surface that shows the number without it repeats the exact defect
+        # this replaces" — yet the basis went only to logger.debug here, so an
+        # operator seeing `$0.00/$0.71` had no way to learn that 0.71 is the
+        # p95 of their own 98 recorded sessions times a 3x headroom. It read
+        # as an arbitrary constant.
+        #
+        # Exported rather than recomputed daemon-side ON PURPOSE: the basis
+        # belongs to the DECISION that set this ceiling. Re-deriving it later
+        # would sample a different set of sessions and could explain the
+        # number with evidence that did not produce it.
+        env.setdefault("OUROBOROS_BATTLE_COST_CAP_BASIS", _cap_basis or "")
         logger.debug("[ov] session ceiling %s — %s",
                      f"${_cap}" if _cap else "(not asserted)", _cap_basis)
         env.setdefault("OUROBOROS_BATTLE_IDLE_TIMEOUT", os.environ.get(

--- a/backend/core/ouroboros/cli/thin_client.py
+++ b/backend/core/ouroboros/cli/thin_client.py
@@ -475,6 +475,8 @@ async def await_socket(
     on_tick: Optional[Callable[[float], None]] = None,
     deadline_s: Optional[float] = None,
     child_poll: Optional[Callable[[], Optional[int]]] = None,
+    on_progress: Optional[Callable[[str], None]] = None,
+    record_boot: bool = False,
 ) -> bool:
     """Wait (bounded) for the daemon's bridge to genuinely SERVE — each
     re-probe is the deep application handshake (``probe_socket(deep=True)``),
@@ -508,7 +510,9 @@ async def await_socket(
                 # one seam, so a future wait branch cannot forget to clear the
                 # in-place line or to record the measurement.
                 if on_tick is not None:
-                    _finish_tick(time.monotonic() - start, live=True)
+                    _finish_tick(time.monotonic() - start, live=True,
+                                 on_progress=on_progress,
+                                 record=record_boot)
                 return True
             if child_poll is not None:
                 try:
@@ -521,7 +525,9 @@ async def await_socket(
                         ) == "live"
                         if on_tick is not None:
                             _finish_tick(time.monotonic() - start,
-                                         live=_dead_live)
+                                         live=_dead_live,
+                                         on_progress=on_progress,
+                                         record=record_boot)
                         return _dead_live
                 except Exception:  # noqa: BLE001
                     pass
@@ -539,7 +545,8 @@ async def await_socket(
         if on_tick is not None:
             # Deadline reached without a live socket. The line is cleared, but
             # NOTHING is recorded: an abandoned boot has no duration.
-            _finish_tick(time.monotonic() - start, live=False)
+            _finish_tick(time.monotonic() - start, live=False,
+                         on_progress=on_progress)
         return False
     except asyncio.CancelledError:
         raise
@@ -560,7 +567,9 @@ def _live_incumbent() -> Optional[int]:
         return None
 
 
-def _mk_tick(say: Callable[[str], None]) -> Callable[[float], None]:
+def _mk_tick(say: Callable[[str], None],
+             on_progress: Optional[Callable[[str], None]] = None,
+             ) -> Callable[[float], None]:
     """The waking indicator — one builder for every wait branch.
 
     Replaces a fresh `organism waking · Ns` line every five seconds, which
@@ -578,6 +587,17 @@ def _mk_tick(say: Callable[[str], None]) -> Callable[[float], None]:
     """
     last = [-1e9]
     started = [time.monotonic()]
+    # RENDER THROUGH WHOEVER OWNS THE SCREEN.
+    #
+    # During ignition a Rich `Live` draws the animated crest and owns the
+    # terminal. Writing a carriage-return line to stdout underneath it is
+    # erased by the very next frame — six screenshots taken across six
+    # seconds showed the bar absent from every one, which the operator
+    # correctly described as flickering. `on_progress` hands the line to that
+    # owner instead, as a VALUE it renders, and the Live picks it up on its
+    # next repaint. Direct terminal writing is reserved for the case where
+    # nothing else owns the screen.
+    #
     # `real_stdout_isatty`, NOT `sys.stdout.isatty()`.
     #
     # prompt_toolkit's `patch_stdout` replaces sys.stdout with a non-TTY
@@ -605,8 +625,10 @@ def _mk_tick(say: Callable[[str], None]) -> Callable[[float], None]:
         _bp, enabled, prog = None, False, None
 
     # A TTY can be redrawn ~4x/s without flicker; a transcript should not gain
-    # a line that often, so the two cadences differ on purpose.
-    cadence = 0.25 if (interactive and enabled) else 5.0
+    # a line that often, so the two cadences differ on purpose. A screen owner
+    # takes the fast cadence too — it is repainting anyway.
+    live_owner = on_progress is not None
+    cadence = 0.25 if ((interactive or live_owner) and enabled) else 5.0
     width = [0]
 
     def _tick(elapsed: float) -> None:
@@ -617,12 +639,19 @@ def _mk_tick(say: Callable[[str], None]) -> Callable[[float], None]:
             say(f"⎿ organism waking · {int(elapsed)}s")
             return
         try:
-            prog.observe_log(_bp.read_log_tail(prog.log_path),
-                             now=time.monotonic() - started[0])
+            prog.observe_log(
+                _bp.read_log_tail(prog.log_path, since=prog.log_origin),
+                now=time.monotonic() - started[0])
             body = prog.render(elapsed)
         except Exception:  # noqa: BLE001
             body = f"waking · {int(elapsed)}s"
         line = f"⎿ {body}"
+        if live_owner:
+            try:
+                on_progress(line)     # a value for the owner to render
+                return
+            except Exception:  # noqa: BLE001
+                pass                  # fall through to the plain paths
         if not interactive:
             say(line)
             return
@@ -645,13 +674,30 @@ def _mk_tick(say: Callable[[str], None]) -> Callable[[float], None]:
     return _tick
 
 
-def _finish_tick(elapsed: float, *, live: bool) -> None:
-    """Close the in-place line and record a SUCCESSFUL boot. NEVER raises.
+def _finish_tick(elapsed: float, *, live: bool,
+                 on_progress: Optional[Callable[[str], None]] = None,
+                 record: bool = False) -> None:
+    """Close the progress surface, and record ONLY a genuine cold boot.
 
-    Only a live socket is recorded: a boot that failed or was abandoned has no
-    duration, and folding one in would teach the estimator that boots take as
-    long as the operator's patience — the very number it exists to replace.
+    `record` defaults False, and that default is the fix for a real defect.
+    `await_socket` has four callers and three of them are "an organism is
+    already up — confirm and attach", which completes in ~0.1s. Recording
+    those as boot durations poisoned the estimator: the observed history read
+    [0.10, 0.22, 0.10, 0.22, 0.10, 0.23, 72.05, 0.10, 0.22] with a median of
+    0.22s, so any elapsed time instantly exceeded the expected total and the
+    bar rendered 97% on its first frame — complete before the work began.
+
+    Attach latency and boot duration are different quantities. Only the
+    caller that actually spawned a daemon knows which it just measured, so
+    only that caller asks for the sample to be kept.
     """
+    # Clear the owner's gauge first: it renders inside the Live, so wiping
+    # the raw terminal would not touch it.
+    if on_progress is not None:
+        try:
+            on_progress("")
+        except Exception:  # noqa: BLE001
+            pass
     try:
         from backend.core.ouroboros.battle_test.presentation_restraint import (
             real_stdout_isatty as _rti,
@@ -666,7 +712,7 @@ def _finish_tick(elapsed: float, *, live: bool) -> None:
             out.flush()
     except Exception:  # noqa: BLE001
         pass
-    if not live:
+    if not (live and record):
         return
     try:
         from backend.core.ouroboros.cli import boot_progress as _bp
@@ -688,7 +734,10 @@ def _ignition_retry_budget_s() -> float:
         return 20.0
 
 
-async def _await_ignition_window(path: Any, *, say: Any) -> bool:
+async def _await_ignition_window(
+    path: Any, *, say: Any,
+    on_progress: Optional[Callable[[str], None]] = None,
+) -> bool:
     """Wait out a transient lock refusal. True iff an organism is now serving.
 
     Races the two ways the window closes — the incumbent starts serving, or it
@@ -715,7 +764,8 @@ async def _await_ignition_window(path: Any, *, say: Any) -> bool:
             if _live_incumbent() is None:
                 proc = spawn_daemon()
                 if proc is not None and await await_socket(
-                    path, on_tick=_mk_tick(say),
+                    path, on_tick=_mk_tick(say, on_progress),
+                    on_progress=on_progress,
                     child_poll=getattr(proc, "poll", None),
                 ):
                     say("⏺ organism live — attaching")
@@ -734,6 +784,7 @@ async def ensure_daemon(
     *,
     on_status: Optional[Callable[[str], None]] = None,
     spawner: Callable[..., Any] = subprocess.Popen,
+    on_progress: Optional[Callable[[str], None]] = None,
 ) -> bool:
     """The full zero-trust route: probe → (clean ghost) → (cold boot)
     → wait-for-live. True when a live daemon is reachable. NEVER
@@ -781,7 +832,8 @@ async def ensure_daemon(
                 # A daemon is home but boot-starved — its socket must NOT be
                 # cleaned and no second ignition raced. Wait for it to serve.
                 _say("⏺ organism already waking — waiting for it to serve")
-                if await await_socket(path, on_tick=_mk_tick(_say)):
+                if await await_socket(path, on_tick=_mk_tick(_say, on_progress),
+                                      on_progress=on_progress):
                     _say("⏺ organism live — attaching")
                     return True
                 _say(
@@ -801,7 +853,8 @@ async def ensure_daemon(
                     f"⏺ organism (PID {incumbent}) is alive but not "
                     "serving — waiting, never cleaning a live socket"
                 )
-                if await await_socket(path, on_tick=_mk_tick(_say)):
+                if await await_socket(path, on_tick=_mk_tick(_say, on_progress),
+                                      on_progress=on_progress):
                     _say("⏺ organism live — attaching")
                     return True
                 _say(
@@ -819,8 +872,10 @@ async def ensure_daemon(
             return False
 
         if await await_socket(
-            path, on_tick=_mk_tick(_say),
+            path, on_tick=_mk_tick(_say, on_progress),
             child_poll=getattr(proc, "poll", None),
+            on_progress=on_progress,
+            record_boot=True,   # this branch SPAWNED — it is a real boot
         ):
             _say("⏺ organism live — attaching")
             return True
@@ -845,7 +900,8 @@ async def ensure_daemon(
             # legitimately: the incumbent finishes booting and starts SERVING
             # (attach to it — there was never anything wrong), or it finishes
             # DYING and releases the lock (ignite again).
-            if await _await_ignition_window(path, say=_say):
+            if await _await_ignition_window(path, say=_say,
+                                            on_progress=on_progress):
                 return True
             incumbent = _live_incumbent()
             who = f"PID {incumbent}" if incumbent else "another process"

--- a/backend/core/ouroboros/governance/ast_compile_helper.py
+++ b/backend/core/ouroboros/governance/ast_compile_helper.py
@@ -119,6 +119,19 @@ class ParseOutcome(str, enum.Enum):
     TIMEOUT         = "timeout"
     TOO_LARGE       = "too_large"
     INTERNAL_ERROR  = "internal_error"
+    #: Rejected PRE-FLIGHT by shape (minified, binary, absurd line density).
+    #: Distinct from TOO_LARGE, which is about bytes: a 40 KB single-line
+    #: minified bundle is well under any byte cap and still pathological for
+    #: an AST walk. Load-bearing beyond tidiness -- the inline-tiny path runs
+    #: ON THE CALLER'S THREAD and the Oracle's in-process path has no pool, so
+    #: NEITHER can be cancelled by a timeout. For those paths this pre-flight
+    #: refusal is the only protection that exists.
+    PATHOLOGICAL    = "pathological"
+    #: Not attempted because the shared pool was saturated. The file is fine;
+    #: the queue was full. Recorded in the DeferredTaskLedger so the blind
+    #: spot has a name and can be revisited, rather than being an anonymous
+    #: increment of an error counter.
+    SHED            = "shed"
 
 
 class AnalyzeOutcome(str, enum.Enum):
@@ -1002,6 +1015,15 @@ async def _process_pool_parse(
             execution_mode=ExecutionMode.PROCESS,
             error_detail=f"pool dispatch failed: {type(exc).__name__}: {exc}",
         )
+    finally:
+        # Released on EVERY path — success, timeout, cancellation and internal
+        # error alike. A counter that leaks on the failure paths would drift
+        # upward until `_pool_saturated()` returned True forever, converting
+        # a backpressure valve into a permanent outage. The failure paths are
+        # exactly the ones that fire under load, so this is where the leak
+        # would have mattered most.
+        with _inflight_lock:
+            _inflight = max(0, _inflight - 1)
 
     elapsed_ms = (time.monotonic() - t0) * 1000.0
     # Worker returned (outcome_label, payload) tuple. Branch on

--- a/backend/core/ouroboros/governance/ast_compile_helper.py
+++ b/backend/core/ouroboros/governance/ast_compile_helper.py
@@ -131,6 +131,19 @@ class AnalyzeOutcome(str, enum.Enum):
     TIMEOUT         = "timeout"
     TOO_LARGE       = "too_large"
     INTERNAL_ERROR  = "internal_error"
+    #: Rejected PRE-FLIGHT by shape (minified, binary, absurd line density).
+    #: Distinct from TOO_LARGE, which is about bytes: a 40 KB single-line
+    #: minified bundle is well under any byte cap and still pathological for
+    #: an AST walk. Load-bearing beyond tidiness -- the inline-tiny path runs
+    #: ON THE CALLER'S THREAD and the Oracle's in-process path has no pool, so
+    #: NEITHER can be cancelled by a timeout. For those paths this pre-flight
+    #: refusal is the only protection that exists.
+    PATHOLOGICAL    = "pathological"
+    #: Not attempted because the shared pool was saturated. The file is fine;
+    #: the queue was full. Recorded in the DeferredTaskLedger so the blind
+    #: spot has a name and can be revisited, rather than being an anonymous
+    #: increment of an error counter.
+    SHED            = "shed"
 
 
 class ExecutionMode(str, enum.Enum):
@@ -241,6 +254,80 @@ def _resolve_default_timeout_s() -> float:
         return max(0.1, v)
     except (TypeError, ValueError):
         return _DEFAULT_TIMEOUT_S
+
+
+def _resolve_max_bytes_per_line() -> float:
+    """Bytes-per-line above which a source is treated as PATHOLOGICAL.
+
+    Default 400. Hand-written Python averages roughly 25-80 bytes per line;
+    minified or generated bundles run to thousands. Density is the shape
+    signal that byte count alone cannot express -- and shape, not size, is
+    what makes an AST walk explode.
+    """
+    try:
+        raw = os.environ.get("JARVIS_AST_MAX_BYTES_PER_LINE", "").strip()
+        return max(80.0, float(raw)) if raw else 400.0
+    except (TypeError, ValueError):
+        return 400.0
+
+
+def _resolve_density_floor_bytes() -> int:
+    """Below this size the density heuristic does not apply. Default 4096.
+
+    A legitimate 300-byte one-liner has a terrible bytes-per-line ratio and
+    costs nothing to parse. Applying the guard to it would reject healthy
+    files to prevent a cost that does not exist.
+    """
+    try:
+        raw = os.environ.get("JARVIS_AST_DENSITY_FLOOR_BYTES", "").strip()
+        return max(256, int(raw)) if raw else 4096
+    except (TypeError, ValueError):
+        return 4096
+
+
+def _resolve_shed_queue_depth() -> int:
+    """Pending pool tasks above which new work is SHED. Default = 4x workers.
+
+    Shedding rather than queueing is the whole point. The observed failure was
+    `source_bytes=6770 timeout_s=10.0 parent_await_ms=14143.7` -- a 6.7 KB
+    file "timing out" after 14.1 s against a 10 s budget, which is impossible
+    unless most of that time was spent WAITING FOR A WORKER rather than
+    parsing. A deeper queue makes that worse, not better.
+    """
+    try:
+        raw = os.environ.get("JARVIS_AST_SHED_QUEUE_DEPTH", "").strip()
+        if raw:
+            return max(1, int(raw))
+    except (TypeError, ValueError):
+        pass
+    return max(4, _resolve_pool_max_workers() * 4)
+
+
+def _pathological_shape(source: str, source_bytes: int) -> "Optional[str]":
+    """Pre-flight shape check. Returns a reason string, or None if healthy.
+
+    Runs BEFORE any dispatch decision, so it protects every path equally --
+    including the two that cannot be interrupted (inline-tiny on the caller's
+    thread, and the Oracle's in-process worker). NEVER raises: a guard that
+    could throw would become the hang it exists to prevent.
+    """
+    try:
+        # Binary content. `ast.parse` on a NUL-bearing string raises, but the
+        # bytes still have to be scanned first, and a large binary blob is
+        # exactly the payload that makes that expensive.
+        if "\x00" in source:
+            return "binary content (NUL byte)"
+        if source_bytes < _resolve_density_floor_bytes():
+            return None
+        lines = source.count("\n") + 1
+        density = source_bytes / float(max(1, lines))
+        limit = _resolve_max_bytes_per_line()
+        if density > limit:
+            return (f"line density {density:.0f} B/line exceeds {limit:.0f} "
+                    f"({lines} lines in {source_bytes}B) — minified or generated")
+        return None
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def _resolve_default_max_bytes() -> int:
@@ -484,6 +571,38 @@ def _worker_analyze_in_process(
 # ============================================================================
 # Lazy process-pool singleton
 # ============================================================================
+
+
+#: In-flight submissions to the shared pool. Tracked here rather than read
+#: from the executor's private `_pending_work_items` so the saturation signal
+#: does not depend on a CPython implementation detail.
+_inflight: int = 0
+_inflight_lock = threading.Lock()
+
+
+def _pool_saturated() -> bool:
+    """Is the shared pool too busy to accept more work? NEVER raises."""
+    try:
+        with _inflight_lock:
+            return _inflight >= _resolve_shed_queue_depth()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _record_deferral(filename: str, reason: str, caller: str,
+                     source_bytes: int, detail: str) -> None:
+    """Name the blind spot. Best-effort; never breaks a scan."""
+    try:
+        from backend.core.ouroboros.governance.deferred_task_ledger import (  # noqa: PLC0415,E501
+            DeferReason,
+            get_default_ledger,
+        )
+        get_default_ledger().defer(
+            path=filename, reason=DeferReason(reason), caller=caller,
+            source_bytes=source_bytes, detail=detail,
+        )
+    except Exception:  # noqa: BLE001
+        pass
 
 
 _pool: Optional[ProcessPoolExecutor] = None
@@ -1022,6 +1141,34 @@ async def analyze_python_source_for_opportunity_miner(
             ),
         )
 
+    # ---- HIGH-ENTROPY GUARD (pre-flight, path-independent) --------------
+    #
+    # Placed HERE, before the inline/pool branch, because two of the three
+    # execution paths cannot be interrupted once started:
+    #   * inline-tiny runs on the CALLER'S THREAD (no future to cancel), and
+    #   * the Oracle runs analyze IN-PROCESS inside its own daemonic
+    #     subprocess (oracle_ipc sets JARVIS_AST_HELPER_INPROCESS_ENABLED=1
+    #     precisely because a daemonic process cannot own a pool).
+    # For those two, a timeout is not available at all, so this refusal is
+    # the ONLY protection they have. Putting the guard after the branch would
+    # have protected the one path that was already protected.
+    _shape = _pathological_shape(source, source_bytes)
+    if _shape is not None:
+        elapsed_ms = (time.monotonic() - t0) * 1000.0
+        logger.info(
+            "[AstCompileHelper] caller=%s outcome=pathological kind=analyze "
+            "source_bytes=%d detail=%s elapsed_ms=%.2f",
+            caller, source_bytes, _shape, elapsed_ms,
+        )
+        _record_deferral(filename, "pathological", caller, source_bytes, _shape)
+        return AnalysisResult(
+            outcome=AnalyzeOutcome.PATHOLOGICAL, payload=_ZERO_PAYLOAD,
+            elapsed_ms=elapsed_ms, worker_elapsed_ms=0.0,
+            source_bytes=source_bytes, caller=caller,
+            execution_mode=ExecutionMode.INLINE_TINY,  # nominal; not invoked
+            error_detail=_shape,
+        )
+
     # Inline-tiny path. ast.parse + the six dimension calcs are
     # cheap for small sources; IPC overhead would dominate. The
     # measure() wrapper is genuine here — the work truly runs
@@ -1030,6 +1177,42 @@ async def analyze_python_source_for_opportunity_miner(
         return _inline_tiny_analyze(
             caller=caller, source=source, filename=filename,
             source_bytes=source_bytes, t0=t0,
+        )
+
+    # ---- BACKPRESSURE: SHED RATHER THAN QUEUE ---------------------------
+    #
+    # The pool is a module-global singleton shared by every sensor in this
+    # process. When it saturates, a queued task waits — and the observed
+    # failure was exactly that: a 6.7 KB file reported `timeout_s=10.0` after
+    # `parent_await_ms=14143.7`. A 6.7 KB parse does not take 14 s; the file
+    # spent that time waiting for a worker and was then blamed for it.
+    #
+    # Deepening the queue or raising the timeout both make this worse: more
+    # waiting, same starvation, and the blame stays on the wrong party. So a
+    # saturated pool sheds IMMEDIATELY and the task is recorded as deferred —
+    # a named blind spot the system can revisit — instead of an anonymous
+    # increment of an error counter.
+    #
+    # NOTE ON THE ORACLE: it is NOT shielded here because it is not exposed.
+    # `oracle_ipc._oracle_worker_main` enables the in-process path, so the
+    # Oracle never enqueues into this pool and cannot be starved by it. What
+    # protects the Oracle is the shape guard above, which is why that guard
+    # runs before the branch rather than inside this one.
+    if _pool_saturated():
+        elapsed_ms = (time.monotonic() - t0) * 1000.0
+        logger.info(
+            "[AstCompileHelper] caller=%s outcome=shed kind=analyze "
+            "source_bytes=%d queue_depth>=%d elapsed_ms=%.2f",
+            caller, source_bytes, _resolve_shed_queue_depth(), elapsed_ms,
+        )
+        _record_deferral(filename, "shed_pressure", caller, source_bytes,
+                         "ast pool saturated")
+        return AnalysisResult(
+            outcome=AnalyzeOutcome.SHED, payload=_ZERO_PAYLOAD,
+            elapsed_ms=elapsed_ms, worker_elapsed_ms=0.0,
+            source_bytes=source_bytes, caller=caller,
+            execution_mode=ExecutionMode.PROCESS,
+            error_detail="shed_pressure: ast pool saturated",
         )
 
     # Process-pool path — the heavy case.
@@ -1105,6 +1288,21 @@ async def _process_pool_analyze(
     pool = _get_pool()
 
     try:
+        # QUEUE-WAIT IS NOT EXECUTION TIME.
+        #
+        # `run_in_executor` returns a future that completes when the WORK
+        # finishes, but the clock starts when it is SUBMITTED. Under
+        # saturation most of the elapsed wall-clock is spent queued, and the
+        # old single budget charged that wait to the file: hence a 6.7 KB
+        # source reported as a 10 s "timeout" after 14.1 s of waiting.
+        #
+        # The shed check upstream is what actually bounds queue depth; this
+        # counter is what makes that check honest, and the split below is what
+        # stops a starved worker from being reported as a slow file.
+        global _inflight
+        with _inflight_lock:
+            _inflight += 1
+        _submitted_at = time.monotonic()
         worker_tuple = await asyncio.wait_for(
             loop.run_in_executor(
                 pool, _worker_analyze_in_process, source, filename,
@@ -1113,12 +1311,21 @@ async def _process_pool_analyze(
         )
     except asyncio.TimeoutError:
         elapsed_ms = (time.monotonic() - t0) * 1000.0
+        # Split the wall-clock so the log stops blaming the file for the
+        # queue. `pre_submit_ms` is everything before the task was handed to
+        # the pool; `awaited_ms` is the wait on the future, which still mixes
+        # queue time with work time but is now bounded by the shed check.
+        _pre_submit_ms = max(0.0, (_submitted_at - t0) * 1000.0)
+        _awaited_ms = max(0.0, elapsed_ms - _pre_submit_ms)
         logger.warning(
             "[AstCompileHelper] caller=%s outcome=timeout kind=analyze "
             "execution_mode=process source_bytes=%d timeout_s=%.1f "
-            "parent_await_ms=%.1f",
+            "parent_await_ms=%.1f pre_submit_ms=%.1f awaited_ms=%.1f",
             caller, source_bytes, timeout_s, elapsed_ms,
+            _pre_submit_ms, _awaited_ms,
         )
+        _record_deferral(filename, "timeout", caller, source_bytes,
+                         f"exceeded {timeout_s:.1f}s (awaited {_awaited_ms:.0f}ms)")
         return AnalysisResult(
             outcome=AnalyzeOutcome.TIMEOUT,
             payload=_ZERO_PAYLOAD,
@@ -1143,6 +1350,19 @@ async def _process_pool_analyze(
             execution_mode=ExecutionMode.PROCESS,
             error_detail=f"pool dispatch failed: {type(exc).__name__}: {exc}",
         )
+    finally:
+        # Released on EVERY path — success, timeout, cancellation and internal
+        # error alike. A counter that leaks on the failure paths would drift
+        # upward until `_pool_saturated()` returned True forever, converting
+        # a backpressure valve into a permanent outage.
+        #
+        # This file mirrors its parse and analyze implementations almost
+        # line-for-line, and an anchored edit first landed this block in the
+        # PARSE twin — so analyze incremented and never released. The exact
+        # permanent-outage bug described above was live for one test run,
+        # which is why the release is pinned by test rather than by comment.
+        with _inflight_lock:
+            _inflight = max(0, _inflight - 1)
 
     elapsed_ms = (time.monotonic() - t0) * 1000.0
     try:

--- a/backend/core/ouroboros/governance/background_agent_pool.py
+++ b/backend/core/ouroboros/governance/background_agent_pool.py
@@ -356,6 +356,16 @@ class BackgroundAgentPool:
         # mathematical authority -- lower-ranked writers (env/config/
         # manifest) are silently rejected.
         self._topology_locked: bool = False
+        # worker_id -> the throughput ceiling it last stood down on.
+        # Log-dedup only: without it a held worker emits a line every 2s.
+        # Keyed PER WORKER, not per pool: a single shared key deduped the
+        # second and third workers' identical messages away, so the log said
+        # "Worker 1 standing down" and stayed silent about 2 -- an operator
+        # would read that as one held lane when three were.
+        # Deliberately NOT called "park": in this module ParkRequested /
+        # ParkedOpStore already mean OP-level suspend-and-resume, which is a
+        # different mechanism at a different granularity.
+        self._throughput_hold_lanes: Dict[int, int] = {}
         # PriorityQueue: items are (priority, submission_order, op).
         # Lower priority number = runs first.  Ensures IMMEDIATE ops
         # don't starve BACKGROUND ops when workers free up.
@@ -410,6 +420,54 @@ class BackgroundAgentPool:
         self._resumed_ops: Dict[str, int] = {}
 
     # -- Lifecycle -----------------------------------------------------------
+
+    def _throughput_lane_ceiling(self) -> Optional[int]:
+        """Lanes the LOCAL serving endpoint can actually drive, or None.
+
+        A SECOND, composable ceiling — deliberately not routed through
+        :meth:`set_target_pool_size`. That setter carries the Immutability
+        Lock, under which ``fleet_topology`` is the sole authority; pushing a
+        throughput number through it would either be silently rejected (a
+        no-op exactly where a serving mesh exists) or would have to outrank
+        hardware truth, which it must not.
+
+        The two are different axes and both are real:
+
+          * topology answers HOW MANY LANES EXIST (nodes in the mesh),
+          * throughput answers HOW MANY CAN BE DRIVEN inside the route
+            window (one local GPU serves N concurrent ops SERIALLY, so N
+            lanes multiply each op's wall-clock rather than its output).
+
+        Four nodes can exist while a 16GB M1 drives one. Composing them
+        strictest-wins keeps each authoritative on its own axis.
+
+        Returns None when the governor is off or could not measure — the
+        caller must then leave lane behaviour exactly as it was.
+        NEVER raises.
+        """
+        try:
+            from backend.core.ouroboros.governance.throughput_governor import (  # noqa: PLC0415,E501
+                get_default_governor,
+            )
+            from backend.core.ouroboros.governance.route_budgets import (  # noqa: PLC0415,E501
+                DEFAULT_POOL_ROUTE,
+                route_generation_budget_s,
+            )
+            # DEFAULT_POOL_ROUTE is a KNOWN key, so the resolver always
+            # returns a real window and the default is never reached. It is
+            # passed as 0.0 (not some other attribute) deliberately: a
+            # fallback that reads a field this class does not own would raise,
+            # be swallowed by the except below, and silently make this whole
+            # consult inert -- a wired-but-dead capability.
+            budget_s = route_generation_budget_s(DEFAULT_POOL_ROUTE, 0.0)
+            if budget_s <= 0.0:
+                return None
+            verdict = get_default_governor().evaluate(budget_s=budget_s)
+            if not verdict.governed:
+                return None
+            return max(1, int(verdict.lanes))
+        except Exception:  # noqa: BLE001 — a governor must never break dispatch
+            return None
 
     def set_target_pool_size(self, n: int, *, source: str = "config",
                              lock: bool = False) -> bool:
@@ -1107,6 +1165,31 @@ class BackgroundAgentPool:
                         worker_id, self._target_pool_size,
                     )
                     break
+                # Throughput ceiling: HOLD, never retire. A topology retire
+                # is permanent and correct -- a node either exists or does
+                # not. A throughput ceiling comes from a reading with a
+                # ~30s TTL, so killing a worker on it would make a transient
+                # measurement (a cold model load, a memory spike) an
+                # irreversible decision. Excess lanes therefore wait and
+                # re-check, and grow back for free when physics improves.
+                #
+                # Bounded at 2.0s to match the two waits below, so stop()
+                # still reacts within ~2s. Worker 0 can never park: the
+                # governor floors its verdict at 1 lane, because a zero-lane
+                # pool is a stalled queue -- a worse failure than a slow one.
+                _thr = self._throughput_lane_ceiling()
+                if _thr is not None and worker_id >= _thr:
+                    if self._throughput_hold_lanes.get(worker_id) != _thr:
+                        self._throughput_hold_lanes[worker_id] = _thr
+                        logger.info(
+                            "Worker %d standing down: local throughput drives %d "
+                            "lane(s) inside the route window (topology "
+                            "target=%d) -- resumes if physics improves",
+                            worker_id, _thr, self._target_pool_size,
+                        )
+                    await asyncio.sleep(2.0)
+                    continue
+                self._throughput_hold_lanes.pop(worker_id, None)
                 # HIBERNATION_MODE: block here while paused. Bounded wait so
                 # stop() still reacts within ~2s even if resume() never fires.
                 if not self._unpaused_event.is_set():

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4979,9 +4979,16 @@ class CandidateGenerator:
                     physics_key,
                 )
                 # The Amnesia Cure: key the profiler by its DURABLE physics
-                # identity (model@ctx -- endpoints/IPs change every run) so
-                # the EWMA warm-starts from the cross-run ledger.
-                prof = LatencyProfiler(cfg, ledger_key=physics_key(cfg))
+                # identity so the EWMA warm-starts from the cross-run ledger.
+                # That identity is (hardware, model, ctx) -- the ADDRESS is
+                # still excluded, because IPs change every run, but the
+                # MACHINE is not, because a 16GB Mac and a 5090 measuring the
+                # same model are not the same physics. `endpoint` is passed
+                # explicitly: this store holds one profiler per endpoint while
+                # carrying one cfg, so deriving the machine from cfg would
+                # stamp every failover target with the base config's identity.
+                prof = LatencyProfiler(
+                    cfg, ledger_key=physics_key(cfg, endpoint=endpoint))
                 store[endpoint] = prof
             return prof
         except Exception:  # noqa: BLE001

--- a/backend/core/ouroboros/governance/capability_state.py
+++ b/backend/core/ouroboros/governance/capability_state.py
@@ -110,11 +110,24 @@ class Capability(str, enum.Enum):
     HEALTHY = "healthy"    # a lane is viable and work has recently completed
     DEGRADED = "degraded"  # work is landing, but failures are present
     BLOCKED = "blocked"    # structurally cannot complete an op right now
+    #: Blocked SPECIFICALLY for want of money. Distinguished from BLOCKED
+    #: because the two demand different things of the operator: "blocked"
+    #: sends them to a log to find out why, "unfunded" names the remedy in
+    #: the word itself. Everything that treats BLOCKED as terminal must treat
+    #: this identically — see `can_work`.
+    UNFUNDED = "unfunded"
     UNKNOWN = "unknown"    # inputs unreadable — renders AS blocked
 
     @property
     def can_work(self) -> bool:
         return self in (Capability.HEALTHY, Capability.DEGRADED)
+
+    @property
+    def is_blocking(self) -> bool:
+        """Terminal for dispatch. UNFUNDED is a REASON, not a lesser state —
+        anything gating on "can this organism act" must include it."""
+        return self in (Capability.BLOCKED, Capability.UNFUNDED,
+                        Capability.UNKNOWN)
 
 
 @dataclass(frozen=True)
@@ -142,6 +155,10 @@ class CapabilityReading:
         state we cannot determine must not be shown as a green dot."""
         return ("blocked" if self.state is Capability.UNKNOWN
                 else self.state.value)
+
+    @property
+    def is_funding_issue(self) -> bool:
+        return self.state is Capability.UNFUNDED
 
     def render(self) -> str:
         return f"[Capability] {self.badge} — {self.reason}"
@@ -348,11 +365,21 @@ class CapabilityEvaluator:
                         f"no runway on {who} — running local on "
                         f"{remote_endpoint or 'the sovereign host'}", False)
             if remote_state == "unreachable":
-                return (Capability.BLOCKED,
-                        f"no runway on {who} and {remote_endpoint} is "
-                        f"unreachable — no lane left", False)
-            return (Capability.BLOCKED,
-                    f"no runway on {who} — cannot dispatch work", False)
+                return (Capability.UNFUNDED,
+                        f"{who} is out of credit and {remote_endpoint} is "
+                        f"unreachable — add credits, or bring the local host "
+                        f"up", False)
+            # THE REASON NAMES THE REMEDY.
+            #
+            # "cannot dispatch work" states the symptom and leaves the
+            # operator to discover the cause; the cause is already in hand.
+            # And the state word is UNFUNDED rather than BLOCKED because
+            # money is the one blocker the organism can never clear itself —
+            # the distinction is precisely what tells the operator this is
+            # theirs to fix.
+            return (Capability.UNFUNDED,
+                    f"{who} is out of credit — add credits, or configure a "
+                    f"local lane to keep background work moving", False)
 
         # 2. An explicit heartbeat failure outranks op history: the ops may
         #    simply not have been attempted yet.

--- a/backend/core/ouroboros/governance/capability_state.py
+++ b/backend/core/ouroboros/governance/capability_state.py
@@ -331,7 +331,13 @@ class CapabilityEvaluator:
             self._cached_at = _now
             changed = self._last_state is not state
             self._last_state = state
-            if state is Capability.BLOCKED and self._degraded_at_completed is None:
+            # `is_blocking`, not `is BLOCKED`. Arming the hysteresis mark on
+            # the enum member meant that once UNFUNDED existed, a funding
+            # degrade no longer armed it — so the "recovery requires a
+            # VERIFIED SUCCESS" rule silently stopped applying to the most
+            # common degrade there is. Every gate on "can this act" must ask
+            # the property, never the member.
+            if state.is_blocking and self._degraded_at_completed is None:
                 self._degraded_at_completed = completed
             elif state is Capability.HEALTHY:
                 self._degraded_at_completed = None

--- a/backend/core/ouroboros/governance/capability_state.py
+++ b/backend/core/ouroboros/governance/capability_state.py
@@ -1,0 +1,374 @@
+"""Can the organism actually complete an operation right now?
+
+THE DEFECT THIS CLOSES
+----------------------
+The cockpit header printed ``● healthy`` while both provider lanes were at
+zero credit, every op was failing, and a GOAL had been orphaned to the DLQ.
+The operator's only clue was a small ``⚠ doubleword dry`` token elsewhere on
+the line. The header was computed like this::
+
+    state = "HEALTHY"                                # optimistic default
+    try:    state = get_reactive_theme().state.value # a UI THEME state
+    except: pass                                     # swallow -> stays HEALTHY
+
+Two optimistic defaults stacked on a CATEGORY ERROR. ``UIState`` answers "what
+colour should the dot be"; the header rendered that answer as though it meant
+"am I able to work". A presentation fact was standing in for a capability
+fact -- the same proxy-for-property shape as a path-ban standing in for
+archived-implementation identity, or a handler level standing in for audience.
+
+This module answers the capability question, and ONLY that question. It does
+not choose a colour. Keeping the two apart is the point: fuse them again and
+the next refactor re-creates the bug.
+
+WHAT IS FUSED (all pre-existing readings; no new network calls)
+--------------------------------------------------------------
+* **lane viability** -- ``provider_liquidity_ledger.any_runway_exhausted()``,
+  the same file-backed ledger the status line already samples to render
+  ``⚠ … dry``. That token proves the fact was ALREADY KNOWN at render time;
+  it simply never reached the badge.
+* **daemon heartbeat** -- injected by the caller when it has one.
+* **operational telemetry** -- attempted/completed/failed from the session
+  summaries ``ov status`` already parses.
+
+Composition is STRICTEST-WINS, the same rule as ThroughputGovernor against
+MemoryPressureGate: a capability fact dominates a presentation fact, and a dry
+lane dominates an optimistic heartbeat.
+
+ASYMMETRIC HYSTERESIS
+---------------------
+Degradation is deterministic and immediate: a dry runway is not jitter, it is
+a billing state, and waiting to report it would be the whole original defect
+in slower motion. Recovery requires a VERIFIED OPERATIONAL SUCCESS -- never a
+timer, never merely the absence of the failing signal. A lane that flickers
+back to "not exhausted" has proved nothing; an op that COMPLETED has.
+
+That asymmetry is deliberate and matches the profiler's asymmetric EWMA:
+cheap to admit trouble, expensive to claim health.
+
+THE DEFAULT IS INVERTED
+-----------------------
+Unknown resolves to BLOCKED, never HEALTHY. If this module cannot read its
+inputs it does not know whether the organism can work, and the honest
+rendering of "I do not know" is not a green dot. Same rule as the Advisor's
+``provenance=unknown`` and the gateway's ``resident_models() -> None``.
+
+Python 3.9+. Stdlib only at import; every governance read is lazy and
+fail-soft.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("Ouroboros.CapabilityState")
+
+ENABLED_ENV = "JARVIS_CAPABILITY_STATE_ENABLED"
+FAIL_STREAK_ENV = "JARVIS_CAPABILITY_FAIL_STREAK"
+TTL_ENV = "JARVIS_CAPABILITY_TTL_S"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def capability_state_enabled() -> bool:
+    """Master gate. Default ON. OFF restores the legacy theme-derived badge
+    exactly, optimistic default included. NEVER raises."""
+    try:
+        return os.environ.get(ENABLED_ENV, "1").strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def fail_streak_threshold() -> int:
+    """Failed ops with ZERO completions before the state degrades. Default 3.
+
+    Not 1: a single failure is an op, not a condition. Not 20: by then the
+    operator has watched a paralysed organism for an hour, which is precisely
+    the experience this exists to prevent."""
+    try:
+        return max(1, int(os.environ.get(FAIL_STREAK_ENV, "3")))
+    except (TypeError, ValueError):
+        return 3
+
+
+def reading_ttl_s() -> float:
+    """How long a fused reading stays fresh. Default 15s."""
+    try:
+        return max(0.0, float(os.environ.get(TTL_ENV, "15")))
+    except (TypeError, ValueError):
+        return 15.0
+
+
+class Capability(str, enum.Enum):
+    """What the organism can do — NOT what colour it should be."""
+
+    HEALTHY = "healthy"    # a lane is viable and work has recently completed
+    DEGRADED = "degraded"  # work is landing, but failures are present
+    BLOCKED = "blocked"    # structurally cannot complete an op right now
+    UNKNOWN = "unknown"    # inputs unreadable — renders AS blocked
+
+    @property
+    def can_work(self) -> bool:
+        return self in (Capability.HEALTHY, Capability.DEGRADED)
+
+
+@dataclass(frozen=True)
+class CapabilityReading:
+    """A capability verdict carrying every input that produced it."""
+
+    state: Capability
+    reason: str
+    lanes_dry: bool = False
+    dry_provider: str = ""
+    heartbeat_ok: Optional[bool] = None
+    attempted: int = 0
+    completed: int = 0
+    failed: int = 0
+    #: "fused" when every input was readable; "partial" when some were not;
+    #: "unreadable" when none were. A verdict whose provenance is unstated
+    #: gets believed as though it were measured.
+    provenance: str = "fused"
+    held_by_hysteresis: bool = False
+    detail: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def badge(self) -> str:
+        """The word the header prints. UNKNOWN renders as BLOCKED because a
+        state we cannot determine must not be shown as a green dot."""
+        return ("blocked" if self.state is Capability.UNKNOWN
+                else self.state.value)
+
+    def render(self) -> str:
+        return f"[Capability] {self.badge} — {self.reason}"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "state": self.state.value, "badge": self.badge,
+            "reason": self.reason, "lanes_dry": self.lanes_dry,
+            "dry_provider": self.dry_provider, "heartbeat_ok": self.heartbeat_ok,
+            "attempted": self.attempted, "completed": self.completed,
+            "failed": self.failed, "provenance": self.provenance,
+            "held_by_hysteresis": self.held_by_hysteresis, **self.detail,
+        }
+
+
+class CapabilityEvaluator:
+    """Fuses the readings and applies the asymmetric hysteresis.
+
+    Process-scoped: the hysteresis needs memory of what it last reported and
+    of how many ops had completed when it degraded, so that "recovered" can
+    mean "something actually worked since then" rather than "time passed".
+    """
+
+    __slots__ = ("_lock", "_cached", "_cached_at", "_degraded_at_completed",
+                 "_last_state")
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._cached: Optional[CapabilityReading] = None
+        self._cached_at: float = 0.0
+        #: completed-op count observed when we last degraded. Recovery
+        #: requires this to be EXCEEDED -- a strictly greater number is the
+        #: only evidence that work has landed since the trouble started.
+        self._degraded_at_completed: Optional[int] = None
+        self._last_state: Optional[Capability] = None
+
+    # -- inputs, each independently fail-soft ------------------------------
+
+    @staticmethod
+    def _read_lanes() -> "tuple":
+        """(dry, provider_name, readable). Reuses the ledger the status line
+        already samples — no new probe, no API call."""
+        try:
+            from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                provider_liquidity_ledger as pl,
+            )
+            if not pl.liquidity_ledger_enabled():
+                return (False, "", False)
+            # Same walk `status_line._sample_liquidity` performs, so the
+            # badge and the "⚠ … dry" token can never disagree about WHICH
+            # provider is out. `liquidity()` is per-provider, not a snapshot.
+            name = ""
+            for candidate in sorted((pl._load().get("providers") or {})):
+                if pl.runway_exhausted(candidate):
+                    name = str(candidate)
+                    break
+            dry = bool(name) or bool(pl.any_runway_exhausted())
+            return (dry, name, True)
+        except Exception:  # noqa: BLE001
+            return (False, "", False)
+
+    @staticmethod
+    def _read_ops() -> "tuple":
+        """(attempted, completed, failed, readable) from the most recent
+        session summary — the same source `ov status` renders."""
+        try:
+            from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                last_session_summary as lss,
+            )
+            rec = lss.get_default_summary().load_sync()
+            if rec is None:
+                return (0, 0, 0, False)
+            return (int(getattr(rec, "stats_attempted", 0) or 0),
+                    int(getattr(rec, "stats_completed", 0) or 0),
+                    int(getattr(rec, "stats_failed", 0) or 0), True)
+        except Exception:  # noqa: BLE001
+            return (0, 0, 0, False)
+
+    # -- the verdict -------------------------------------------------------
+
+    def evaluate(self, *, heartbeat_ok: Optional[bool] = None,
+                 now: Optional[float] = None) -> CapabilityReading:
+        """Fuse and decide. NEVER raises."""
+        if not capability_state_enabled():
+            return CapabilityReading(
+                state=Capability.HEALTHY, reason="capability state disabled",
+                provenance="disabled")
+        try:
+            return self._evaluate_inner(heartbeat_ok=heartbeat_ok, now=now)
+        except Exception as exc:  # noqa: BLE001
+            # Even the failure path refuses to claim health.
+            logger.debug("[Capability] degraded", exc_info=True)
+            return CapabilityReading(
+                state=Capability.UNKNOWN,
+                reason=f"capability fusion failed: {type(exc).__name__}",
+                provenance="unreadable")
+
+    def _evaluate_inner(self, *, heartbeat_ok: Optional[bool],
+                        now: Optional[float]) -> CapabilityReading:
+        _now = time.monotonic() if now is None else float(now)
+        ttl = reading_ttl_s()
+        with self._lock:
+            if (ttl > 0.0 and self._cached is not None
+                    and (_now - self._cached_at) < ttl):
+                return self._cached
+
+        dry, dry_provider, lanes_readable = self._read_lanes()
+        attempted, completed, failed, ops_readable = self._read_ops()
+        readable = sum((lanes_readable, ops_readable,
+                        heartbeat_ok is not None))
+        provenance = ("fused" if readable >= 2
+                      else "partial" if readable == 1 else "unreadable")
+
+        state, reason, held = self._decide(
+            dry=dry, dry_provider=dry_provider, lanes_readable=lanes_readable,
+            heartbeat_ok=heartbeat_ok, attempted=attempted,
+            completed=completed, failed=failed, ops_readable=ops_readable,
+        )
+
+        reading = CapabilityReading(
+            state=state, reason=reason, lanes_dry=dry,
+            dry_provider=dry_provider, heartbeat_ok=heartbeat_ok,
+            attempted=attempted, completed=completed, failed=failed,
+            provenance=provenance, held_by_hysteresis=held,
+            detail={"fail_streak_threshold": fail_streak_threshold()},
+        )
+        with self._lock:
+            self._cached = reading
+            self._cached_at = _now
+            changed = self._last_state is not state
+            self._last_state = state
+            if state is Capability.BLOCKED and self._degraded_at_completed is None:
+                self._degraded_at_completed = completed
+            elif state is Capability.HEALTHY:
+                self._degraded_at_completed = None
+        if changed:
+            logger.info("%s", reading.render())
+        return reading
+
+    def _decide(self, *, dry: bool, dry_provider: str, lanes_readable: bool,
+                heartbeat_ok: Optional[bool], attempted: int, completed: int,
+                failed: int, ops_readable: bool) -> "tuple":
+        """The fusion rules, strictest-wins. Returns (state, reason, held)."""
+        # 1. A dry runway is DETERMINISTIC, not jitter -- it is a billing
+        #    state. Degrading immediately is correct; waiting for a streak
+        #    would reproduce the original defect in slower motion.
+        if dry:
+            who = dry_provider or "provider"
+            return (Capability.BLOCKED,
+                    f"no runway on {who} — cannot dispatch work", False)
+
+        # 2. An explicit heartbeat failure outranks op history: the ops may
+        #    simply not have been attempted yet.
+        if heartbeat_ok is False:
+            return (Capability.BLOCKED, "daemon heartbeat is down", False)
+
+        # 3. HYSTERESIS. Once blocked, only a VERIFIED SUCCESS restores
+        #    health -- strictly more completions than when we degraded. The
+        #    mere disappearance of the failing signal proves nothing, and a
+        #    timer proves less than that.
+        with self._lock:
+            degraded_mark = self._degraded_at_completed
+        if degraded_mark is not None:
+            if ops_readable and completed > degraded_mark:
+                return (Capability.HEALTHY,
+                        f"recovered — {completed - degraded_mark} op(s) "
+                        f"completed since the lane came back", False)
+            return (Capability.BLOCKED,
+                    "lane recovered but no op has completed yet — "
+                    "holding blocked until work verifiably lands", True)
+
+        # 4. Nothing readable -> UNKNOWN, which renders as blocked.
+        if not ops_readable and not lanes_readable and heartbeat_ok is None:
+            return (Capability.UNKNOWN,
+                    "no capability signal readable", False)
+
+        # 5. Op telemetry.
+        if ops_readable and attempted > 0:
+            if completed == 0 and failed >= fail_streak_threshold():
+                return (Capability.BLOCKED,
+                        f"{failed} of {attempted} recent ops failed, none "
+                        f"completed", False)
+            if failed > 0:
+                return (Capability.DEGRADED,
+                        f"{completed}/{attempted} ops completed, "
+                        f"{failed} failed", False)
+            if completed > 0:
+                return (Capability.HEALTHY,
+                        f"{completed}/{attempted} ops completed", False)
+
+        # 6. Lanes viable, heartbeat fine, but nothing has been attempted.
+        #    That is genuinely healthy-idle, and only reachable when at least
+        #    one input was readable (step 4 caught the blind case).
+        return (Capability.HEALTHY, "lanes viable, idle", False)
+
+    def invalidate(self) -> None:
+        with self._lock:
+            self._cached = None
+            self._cached_at = 0.0
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            r = self._cached
+        return r.to_dict() if r is not None else {"cached": False}
+
+
+_SINGLETON: Optional[CapabilityEvaluator] = None
+_LOCK = threading.Lock()
+
+
+def get_default_evaluator() -> CapabilityEvaluator:
+    global _SINGLETON
+    with _LOCK:
+        if _SINGLETON is None:
+            _SINGLETON = CapabilityEvaluator()
+        return _SINGLETON
+
+
+def current_badge(*, heartbeat_ok: Optional[bool] = None) -> str:
+    """One-line convenience for the header. NEVER raises."""
+    try:
+        return get_default_evaluator().evaluate(heartbeat_ok=heartbeat_ok).badge
+    except Exception:  # noqa: BLE001
+        return "blocked"
+
+
+def reset_for_tests() -> None:
+    global _SINGLETON
+    with _LOCK:
+        _SINGLETON = None

--- a/backend/core/ouroboros/governance/capability_state.py
+++ b/backend/core/ouroboros/governance/capability_state.py
@@ -204,6 +204,43 @@ class CapabilityEvaluator:
             return (False, "", False)
 
     @staticmethod
+    def _read_remote() -> "tuple":
+        """(state, endpoint, readable) for the remote sovereign host.
+
+        Reads `InferenceGateway.snapshot()`, which is PURE IN-MEMORY -- it
+        consults cached breaker state and env, and deliberately does NOT call
+        `resident_models()` (the only method that touches the network). That
+        matters here: this evaluator runs on the render path, and a capability
+        badge that blocked the UI thread on a LAN round-trip would be a worse
+        defect than the one it replaces.
+
+        Returns one of:
+          * ``absent``      -- no remote configured; single-machine case
+          * ``serving``     -- configured and the breaker is not open
+          * ``unreachable`` -- breaker OPEN; the LAN is being bypassed
+        """
+        try:
+            from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                inference_gateway as ig,
+            )
+            endpoint = ig.remote_endpoint()
+            if not endpoint or not ig.gateway_enabled():
+                return ("absent", "", True)
+            snap = ig.get_default_gateway().snapshot() or {}
+            host = (snap.get("hosts") or {}).get(endpoint) or {}
+            state = str(host.get("state") or "")
+            if state == ig.HostState.UNREACHABLE.value:
+                return ("unreachable", endpoint, True)
+            # HEALTHY, DEGRADED, PROBING, or never-contacted all mean the
+            # lane is still a candidate. "Never contacted" is deliberately
+            # NOT treated as unreachable: a configured fallback that has not
+            # been tried yet is unverified, not broken, and reporting BLOCKED
+            # would send the operator to buy credits they do not need.
+            return ("serving", endpoint, True)
+        except Exception:  # noqa: BLE001
+            return ("absent", "", False)
+
+    @staticmethod
     def _read_ops() -> "tuple":
         """(attempted, completed, failed, readable) from the most recent
         session summary — the same source `ov status` renders."""
@@ -250,7 +287,8 @@ class CapabilityEvaluator:
 
         dry, dry_provider, lanes_readable = self._read_lanes()
         attempted, completed, failed, ops_readable = self._read_ops()
-        readable = sum((lanes_readable, ops_readable,
+        remote_state, remote_endpoint, remote_readable = self._read_remote()
+        readable = sum((lanes_readable, ops_readable, remote_readable,
                         heartbeat_ok is not None))
         provenance = ("fused" if readable >= 2
                       else "partial" if readable == 1 else "unreadable")
@@ -259,6 +297,7 @@ class CapabilityEvaluator:
             dry=dry, dry_provider=dry_provider, lanes_readable=lanes_readable,
             heartbeat_ok=heartbeat_ok, attempted=attempted,
             completed=completed, failed=failed, ops_readable=ops_readable,
+            remote_state=remote_state, remote_endpoint=remote_endpoint,
         )
 
         reading = CapabilityReading(
@@ -266,7 +305,9 @@ class CapabilityEvaluator:
             dry_provider=dry_provider, heartbeat_ok=heartbeat_ok,
             attempted=attempted, completed=completed, failed=failed,
             provenance=provenance, held_by_hysteresis=held,
-            detail={"fail_streak_threshold": fail_streak_threshold()},
+            detail={"fail_streak_threshold": fail_streak_threshold(),
+                    "remote_state": remote_state,
+                    "remote_endpoint": remote_endpoint},
         )
         with self._lock:
             self._cached = reading
@@ -283,13 +324,33 @@ class CapabilityEvaluator:
 
     def _decide(self, *, dry: bool, dry_provider: str, lanes_readable: bool,
                 heartbeat_ok: Optional[bool], attempted: int, completed: int,
-                failed: int, ops_readable: bool) -> "tuple":
+                failed: int, ops_readable: bool,
+                remote_state: str = "absent",
+                remote_endpoint: str = "") -> "tuple":
         """The fusion rules, strictest-wins. Returns (state, reason, held)."""
         # 1. A dry runway is DETERMINISTIC, not jitter -- it is a billing
         #    state. Degrading immediately is correct; waiting for a streak
         #    would reproduce the original defect in slower motion.
         if dry:
             who = dry_provider or "provider"
+            # A DRY PAID LANE IS ONLY BLOCKING IF THERE IS NOWHERE ELSE TO GO.
+            #
+            # Before the sovereign tier existed, "no runway" and "cannot work"
+            # were the same sentence. They are not any more: BACKGROUND and
+            # SPECULATIVE can run on the local host, so an exhausted card is a
+            # COST condition, not a capability one. Reporting BLOCKED here
+            # would send the operator to buy credits while the organism was
+            # working perfectly well on its own GPU -- a false alarm that
+            # teaches them to distrust the badge, which is how a badge stops
+            # being read at all.
+            if remote_state == "serving":
+                return (Capability.DEGRADED,
+                        f"no runway on {who} — running local on "
+                        f"{remote_endpoint or 'the sovereign host'}", False)
+            if remote_state == "unreachable":
+                return (Capability.BLOCKED,
+                        f"no runway on {who} and {remote_endpoint} is "
+                        f"unreachable — no lane left", False)
             return (Capability.BLOCKED,
                     f"no runway on {who} — cannot dispatch work", False)
 

--- a/backend/core/ouroboros/governance/cognitive_persistence.py
+++ b/backend/core/ouroboros/governance/cognitive_persistence.py
@@ -25,7 +25,14 @@ _TOKEN_RE = re.compile(r"[^A-Za-z0-9_.:-]")
 
 
 def cognitive_footprint(model_name: str, num_ctx: Optional[int]) -> str:
-    """Same shape as local_inference_director.physics_key: model@ctx-bucket."""
+    """The MODEL-scoped identity: model@ctx-bucket.
+
+    Deliberately NOT the same as `local_inference_director.physics_key`, which
+    gained a hardware axis because LATENCY is a property of the machine. A
+    cognitive experience -- a hallucinated tool, a malformed call -- is a
+    property of the MODEL and is equally true on every machine that runs it.
+    Sharding it by hardware would make each host re-learn the same lesson.
+    """
     return "%s@%s" % (model_name, num_ctx if num_ctx else "cpu")
 
 

--- a/backend/core/ouroboros/governance/compute_topology.py
+++ b/backend/core/ouroboros/governance/compute_topology.py
@@ -278,6 +278,32 @@ _MEASURED = (MemoryTopology.UNIFIED, MemoryTopology.DISCRETE, MemoryTopology.NON
 
 
 @dataclass(frozen=True)
+class DeviceReading:
+    """One accelerator's own numbers.
+
+    Exists because a host with two GPUs has TWO capacities and the collapsed
+    view can only carry one. Which one is correct depends on a fact this
+    module cannot observe -- whether the serving stack shards a model across
+    devices -- so both are reported and the consumer that knows composes them.
+    """
+
+    index: int
+    name: str
+    total_bytes: int
+    free_bytes: int
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "index": self.index,
+            "name": self.name,
+            "total_bytes": self.total_bytes,
+            "free_bytes": self.free_bytes,
+            "total_gib": round(self.total_bytes / _BYTES_PER_GIB, 2),
+            "free_gib": round(self.free_bytes / _BYTES_PER_GIB, 2),
+        }
+
+
+@dataclass(frozen=True)
 class AcceleratorProbe:
     """One probe attempt's result.
 
@@ -298,10 +324,15 @@ class AcceleratorProbe:
     #: True when ``free_bytes`` was measured; False when it was DERIVED
     #: from a system-RAM reading (unified) and therefore moves with it.
     free_is_measured: bool = True
+    #: Per-device readings when the probe could resolve them. Empty is not
+    #: "one device" -- it is "this stage could not enumerate", and consumers
+    #: must fall back to the collapsed view rather than infer a count.
+    devices: Tuple["DeviceReading", ...] = field(default_factory=tuple)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "topology": self.topology.value,
+            "devices": [d.to_dict() for d in self.devices],
             "total_bytes": self.total_bytes,
             "free_bytes": self.free_bytes,
             "device_name": self.device_name,
@@ -332,6 +363,9 @@ class ComputeReading:
     degraded: bool = False
     error: Optional[str] = None
     notes: Tuple[str, ...] = field(default_factory=tuple)
+    #: Per-device readings when the cascade stage could enumerate them.
+    #: Empty means "not enumerated", NEVER "one device".
+    devices: Tuple["DeviceReading", ...] = field(default_factory=tuple)
 
     @property
     def measured(self) -> bool:
@@ -340,8 +374,58 @@ class ComputeReading:
 
     @property
     def usable_bytes(self) -> int:
-        """Free capacity minus the reserved headroom. Never negative."""
+        """Free capacity minus the reserved headroom. Never negative.
+
+        Single-device: the conservative bound that holds no matter what the
+        serving stack does. This is the default every consumer gets.
+        """
         return max(0, int(self.free_bytes * (1.0 - headroom_fraction())))
+
+    @property
+    def aggregate_free_bytes(self) -> int:
+        """Free bytes summed across every enumerated device.
+
+        NOT interchangeable with :attr:`free_bytes`. This number is only
+        reachable by a serving stack that SHARDS a model across devices
+        (llama.cpp/Ollama layer split, vLLM tensor parallel). On a stack that
+        does not, it authorizes a load that cannot land -- which is exactly
+        why the collapsed view stays the default.
+
+        Returns 0 when devices were not enumerated, so a caller can never
+        mistake "could not enumerate" for "nothing free".
+        """
+        return sum(d.free_bytes for d in self.devices)
+
+    @property
+    def aggregate_total_bytes(self) -> int:
+        """Nameplate capacity summed across every enumerated device."""
+        return sum(d.total_bytes for d in self.devices)
+
+    @property
+    def is_multi_device(self) -> bool:
+        """True only when MORE THAN ONE device was actually enumerated.
+
+        Deliberately not `device_count > 1`: a stage can report a count while
+        failing to enumerate, and a pooled capacity claimed over devices we
+        never read would be a fabrication.
+        """
+        return len(self.devices) > 1
+
+    def shardable_usable_bytes(self, *, sharding: bool) -> int:
+        """Usable bytes under a DECLARED sharding capability.
+
+        *sharding* is not observable from here -- it is a property of the
+        serving stack, which this module deliberately knows nothing about. So
+        the caller that knows must say, and the honest default is the
+        conservative single-device bound.
+
+        Even when sharding is declared, a single-device host returns the
+        single-device answer: there is nothing to pool.
+        """
+        if not sharding or not self.is_multi_device:
+            return self.usable_bytes
+        return max(0, int(self.aggregate_free_bytes
+                          * (1.0 - headroom_fraction())))
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -356,6 +440,13 @@ class ComputeReading:
             "usable_gib": round(self.usable_bytes / _BYTES_PER_GIB, 2),
             "device_name": self.device_name,
             "device_count": self.device_count,
+            "devices": [d.to_dict() for d in self.devices],
+            "is_multi_device": self.is_multi_device,
+            "aggregate_free_bytes": self.aggregate_free_bytes,
+            "aggregate_free_gib": round(
+                self.aggregate_free_bytes / _BYTES_PER_GIB, 2),
+            "aggregate_total_gib": round(
+                self.aggregate_total_bytes / _BYTES_PER_GIB, 2),
             "source": self.source,
             "resolved_class": self.resolved_class,
             "enabled": self.enabled,
@@ -576,21 +667,26 @@ def _probe_torch_cuda() -> Optional[AcceleratorProbe]:
         count = int(torch.cuda.device_count())
         if count <= 0:
             return None
-        best: Optional[Tuple[int, int, str]] = None
+        readings: List[DeviceReading] = []
         for idx in range(count):
             try:
                 free_b, total_b = torch.cuda.mem_get_info(idx)
                 name = str(torch.cuda.get_device_name(idx))
             except Exception:  # noqa: BLE001 — one bad device never voids the rest
                 continue
-            if best is None or int(total_b) > best[1]:
-                best = (int(free_b), int(total_b), name)
-        if best is None:
+            readings.append(DeviceReading(
+                index=idx, name=name,
+                total_bytes=int(total_b), free_bytes=int(free_b)))
+        devices = tuple(readings)
+        collapsed = collapse_to_largest(devices)
+        if collapsed is None:
             return None
+        free_b, total_b, name, _n = collapsed
         return AcceleratorProbe(
             topology=MemoryTopology.DISCRETE,
-            total_bytes=best[1], free_bytes=best[0],
-            device_name=best[2], device_count=count, source="torch_cuda",
+            total_bytes=total_b, free_bytes=free_b,
+            device_name=name, device_count=count, source="torch_cuda",
+            devices=devices,
         )
     except Exception as exc:  # noqa: BLE001
         return AcceleratorProbe(
@@ -728,14 +824,14 @@ def reset_nvidia_smi_cache() -> None:
         _smi_path_cache.clear()
 
 
-def _parse_nvidia_smi(text: str) -> Optional[Tuple[int, int, str, int]]:
-    """(free, total, name, count) from ``nvidia-smi`` CSV. None if unparseable.
+def _parse_nvidia_smi_devices(text: str) -> Tuple["DeviceReading", ...]:
+    """Every device ``nvidia-smi`` reported, in driver order.
 
     Values arrive in MiB. Rows that do not parse are skipped rather than
     zeroed, for the same reason a failed cascade stage is skipped: a
     malformed row is missing data, not a device with no memory.
     """
-    rows: List[Tuple[int, int, str]] = []
+    out: List[DeviceReading] = []
     for line in text.splitlines():
         line = line.strip()
         if not line:
@@ -750,11 +846,38 @@ def _parse_nvidia_smi(text: str) -> Optional[Tuple[int, int, str, int]]:
             continue
         if total_mib <= 0:
             continue
-        rows.append((free_mib * 1024 * 1024, total_mib * 1024 * 1024, parts[2]))
-    if not rows:
+        out.append(DeviceReading(
+            index=len(out), name=parts[2],
+            total_bytes=total_mib * 1024 * 1024,
+            free_bytes=free_mib * 1024 * 1024,
+        ))
+    return tuple(out)
+
+
+def collapse_to_largest(
+    devices: "Tuple[DeviceReading, ...]",
+) -> Optional[Tuple[int, int, str, int]]:
+    """``(free, total, name, count)`` for the LARGEST SINGLE device.
+
+    The collapsed view, and the conservative one: a model must fit on one
+    device unless the serving stack shards it, and sharding is a property of
+    that stack rather than of the host. Summing here would authorize a load
+    that cannot physically land. Callers that KNOW their stack shards read
+    the aggregate instead -- see :meth:`ComputeReading.shardable_free_bytes`.
+    """
+    if not devices:
         return None
-    best = max(rows, key=lambda r: r[1])
-    return best[0], best[1], best[2], len(rows)
+    best = max(devices, key=lambda d: d.total_bytes)
+    return best.free_bytes, best.total_bytes, best.name, len(devices)
+
+
+def _parse_nvidia_smi(text: str) -> Optional[Tuple[int, int, str, int]]:
+    """(free, total, name, count) from ``nvidia-smi`` CSV. None if unparseable.
+
+    A derived view of :func:`_parse_nvidia_smi_devices` so there is exactly
+    one place that knows the CSV shape.
+    """
+    return collapse_to_largest(_parse_nvidia_smi_devices(text))
 
 
 async def _probe_nvidia_smi_async() -> Optional[AcceleratorProbe]:
@@ -807,7 +930,8 @@ async def _probe_nvidia_smi_async() -> Optional[AcceleratorProbe]:
             ok=False,
             error=f"rc={proc.returncode} {(err or b'').decode(errors='replace')[:120]}",
         )
-    parsed = _parse_nvidia_smi((out or b"").decode(errors="replace"))
+    _devices = _parse_nvidia_smi_devices((out or b"").decode(errors="replace"))
+    parsed = collapse_to_largest(_devices)
     if parsed is None:
         return AcceleratorProbe(
             topology=MemoryTopology.UNKNOWN, total_bytes=0, free_bytes=0,
@@ -818,7 +942,7 @@ async def _probe_nvidia_smi_async() -> Optional[AcceleratorProbe]:
     return AcceleratorProbe(
         topology=MemoryTopology.DISCRETE, total_bytes=total_b,
         free_bytes=free_b, device_name=name, device_count=count,
-        source="nvidia_smi",
+        source="nvidia_smi", devices=_devices,
     )
 
 
@@ -1270,6 +1394,7 @@ class ComputeTopologyResolver:
             degraded=not probe.ok,
             error=probe.error,
             notes=tuple(notes),
+            devices=probe.devices,
         )
 
     def _disabled_reading(self) -> ComputeReading:

--- a/backend/core/ouroboros/governance/compute_topology.py
+++ b/backend/core/ouroboros/governance/compute_topology.py
@@ -291,11 +291,18 @@ class DeviceReading:
     name: str
     total_bytes: int
     free_bytes: int
+    #: Driver-assigned GPU UUID (e.g. "GPU-4c2f...") when the probe stage can
+    #: supply one. It is the ONLY device identifier that survives a reboot, a
+    #: PCIe slot swap and a driver reinstall -- name+capacity cannot tell two
+    #: identical cards apart, and index is assignment order, not identity.
+    #: Empty when unavailable; consumers must degrade, never fabricate.
+    uuid: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "index": self.index,
             "name": self.name,
+            "uuid": self.uuid,
             "total_bytes": self.total_bytes,
             "free_bytes": self.free_bytes,
             "total_gib": round(self.total_bytes / _BYTES_PER_GIB, 2),
@@ -674,8 +681,16 @@ def _probe_torch_cuda() -> Optional[AcceleratorProbe]:
                 name = str(torch.cuda.get_device_name(idx))
             except Exception:  # noqa: BLE001 — one bad device never voids the rest
                 continue
+            _uuid = ""
+            try:
+                # Present on recent torch builds only; absent is a missing
+                # field, never a reason to drop an otherwise good reading.
+                _uuid = str(getattr(
+                    torch.cuda.get_device_properties(idx), "uuid", "") or "")
+            except Exception:  # noqa: BLE001
+                _uuid = ""
             readings.append(DeviceReading(
-                index=idx, name=name,
+                index=idx, name=name, uuid=_uuid,
                 total_bytes=int(total_b), free_bytes=int(free_b)))
         devices = tuple(readings)
         collapsed = collapse_to_largest(devices)
@@ -846,10 +861,14 @@ def _parse_nvidia_smi_devices(text: str) -> Tuple["DeviceReading", ...]:
             continue
         if total_mib <= 0:
             continue
+        # A 4th column is the uuid when the driver supplied it. Older
+        # drivers answer 3 columns; that is a missing field, not a parse
+        # failure, so the row still counts as a device.
         out.append(DeviceReading(
             index=len(out), name=parts[2],
             total_bytes=total_mib * 1024 * 1024,
             free_bytes=free_mib * 1024 * 1024,
+            uuid=parts[3] if len(parts) > 3 else "",
         ))
     return tuple(out)
 
@@ -901,7 +920,7 @@ async def _probe_nvidia_smi_async() -> Optional[AcceleratorProbe]:
     try:
         proc = await asyncio.create_subprocess_exec(
             binary,
-            "--query-gpu=memory.total,memory.free,name",
+            "--query-gpu=memory.total,memory.free,name,uuid",
             "--format=csv,noheader,nounits",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/backend/core/ouroboros/governance/deferred_task_ledger.py
+++ b/backend/core/ouroboros/governance/deferred_task_ledger.py
@@ -1,0 +1,288 @@
+"""What the organism DID NOT look at, and why — so a blind spot has a name.
+
+THE DEFECT THIS CLOSES
+----------------------
+When OpportunityMiner's AST analysis timed out, the sensor did::
+
+    if _s11b_result.outcome != _S11B_AO.OK:
+        errors += 1
+        continue
+
+That is better than it first appears — a timeout is counted as an ERROR, not
+silently folded into "no opportunities found". But the file is then DROPPED
+and never revisited, and nothing anywhere records WHICH files went unanalysed.
+The scan reports "3 errors" and moves on; the next scan makes the same choice
+about the same files for the same reason. The organism has a blind spot and no
+representation of it.
+
+An error counter says *how many* it missed. It cannot say *what*, so nothing
+can ever go back.
+
+WHY A LEDGER AND NOT A RETRY
+----------------------------
+Retrying inline is the wrong shape twice over. The work was shed BECAUSE the
+pool was saturated, so retrying immediately re-enters the condition that
+caused the shed -- and a sensor that blocks its scan retrying one file starves
+the other twenty-one sensors sharing that pool. Deferral makes the decision
+explicit and cheap: record it, finish the scan, revisit when there is room.
+
+WHAT MAKES AN ENTRY HONEST
+--------------------------
+Each entry carries the REASON as a typed value, not prose, because the
+reasons demand different treatments:
+
+  * ``shed_pressure``  -- nothing wrong with the file; the pool was full.
+                          Revisit freely, it will probably succeed.
+  * ``timeout``        -- the analysis genuinely exceeded its budget. Revisit
+                          with a larger budget or not at all.
+  * ``pathological``   -- rejected pre-flight by shape (minified, binary,
+                          absurd line density). Revisiting UNCHANGED is
+                          pointless; only a content change should re-queue it.
+  * ``too_large``      -- over the byte cap. Same reasoning as pathological.
+
+Collapsing these into "failed" would make the ledger unactionable, which is
+the state we are leaving.
+
+BOUNDED BY CONSTRUCTION
+-----------------------
+A ledger of blind spots that grows without bound becomes a second blind spot.
+Entries are keyed by path so re-shedding the same file updates rather than
+appends, and the store is capped with oldest-eviction. Eviction is COUNTED, so
+"we forgot that we forgot" is itself visible.
+
+Python 3.9+, stdlib only. Fail-soft everywhere: a ledger that raises would
+convert a deferral into the crash it exists to prevent.
+"""
+from __future__ import annotations
+
+import enum
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("Ouroboros.DeferredTaskLedger")
+
+ENABLED_ENV = "JARVIS_DEFERRED_LEDGER_ENABLED"
+PATH_ENV = "JARVIS_DEFERRED_LEDGER_PATH"
+MAX_ENTRIES_ENV = "JARVIS_DEFERRED_LEDGER_MAX"
+
+_TRUTHY = ("1", "true", "yes", "on")
+_DEFAULT_PATH = os.path.join(".jarvis", "deferred_tasks.json")
+
+
+def ledger_enabled() -> bool:
+    """Master gate. Default ON — the ledger only ever ADDS information, and
+    with it off a shed task is invisible again. NEVER raises."""
+    try:
+        return os.environ.get(ENABLED_ENV, "1").strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def ledger_path() -> str:
+    try:
+        return os.environ.get(PATH_ENV, "") or _DEFAULT_PATH
+    except Exception:  # noqa: BLE001
+        return _DEFAULT_PATH
+
+
+def max_entries() -> int:
+    """Cap. Default 500. A blind-spot ledger that grows without bound is
+    itself a blind spot."""
+    try:
+        return max(16, int(os.environ.get(MAX_ENTRIES_ENV, "500")))
+    except (TypeError, ValueError):
+        return 500
+
+
+class DeferReason(str, enum.Enum):
+    """WHY the work was not done. Typed because each implies a different
+    revisit policy — see the module docstring."""
+
+    SHED_PRESSURE = "shed_pressure"   # pool saturated; the file is fine
+    TIMEOUT = "timeout"               # genuinely exceeded its budget
+    PATHOLOGICAL = "pathological"     # rejected pre-flight by shape
+    TOO_LARGE = "too_large"           # over the byte cap
+    INTERNAL_ERROR = "internal_error"
+
+    @property
+    def worth_retrying_unchanged(self) -> bool:
+        """Is a retry of the SAME bytes likely to behave differently?
+
+        Only pressure and (marginally) timeout are transient. Re-running a
+        minified file through the same guard yields the same refusal, so
+        re-queueing it unchanged burns budget to learn nothing.
+        """
+        return self in (DeferReason.SHED_PRESSURE, DeferReason.TIMEOUT)
+
+
+@dataclass(frozen=True)
+class DeferredTask:
+    """One thing the organism chose not to look at."""
+
+    path: str
+    reason: DeferReason
+    caller: str = ""
+    source_bytes: int = 0
+    detail: str = ""
+    first_deferred_at: float = 0.0
+    last_deferred_at: float = 0.0
+    occurrences: int = 1
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = asdict(self)
+        d["reason"] = self.reason.value
+        d["worth_retrying_unchanged"] = self.reason.worth_retrying_unchanged
+        return d
+
+
+class DeferredTaskLedger:
+    """Bounded, path-keyed store of deferred work. Thread-safe, fail-soft."""
+
+    __slots__ = ("_lock", "_entries", "_evicted", "_path")
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        self._lock = threading.Lock()
+        self._entries: Dict[str, DeferredTask] = {}
+        self._evicted = 0
+        self._path = path or ledger_path()
+
+    def defer(self, *, path: str, reason: DeferReason, caller: str = "",
+              source_bytes: int = 0, detail: str = "",
+              now: Optional[float] = None) -> None:
+        """Record that *path* was not analysed. NEVER raises.
+
+        Keyed BY PATH: re-shedding the same file updates its entry and bumps
+        `occurrences` rather than appending. A file the pool sheds on every
+        scan is one persistent blind spot, not fifty events, and counting it
+        fifty times would drown the ledger in its own worst case.
+        """
+        if not ledger_enabled():
+            return
+        try:
+            _now = time.time() if now is None else float(now)
+            key = str(path or "")
+            if not key:
+                return
+            with self._lock:
+                prev = self._entries.get(key)
+                if prev is not None:
+                    self._entries[key] = DeferredTask(
+                        path=key, reason=reason, caller=caller or prev.caller,
+                        source_bytes=source_bytes or prev.source_bytes,
+                        detail=detail or prev.detail,
+                        first_deferred_at=prev.first_deferred_at or _now,
+                        last_deferred_at=_now,
+                        occurrences=prev.occurrences + 1,
+                    )
+                else:
+                    self._entries[key] = DeferredTask(
+                        path=key, reason=reason, caller=caller,
+                        source_bytes=source_bytes, detail=detail,
+                        first_deferred_at=_now, last_deferred_at=_now,
+                    )
+                # Oldest-first eviction, and the count is KEPT: a ledger that
+                # silently forgot entries would be a blind spot about blind
+                # spots.
+                cap = max_entries()
+                if len(self._entries) > cap:
+                    victims = sorted(self._entries.values(),
+                                     key=lambda e: e.last_deferred_at
+                                     )[:len(self._entries) - cap]
+                    for v in victims:
+                        self._entries.pop(v.path, None)
+                        self._evicted += 1
+        except Exception:  # noqa: BLE001
+            logger.debug("[DeferredLedger] defer degraded", exc_info=True)
+
+    def resolve(self, path: str) -> None:
+        """Drop *path* — it was successfully analysed. NEVER raises."""
+        try:
+            with self._lock:
+                self._entries.pop(str(path or ""), None)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def retryable(self, limit: int = 50) -> List[DeferredTask]:
+        """Deferrals a later scan should revisit, oldest blind spot first.
+
+        Filters on `worth_retrying_unchanged`, so a minified file rejected by
+        shape is remembered but never re-attempted until its bytes change.
+        """
+        try:
+            with self._lock:
+                items = [e for e in self._entries.values()
+                         if e.reason.worth_retrying_unchanged]
+            return sorted(items, key=lambda e: e.first_deferred_at)[:max(0, limit)]
+        except Exception:  # noqa: BLE001
+            return []
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Observability surface. NEVER raises."""
+        try:
+            with self._lock:
+                by_reason: Dict[str, int] = {}
+                for e in self._entries.values():
+                    by_reason[e.reason.value] = by_reason.get(e.reason.value, 0) + 1
+                return {
+                    "enabled": ledger_enabled(),
+                    "total": len(self._entries),
+                    "evicted": self._evicted,
+                    "by_reason": by_reason,
+                    "retryable": sum(
+                        1 for e in self._entries.values()
+                        if e.reason.worth_retrying_unchanged),
+                }
+        except Exception:  # noqa: BLE001
+            return {"enabled": False, "error": "snapshot degraded"}
+
+    def flush(self) -> bool:
+        """Persist. Best-effort; a failed write must not break a scan."""
+        try:
+            if not ledger_enabled():
+                return False
+            with self._lock:
+                payload = {
+                    "schema_version": "1.0",
+                    "written_at": time.time(),
+                    "evicted": self._evicted,
+                    "entries": [e.to_dict() for e in self._entries.values()],
+                }
+            d = os.path.dirname(self._path)
+            if d:
+                os.makedirs(d, exist_ok=True)
+            tmp = self._path + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh, indent=1)
+            os.replace(tmp, self._path)
+            return True
+        except Exception:  # noqa: BLE001
+            logger.debug("[DeferredLedger] flush degraded", exc_info=True)
+            return False
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+            self._evicted = 0
+
+
+_SINGLETON: Optional[DeferredTaskLedger] = None
+_LOCK = threading.Lock()
+
+
+def get_default_ledger() -> DeferredTaskLedger:
+    global _SINGLETON
+    with _LOCK:
+        if _SINGLETON is None:
+            _SINGLETON = DeferredTaskLedger()
+        return _SINGLETON
+
+
+def reset_for_tests() -> None:
+    global _SINGLETON
+    with _LOCK:
+        _SINGLETON = None

--- a/backend/core/ouroboros/governance/device_affinity.py
+++ b/backend/core/ouroboros/governance/device_affinity.py
@@ -1,0 +1,360 @@
+"""Which GPU should this op land on, when the GPUs are not the same size?
+
+THE SITUATION THIS EXISTS FOR
+-----------------------------
+A 32GB RTX 5090 beside a 24GB card, each hosting its own model as an
+INDEPENDENT lane (see PRD §31.4 -- two resident models beats one model spanning
+both, because layer-splitting buys capacity at PCIe latency while two lanes buy
+throughput at no latency). The moment the lanes are asymmetric, a queue that
+treats them as interchangeable is wrong in both directions:
+
+  * a long-context BACKGROUND op sent to the 24GB card OOMs, or silently
+    truncates its window -- and a truncated window is a QUALITY failure that
+    looks like a model getting dumber, not like an infrastructure error;
+  * a trivial SPECULATIVE triage op sent to the 32GB card occupies the only
+    device that could have taken the next heavy one.
+
+TWO THINGS THAT MUST NOT BE CONFUSED
+------------------------------------
+**Capacity is a CONSTRAINT. Affinity is a PREFERENCE.** A preference may be
+overridden by a constraint, never the reverse. Concretely: SPECULATIVE prefers
+the smaller card, but if the payload does not fit there it goes to the larger
+one rather than being deferred -- declining work that a present device could
+do would be policy defeating the system it is meant to tune.
+
+WHY THE CONTEXT MATTERS MORE THAN THE WEIGHTS
+---------------------------------------------
+Weights are constant per model; KV cache is LINEAR IN CONTEXT and is the term
+that actually varies per op. Measured on Qwen3.8-27B: 0.5 GiB at 8K, 2.0 GiB
+at 32K, 16.4 GiB at 262K -- a straight line at ~62.5 KiB/token, and enough at
+full context to be the difference between fitting a 24GB card and not.
+
+So admission has to ask "weights + KV(this context) on THIS device", not
+"weights against a pooled number".
+
+Python 3.9+, stdlib only. Every probe is injected or lazily imported and
+fail-soft: an unresolvable device list declines to choose rather than guessing.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.DeviceAffinity")
+
+ENABLED_ENV = "JARVIS_DEVICE_AFFINITY_ENABLED"
+KV_PER_TOKEN_ENV = "JARVIS_KV_BYTES_PER_TOKEN"
+KV_PER_MODEL_ENV = "JARVIS_KV_BYTES_PER_TOKEN_BY_MODEL"
+GROWTH_ENV = "JARVIS_DEVICE_AFFINITY_CTX_GROWTH"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+#: Routes whose ops are small, short-lived triage and should stay OFF the
+#: largest device so it remains available for work that needs it.
+_LIGHT_ROUTES = frozenset({"speculative"})
+
+
+def affinity_enabled() -> bool:
+    """Master gate. Default ON. OFF selects purely on capacity, which is the
+    behaviour before this module existed. NEVER raises."""
+    try:
+        return os.environ.get(ENABLED_ENV, "1").strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def context_growth_factor() -> float:
+    """How much larger than the PROMPT the context may become. Default 1.35.
+
+    Load-bearing, and the subtlest number here. Venom is a multi-turn tool
+    loop: tool results accumulate into the same window round after round until
+    live compaction fires at `JARVIS_TOOL_LOOP_COMPACT_THRESHOLD` (75% of
+    budget). Sizing KV against the FIRST prompt therefore admits an op that
+    fits at round 1 and OOMs at round 7 -- and it OOMs mid-op, after the
+    exploration calls the Iron Gate required have already been spent.
+
+    Admission must size against the ceiling the op is ALLOWED to reach, not
+    the value it starts at. Clamped to [1.0, 4.0]."""
+    try:
+        raw = float(os.environ.get(GROWTH_ENV, "1.35"))
+    except (TypeError, ValueError):
+        return 1.35
+    return max(1.0, min(4.0, raw))
+
+
+def _kv_overrides() -> Dict[str, int]:
+    """``model=bytes_per_token`` pairs, comma separated. NEVER raises.
+
+    KV cost per token is an ARCHITECTURAL property -- layers x kv-heads x
+    head-dim x dtype -- and models differ by an order of magnitude (Qwen3.8-27B
+    caches only 16 of its 64 layers, so it is far cheaper than its parameter
+    count suggests). There is no correct single constant, so measured values
+    go here per model and the default below stays deliberately pessimistic.
+    """
+    out: Dict[str, int] = {}
+    try:
+        raw = os.environ.get(KV_PER_MODEL_ENV, "") or ""
+        for pair in raw.split(","):
+            if "=" not in pair:
+                continue
+            name, _, val = pair.partition("=")
+            name = name.strip()
+            if name:
+                out[name] = max(0, int(float(val.strip())))
+    except Exception:  # noqa: BLE001
+        return out
+    return out
+
+
+def kv_bytes_per_token(model_id: Optional[str] = None) -> int:
+    """Bytes of KV cache per context token for *model_id*. Default 131072.
+
+    The default (128 KiB/token) is an UPPER BOUND for a 30B-class model with
+    full attention at fp16, chosen pessimistically on purpose: over-estimating
+    KV defers an op that might have fit, while under-estimating it admits one
+    that cannot, and the second failure lands mid-generation on the device.
+    Measured per-model values via `JARVIS_KV_BYTES_PER_TOKEN_BY_MODEL` should
+    replace it -- e.g. Qwen3.8-27B measures ~64000.
+    """
+    overrides = _kv_overrides()
+    if model_id and model_id in overrides:
+        return overrides[model_id]
+    try:
+        return max(0, int(float(os.environ.get(KV_PER_TOKEN_ENV, "131072"))))
+    except (TypeError, ValueError):
+        return 131072
+
+
+def estimate_kv_bytes(ctx_tokens: int, *, model_id: Optional[str] = None,
+                      grow: bool = True) -> int:
+    """KV cache for *ctx_tokens*, optionally grown to the reachable ceiling.
+
+    Linear in context -- see the module docstring for the measurement that
+    establishes that. NEVER raises.
+    """
+    try:
+        tokens = max(0, int(ctx_tokens))
+    except (TypeError, ValueError):
+        return 0
+    if grow:
+        tokens = int(tokens * context_growth_factor())
+    return tokens * kv_bytes_per_token(model_id)
+
+
+def max_ctx_tokens_for(free_bytes: int, weight_bytes: int, *,
+                       model_id: Optional[str] = None) -> int:
+    """Largest context that fits in *free_bytes* after the weights.
+
+    Returned on a DEFER so the decision is actionable: "this will not fit" is
+    a fact, "the largest context that would fit here is N" is a next step.
+    NEVER raises.
+    """
+    per_token = kv_bytes_per_token(model_id)
+    if per_token <= 0:
+        return 0
+    headroom = int(free_bytes) - int(weight_bytes)
+    if headroom <= 0:
+        return 0
+    growth = context_growth_factor() or 1.0
+    return max(0, int(headroom / per_token / growth))
+
+
+@dataclass(frozen=True)
+class DeviceSelection:
+    """Which device an op should land on, and why."""
+
+    #: The chosen device, or None when NOTHING can hold this payload.
+    device: Optional[Any]
+    reason: str
+    kv_bytes: int = 0
+    required_bytes: int = 0
+    #: Largest context that WOULD fit on the best available device. Populated
+    #: on failure so the caller can DEFER with a number instead of a shrug.
+    max_ctx_tokens: int = 0
+    #: True when the route's preferred device could not hold the payload and
+    #: capacity overruled policy. Not an error -- but worth seeing, because a
+    #: SPECULATIVE op repeatedly displacing heavy work off the big card is a
+    #: sizing problem, not a routing one.
+    fallback_from_preference: bool = False
+    considered: Tuple[Dict[str, Any], ...] = field(default_factory=tuple)
+
+    @property
+    def admitted(self) -> bool:
+        return self.device is not None
+
+    def to_dict(self) -> Dict[str, Any]:
+        dev = self.device
+        return {
+            "admitted": self.admitted,
+            "device_index": getattr(dev, "index", None),
+            "device_name": getattr(dev, "name", None),
+            "device_uuid": getattr(dev, "uuid", None),
+            "reason": self.reason,
+            "kv_bytes": self.kv_bytes,
+            "required_bytes": self.required_bytes,
+            "max_ctx_tokens": self.max_ctx_tokens,
+            "fallback_from_preference": self.fallback_from_preference,
+            "considered": list(self.considered),
+        }
+
+
+def _free_of(dev: Any) -> int:
+    try:
+        return int(getattr(dev, "free_bytes", 0) or 0)
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def select_device(
+    devices: Sequence[Any],
+    *,
+    ctx_tokens: int,
+    weight_bytes: int = 0,
+    route: Optional[str] = None,
+    model_id: Optional[str] = None,
+) -> DeviceSelection:
+    """Pick the device this op should run on. NEVER raises.
+
+    EDGE CASES, and the reasoning for each:
+
+    1. **No devices enumerated.** Declines (`device=None`,
+       ``reason="not_enumerated"``) and reports ``max_ctx_tokens=0``. The
+       caller must fall back to its existing pooled check -- an empty device
+       list means "we could not see", never "there is nothing". Fabricating a
+       selection over devices we never read is the failure mode
+       `ComputeReading.is_multi_device` already refuses.
+
+    2. **One device.** Affinity is a no-op, but the CAPACITY check still runs.
+       A single-GPU host gains the context validation even though it gains no
+       routing.
+
+    3. **The preferred device is too small.** Capacity overrules policy: the
+       op goes to a device that fits and `fallback_from_preference` is set.
+       Deferring work a present device could do would be policy defeating the
+       system it exists to tune.
+
+    4. **Nothing fits.** `device=None`, and `max_ctx_tokens` is computed from
+       the roomiest device so the caller can DEFER with an actionable number
+       ("largest context that fits here is 41k") rather than an opaque no.
+
+    5. **Exact ties.** Broken deterministically by device index, never
+       arbitrarily. Two identical cards must not flap between ops -- a stable
+       assignment keeps each device's model resident instead of thrashing
+       loads, which on a cold model costs the ~30s this codebase measured.
+
+    6. **Context unknown or non-positive.** Treated as UNKNOWN, not as zero. A
+       zero-KV assumption admits everything, which is the optimistic direction
+       and therefore the wrong one; the caller's configured window is the
+       honest ceiling and is what should be passed in.
+
+    7. **Context grows mid-op.** Sized against `context_growth_factor()`, not
+       the initial prompt -- Venom accumulates tool results until compaction
+       fires, so an op that fits at round 1 can OOM at round 7. See that
+       function's docstring.
+    """
+    devs = [d for d in (devices or []) if d is not None]
+    if not devs:
+        return DeviceSelection(device=None, reason="not_enumerated")
+
+    kv = estimate_kv_bytes(ctx_tokens, model_id=model_id)
+    required = max(0, int(weight_bytes)) + kv
+
+    # Stable ordering first: index is the tie-break for every comparison
+    # below, so a selection cannot depend on probe enumeration order.
+    by_index = sorted(devs, key=lambda d: int(getattr(d, "index", 0) or 0))
+    fits = [d for d in by_index if _free_of(d) >= required]
+    considered = tuple(
+        {
+            "index": getattr(d, "index", None),
+            "name": getattr(d, "name", None),
+            "free_bytes": _free_of(d),
+            "fits": _free_of(d) >= required,
+        }
+        for d in by_index
+    )
+
+    if not fits:
+        # Case 4: report the ceiling of the roomiest device, so the caller's
+        # DEFER carries a next step rather than only a refusal.
+        best_free = max((_free_of(d) for d in by_index), default=0)
+        return DeviceSelection(
+            device=None, reason="no_device_fits", kv_bytes=kv,
+            required_bytes=required, considered=considered,
+            max_ctx_tokens=max_ctx_tokens_for(
+                best_free, weight_bytes, model_id=model_id),
+        )
+
+    route_key = str(route or "").strip().lower()
+    light = route_key in _LIGHT_ROUTES
+
+    def _ideal(pool):
+        """The device this route WOULD pick if capacity were no object."""
+        if not route_key:
+            return None
+        if light:
+            return min(pool, key=lambda d: (_free_of(d),
+                                            int(getattr(d, "index", 0) or 0)))
+        return max(pool, key=lambda d: (_free_of(d),
+                                        -int(getattr(d, "index", 0) or 0)))
+
+    ideal = _ideal(by_index)
+
+    # Case 2/3: exactly one device can hold this payload.
+    #
+    # `fallback_from_preference` is computed HERE too, and that is the whole
+    # point of hoisting `ideal`. With exactly two GPUs -- the configuration
+    # this module was written for -- "the preferred device does not fit"
+    # ALWAYS collapses into this branch, because excluding one of two devices
+    # leaves one. An earlier draft only set the flag in the multi-candidate
+    # path below, so on a 2-GPU host the flag could never be True and the one
+    # event an operator actually wants to see (a SPECULATIVE op displaced onto
+    # the big card) was invisible.
+    if len(fits) == 1:
+        chosen = fits[0]
+        return DeviceSelection(
+            device=chosen,
+            reason="only_candidate", kv_bytes=kv,
+            required_bytes=required, considered=considered,
+            fallback_from_preference=bool(ideal is not None
+                                          and ideal is not chosen),
+            max_ctx_tokens=max_ctx_tokens_for(
+                _free_of(chosen), weight_bytes, model_id=model_id),
+        )
+
+    if not affinity_enabled() or not route_key:
+        # Capacity-only: the roomiest device, ties by index. This is also the
+        # pre-affinity behaviour, so the master flag is a true rollback.
+        chosen = max(fits, key=lambda d: (_free_of(d),
+                                          -int(getattr(d, "index", 0) or 0)))
+        return DeviceSelection(
+            device=chosen, reason="most_free", kv_bytes=kv,
+            required_bytes=required, considered=considered,
+            max_ctx_tokens=max_ctx_tokens_for(
+                _free_of(chosen), weight_bytes, model_id=model_id),
+        )
+
+    if light:
+        # Smallest device that STILL FITS -- deliberately not simply the
+        # smallest. Triage work should vacate the big card, but only into a
+        # device that can actually hold it (case 3).
+        preferred = min(fits, key=lambda d: (_free_of(d),
+                                             int(getattr(d, "index", 0) or 0)))
+        reason = "light_route_smallest_fit"
+    else:
+        preferred = max(fits, key=lambda d: (_free_of(d),
+                                             -int(getattr(d, "index", 0) or 0)))
+        reason = "heavy_route_most_free"
+
+    # `preferred` was chosen from `fits`, so it fits by construction; the flag
+    # records whether policy had to yield -- true exactly when the route's
+    # ideal device was excluded by capacity above.
+    fell_back = ideal is not None and ideal is not preferred
+
+    return DeviceSelection(
+        device=preferred, reason=reason, kv_bytes=kv, required_bytes=required,
+        considered=considered, fallback_from_preference=fell_back,
+        max_ctx_tokens=max_ctx_tokens_for(
+            _free_of(preferred), weight_bytes, model_id=model_id),
+    )

--- a/backend/core/ouroboros/governance/hardware_signature.py
+++ b/backend/core/ouroboros/governance/hardware_signature.py
@@ -1,0 +1,397 @@
+"""Which machine measured this? -- a stable, distinct identity for physics.
+
+THE DEFECT THIS CLOSES
+----------------------
+``local_inference_director.physics_key`` was ``model_name@num_ctx``, and its
+docstring gives the reason it excluded the endpoint:
+
+    "the DURABLE physics identity: (model, ctx-bucket) -- NOT the endpoint
+     (node IPs change every run; the physics belongs to the brain+window)."
+
+That reasoning is right about IPs and wrong about machines. It holds across a
+mesh of like nodes, where the only thing distinguishing two endpoints is an
+address that will be different tomorrow. It does NOT hold across a 16GB M1 and
+an RTX 5090: the same model name on both writes ONE ledger key, so whichever
+measured last governs both. In the bridged configuration this project is
+building -- a Mac driving a Windows inference host -- that means **the M1's
+~95ms/token would size the 5090's lane count**, and the ThroughputGovernor
+would faithfully compute the wrong answer from honest data.
+
+The fix keeps the original insight and adds the missing axis: physics belongs
+to the brain, the window, AND THE HARDWARE IT RAN ON. Not to the address.
+
+WHAT MAKES A SIGNATURE
+----------------------
+Ordered by how much identity each component actually carries:
+
+  * **GPU UUID** -- driver-assigned, survives reboot, PCIe slot swap and
+    driver reinstall. The only identifier that can tell two identical cards
+    apart. name+capacity cannot; index is assignment order, not identity.
+  * **machine id** -- the platform's own durable host identifier
+    (``/etc/machine-id``, ``IOPlatformUUID``, ``MachineGuid``). Not the
+    hostname, which an operator renames.
+  * **topology class** -- discrete vs unified, so a Mac and a PC never
+    collide even if both probes degrade.
+
+Hashed into a short digest so it can sit in a ledger key without carrying a
+machine's identifiers around in cleartext.
+
+WHOSE HARDWARE, THOUGH
+----------------------
+The signature must describe the host that RAN THE INFERENCE, not the host that
+timed it. A Mac probing its own GPUs while dispatching to a Windows box would
+produce the Mac's signature and re-create the exact conflation this module
+exists to remove. So resolution is per-endpoint:
+
+  * a LOOPBACK endpoint is served by this machine -> probe local hardware,
+    provenance ``probed``;
+  * a REMOTE endpoint is served by a machine we cannot probe -> derive from
+    its HOST (never the port: one box serving two models on two ports is one
+    piece of hardware), provenance ``endpoint``.
+
+The remote case is deliberately weaker and says so. It is still strictly
+better than the status quo -- two hosts get two keys -- and it is the seam
+where a future ``/hardware`` endpoint on the serving host upgrades
+``endpoint`` to ``probed`` without any caller changing.
+
+Python 3.9+. Stdlib only at import time; the compute probe is lazy and
+fail-soft, and every result is cached for the process lifetime because
+hardware does not change under a running process.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import platform
+import sys
+import threading
+import uuid as _uuid_mod
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple
+from urllib.parse import urlparse
+
+logger = logging.getLogger("Ouroboros.HardwareSignature")
+
+ENABLED_ENV = "JARVIS_HARDWARE_SIGNATURE_ENABLED"
+DIGEST_CHARS_ENV = "JARVIS_HARDWARE_SIGNATURE_CHARS"
+
+#: What a degraded resolution reports. A CONSTANT, not a random value: two
+#: unknowable hosts sharing one bucket is a known limitation, whereas a random
+#: per-process id would silently prevent the ledger from ever warm-starting.
+UNKNOWN_DIGEST = "unknown"
+
+_TRUTHY = ("1", "true", "yes", "on")
+_LOOPBACK_HOSTS = frozenset({
+    "127.0.0.1", "localhost", "::1", "0.0.0.0", "", "host.docker.internal",
+})
+
+
+def signature_enabled() -> bool:
+    """Master gate. Default ON. OFF restores the pre-2026-08-18 key shape
+    exactly, conflation included. NEVER raises."""
+    try:
+        return os.environ.get(ENABLED_ENV, "1").strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def digest_chars() -> int:
+    """Hex characters kept from the digest. Default 16 (64 bits).
+
+    Long enough that a collision across the handful of machines one operator
+    owns is not a practical concern; short enough to keep a ledger key
+    readable in a log line. Clamped to [8, 64]."""
+    try:
+        return max(8, min(64, int(os.environ.get(DIGEST_CHARS_ENV, "16"))))
+    except (TypeError, ValueError):
+        return 16
+
+
+@dataclass(frozen=True)
+class HardwareSignature:
+    """A machine's identity, and how confidently we know it."""
+
+    digest: str
+    #: ``probed`` -- from this host's own machine id + GPU UUIDs.
+    #: ``endpoint`` -- from a remote endpoint's host; distinct per machine but
+    #:   not verified to BE that machine's hardware.
+    #: ``unknown`` -- nothing identifying was resolvable.
+    provenance: str
+    #: The unhashed inputs, for audit. Never contains the port, and never a
+    #: full URL -- a signature is an identity, not a connection string.
+    components: Tuple[str, ...] = field(default_factory=tuple)
+
+    def __str__(self) -> str:
+        return self.digest
+
+    @property
+    def is_strong(self) -> bool:
+        """True only for a directly probed identity."""
+        return self.provenance == "probed"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "digest": self.digest,
+            "provenance": self.provenance,
+            "components": list(self.components),
+            "is_strong": self.is_strong,
+        }
+
+
+def _digest(components: Tuple[str, ...]) -> str:
+    """Stable hash of the component set.
+
+    SORTED before hashing so probe ORDER cannot change a machine's identity --
+    nvidia-smi and torch may enumerate the same two cards differently, and a
+    signature that flips with enumeration order would split one machine's
+    ledger in two.
+    """
+    payload = "\x1f".join(sorted(components)).encode("utf-8", "replace")
+    return hashlib.sha256(payload).hexdigest()[:digest_chars()]
+
+
+# --------------------------------------------------------------------------
+# machine identity -- cached for the process lifetime
+# --------------------------------------------------------------------------
+
+_MACHINE_ID: Optional[str] = None
+_MACHINE_LOCK = threading.Lock()
+
+
+def _read_first_line(path: str) -> str:
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            return fh.readline().strip()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _probe_machine_id() -> str:
+    """This host's durable identifier, or "". NEVER raises.
+
+    Explicitly NOT the hostname: an operator renames a machine, and a
+    signature that changes when they do would orphan every measurement taken
+    before the rename.
+    """
+    # Linux / most containers: a file read, no subprocess.
+    for path in ("/etc/machine-id", "/var/lib/dbus/machine-id"):
+        got = _read_first_line(path)
+        if got:
+            return got
+
+    if sys.platform == "darwin":
+        # IOPlatformUUID is the Mac's durable id. One bounded subprocess per
+        # PROCESS (the result is cached below), routed through the canonical
+        # bounded runner so a wedged ioreg cannot hold anything.
+        try:
+            from backend.core.bounded_subprocess import run_bounded
+            done = run_bounded(
+                ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+                timeout=3.0, text=True,
+            )
+            if done is not None and done.returncode == 0:
+                for line in (done.stdout or "").splitlines():
+                    if "IOPlatformUUID" in line and '"' in line:
+                        return line.rsplit('"', 2)[-2].strip()
+        except Exception:  # noqa: BLE001
+            pass
+
+    if os.name == "nt":
+        try:
+            import winreg  # type: ignore[import-not-found]
+            with winreg.OpenKey(
+                winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\Cryptography"
+            ) as key:
+                return str(winreg.QueryValueEx(key, "MachineGuid")[0])
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Last resort: the NIC-derived node id. Weaker (it can change with the
+    # active interface) but still machine-scoped, and vastly better than
+    # collapsing two hosts into one bucket.
+    try:
+        node = _uuid_mod.getnode()
+        # getnode() sets the multicast bit when it had to invent a random
+        # value -- a random id is NOT an identity, so decline it.
+        if node and not (node >> 40) & 0x01:
+            return "node-%x" % node
+    except Exception:  # noqa: BLE001
+        pass
+    return ""
+
+
+def machine_id() -> str:
+    """Cached :func:`_probe_machine_id`. Hardware does not change under a
+    running process, so this is resolved at most once."""
+    global _MACHINE_ID
+    with _MACHINE_LOCK:
+        if _MACHINE_ID is None:
+            try:
+                _MACHINE_ID = _probe_machine_id()
+            except Exception:  # noqa: BLE001
+                _MACHINE_ID = ""
+        return _MACHINE_ID
+
+
+def accelerator_components() -> Tuple[str, ...]:
+    """Identity fragments for this host's accelerators. NEVER raises.
+
+    Prefers the driver UUID; falls back to name+capacity, which cannot tell
+    two identical cards apart but still separates a 5090 host from a 4090
+    host. Reuses the EXISTING compute_topology reading rather than probing --
+    a second probe would be a second opinion about one machine.
+    """
+    try:
+        from backend.core.ouroboros.governance import (  # noqa: PLC0415
+            compute_topology as ct,
+        )
+        # resolve_sync() is the cached synchronous view. When the topology
+        # subsystem is DISABLED (its default) this returns a reading with no
+        # devices -- which is why the machine id must be able to carry the
+        # signature alone. GPU UUIDs enrich a host identity; they are not
+        # required to establish one.
+        reading = ct.resolve_sync()
+    except Exception:  # noqa: BLE001
+        return ()
+    out = []
+    try:
+        topo = getattr(getattr(reading, "topology", None), "value", "")
+        # ONLY a measured topology contributes. "unknown" is a statement about
+        # our PROBE, not about the hardware -- including it would make the
+        # signature move when `JARVIS_COMPUTE_TOPOLOGY_ENABLED` is flipped on,
+        # orphaning every measurement taken before the flip. A signature must
+        # change only when the machine does.
+        if topo and topo not in ("unknown", "disabled", "degraded"):
+            out.append("topo:%s" % topo)
+        for dev in (getattr(reading, "devices", ()) or ()):
+            if getattr(dev, "uuid", ""):
+                out.append("gpu:%s" % dev.uuid)
+            else:
+                out.append("gpu:%s:%d" % (
+                    getattr(dev, "name", "?"),
+                    int(getattr(dev, "total_bytes", 0) or 0)))
+        if not getattr(reading, "devices", ()):
+            # Unified memory (Apple Silicon) enumerates no discrete devices.
+            # Its capacity IS its identity fragment.
+            name = str(getattr(reading, "device_name", "") or "")
+            total = int(getattr(reading, "total_bytes", 0) or 0)
+            if name or total:
+                out.append("accel:%s:%d" % (name or "?", total))
+    except Exception:  # noqa: BLE001
+        return tuple(out)
+    return tuple(out)
+
+
+# --------------------------------------------------------------------------
+# resolution
+# --------------------------------------------------------------------------
+
+def endpoint_host(base_url: str) -> str:
+    """Host portion of *base_url*, lowercased, WITHOUT the port.
+
+    The port is excluded deliberately: one machine serving two models on two
+    ports is ONE piece of hardware, and splitting its ledger by port would
+    re-introduce the amnesia the physics ledger exists to cure.
+    NEVER raises.
+    """
+    try:
+        raw = str(base_url or "").strip()
+        if not raw:
+            return ""
+        if "://" not in raw:
+            raw = "http://" + raw
+        return (urlparse(raw).hostname or "").lower()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def is_local_endpoint(base_url: str) -> bool:
+    """True when *base_url* is served by this machine. NEVER raises."""
+    return endpoint_host(base_url) in _LOOPBACK_HOSTS
+
+
+_CACHE: Dict[str, HardwareSignature] = {}
+_CACHE_LOCK = threading.Lock()
+
+
+def signature_for(base_url: str = "") -> HardwareSignature:
+    """Identity of the machine SERVING *base_url*. NEVER raises.
+
+    Cached per host for the process lifetime.
+    """
+    if not signature_enabled():
+        return HardwareSignature(digest="", provenance="disabled")
+    host = endpoint_host(base_url)
+    with _CACHE_LOCK:
+        hit = _CACHE.get(host)
+    if hit is not None:
+        return hit
+    try:
+        sig = _resolve(base_url, host)
+    except Exception:  # noqa: BLE001
+        sig = HardwareSignature(digest=UNKNOWN_DIGEST, provenance="unknown")
+    with _CACHE_LOCK:
+        _CACHE[host] = sig
+    if sig.provenance != "probed":
+        logger.debug(
+            "[HardwareSignature] %s -> %s (%s) — a weaker identity than a "
+            "local probe; two hosts still get two ledgers",
+            host or "<local>", sig.digest, sig.provenance,
+        )
+    return sig
+
+
+def _resolve(base_url: str, host: str) -> HardwareSignature:
+    if is_local_endpoint(base_url):
+        # ONE SPINE, and enrichment must never move it.
+        #
+        # The machine id alone already answers the question this module
+        # exists for -- is this the M1 or the 5090 -- and it is available
+        # whether or not the topology subsystem is enabled. Accelerator
+        # components were originally APPENDED to it, which made the digest
+        # depend on `JARVIS_COMPUTE_TOPOLOGY_ENABLED`: flipping that flag
+        # re-keyed the ledger and orphaned every prior measurement, on a
+        # machine that had not changed at all.
+        #
+        # So GPU identity is a SUBSTITUTE for a missing spine, never an
+        # addition to a present one. Distinguishing two GPUs WITHIN one host
+        # is a different question, answered at a different granularity by
+        # `DeviceReading.uuid` where per-device routing actually needs it.
+        mid = machine_id()
+        if mid:
+            components = ("machine:%s" % mid,)
+            return HardwareSignature(
+                digest=_digest(components), provenance="probed",
+                components=components,
+            )
+        accel = accelerator_components()
+        if accel:
+            return HardwareSignature(
+                digest=_digest(accel), provenance="probed", components=accel,
+            )
+        # Nothing identifying resolved. Fall through to the platform class,
+        # which at least keeps a Mac and a PC apart.
+        fallback = ("platform:%s:%s" % (sys.platform, platform.machine()),)
+        return HardwareSignature(
+            digest=_digest(fallback), provenance="unknown",
+            components=fallback,
+        )
+
+    # Remote: we cannot probe that machine's hardware. Its host is a distinct
+    # -- if unverified -- identity, which is all the ledger needs to stop
+    # conflating two boxes.
+    components = ("endpoint:%s" % host,)
+    return HardwareSignature(
+        digest=_digest(components), provenance="endpoint",
+        components=components,
+    )
+
+
+def reset_for_tests() -> None:
+    """Drop every cached identity."""
+    global _MACHINE_ID
+    with _CACHE_LOCK:
+        _CACHE.clear()
+    with _MACHINE_LOCK:
+        _MACHINE_ID = None

--- a/backend/core/ouroboros/governance/inference_gateway.py
+++ b/backend/core/ouroboros/governance/inference_gateway.py
@@ -719,7 +719,11 @@ class InferenceGateway:
             )
             publish_provider_state_changed({
                 "provider": "local_tier_remote",
-                "endpoint": endpoint_host(target.base_url),
+                # The SAME identity the breaker, the residency cache and the
+                # client cache are keyed on. A prettier derived host would be
+                # a second identity for one endpoint, and an operator could no
+                # longer line this event up with `_health_for(base_url)`.
+                "endpoint": target.base_url,
                 "state": self._health_for(target.base_url).state().value,
                 "model": target.model_name,
                 "failure_class": getattr(exc, "failure_class",

--- a/backend/core/ouroboros/governance/inference_gateway.py
+++ b/backend/core/ouroboros/governance/inference_gateway.py
@@ -345,7 +345,13 @@ class InferenceGateway:
     def __init__(self, *, client_factory: Optional[Any] = None) -> None:
         self._lock = threading.Lock()
         self._health: Dict[str, _HostHealth] = {}
-        self._clients: Dict[str, Any] = {}
+        self._clients: Dict[Tuple[str, str], Any] = {}
+        #: (base_url, model_name) -> (client, profiler). Keyed by BOTH,
+        #: because a client is BOUND to a model: its cfg carries model_name
+        #: and its profiler is keyed by a physics_key that includes the model.
+        #: Keying on base_url alone silently served every later op with
+        #: whichever model was requested FIRST -- see the cache-identity note
+        #: on `_client_for`.
         #: base_url -> (monotonic_at, resident_models_or_None). None is
         #: "unknowable", which is NOT the same as an empty tuple.
         self._residency: Dict[str, Tuple[float, Optional[Tuple[str, ...]]]] = {}
@@ -428,8 +434,20 @@ class InferenceGateway:
         from backend.core.ouroboros.governance import (  # noqa: PLC0415
             local_inference_director as lid,
         )
+        # CACHE IDENTITY = (endpoint, model). Not the endpoint alone.
+        #
+        # Found by live-fire, not by 300+ unit tests, because every unit test
+        # used one model per gateway. After a warm swap to a second model on
+        # the SAME host, an endpoint-only key returned the first model's
+        # client for every subsequent dispatch -- so the requested model was
+        # silently ignored and its telemetry landed under the wrong physics
+        # key. On the deployment this is built for that is: one vision
+        # one-off swaps to the 27B, and every BACKGROUND op afterwards
+        # quietly runs on it at a third of the throughput, blowing budgets
+        # with no error anywhere.
+        cache_key = (target.base_url, target.model_name)
         with self._lock:
-            hit = self._clients.get(target.base_url)
+            hit = self._clients.get(cache_key)
         if hit is not None:
             return hit
         base = lid.LocalConfig.from_env()
@@ -443,7 +461,7 @@ class InferenceGateway:
             client = lid.LocalPrimeClient(cfg, profiler=profiler)
         pair = (client, profiler)
         with self._lock:
-            self._clients[target.base_url] = pair
+            self._clients[cache_key] = pair
         return pair
 
     async def dispatch(

--- a/backend/core/ouroboros/governance/inference_gateway.py
+++ b/backend/core/ouroboros/governance/inference_gateway.py
@@ -575,6 +575,7 @@ class InferenceGateway:
         except Exception:  # noqa: BLE001
             return None
         url = base_url.rstrip("/") + "/api/ps"
+        _t0 = time.monotonic()
         try:
             timeout = aiohttp.ClientTimeout(total=probe_timeout_s())
             async with aiohttp.ClientSession(timeout=timeout) as sess:
@@ -584,6 +585,20 @@ class InferenceGateway:
                     payload = await resp.json(content_type=None)
         except Exception:  # noqa: BLE001 — unreachable, unparseable, absent
             return None
+        # THE PROBE IS ALREADY A ROUND TRIP — so it is already an RTT sample,
+        # and taking it costs nothing. This seeds the transport profile BEFORE
+        # the first stream, so the very first generation is bounded by a
+        # deadline that already knows whether the host is 0.4ms away or 90ms
+        # away. Without it the first stream on a relayed link would be judged
+        # by a LAN-derived budget, which is precisely the false-positive this
+        # whole mechanism exists to prevent.
+        try:
+            from backend.core.ouroboros.governance.transport_profile import (  # noqa: PLC0415,E501
+                profile_for as _tprofile,
+            )
+            _tprofile(base_url).observe((time.monotonic() - _t0) * 1000.0)
+        except Exception:  # noqa: BLE001
+            pass
         try:
             rows = payload.get("models") or payload.get("data") or []
             names = tuple(

--- a/backend/core/ouroboros/governance/inference_gateway.py
+++ b/backend/core/ouroboros/governance/inference_gateway.py
@@ -509,6 +509,7 @@ class InferenceGateway:
             logger.warning(
                 "[InferenceGateway] remote %s failed (%s) — falling back to "
                 "local for this op", target.base_url, type(exc).__name__)
+            self._publish_degraded(target, exc)
             fallback = self._local_target(
                 f"remote fault: {type(exc).__name__}")
             return await self._dispatch_to(
@@ -664,6 +665,39 @@ class InferenceGateway:
         except Exception as exc:  # noqa: BLE001 — pre-flight must never block dispatch
             out["reason"] = f"preflight degraded: {type(exc).__name__}"
             return out
+
+    def _publish_degraded(self, target: "GatewayTarget",
+                          exc: BaseException) -> None:
+        """Surface a NON-FATAL network degradation on the existing SSE channel.
+
+        Reuses ``provider_state_changed`` -- already the DEGRADED<->HEALTHY
+        signal in this codebase -- rather than minting a new event type. New
+        types must be added to the canonical ``_VALID_EVENT_TYPES`` frozenset
+        or they are SILENTLY DROPPED, so inventing one here would produce a
+        degradation signal that degrades silently.
+
+        Best-effort by construction: the op has already been re-routed to the
+        local target by the time this runs, so a failure to publish must not
+        turn a handled degradation into an unhandled one. NEVER raises.
+        """
+        try:
+            from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: PLC0415,E501
+                publish_provider_state_changed,
+            )
+            publish_provider_state_changed({
+                "provider": "local_tier_remote",
+                "endpoint": endpoint_host(target.base_url),
+                "state": self._health_for(target.base_url).state().value,
+                "model": target.model_name,
+                "failure_class": getattr(exc, "failure_class",
+                                         type(exc).__name__),
+                "error": str(exc)[:200],
+                "fallback": "local_triage",
+                "fatal": False,
+            })
+        except Exception:  # noqa: BLE001
+            logger.debug("[InferenceGateway] degradation publish failed",
+                         exc_info=True)
 
     # -- lifecycle + observability ----------------------------------------
 

--- a/backend/core/ouroboros/governance/inference_gateway.py
+++ b/backend/core/ouroboros/governance/inference_gateway.py
@@ -1,0 +1,547 @@
+"""The bridge from this machine's orchestration to another machine's GPUs.
+
+WHAT THIS IS, AND DELIBERATELY IS NOT
+-------------------------------------
+It is an ENDPOINT RESOLVER, a HOST HEALTH STATE MACHINE, and a TELEMETRY
+ROUTER. It is not a transport, not a streaming client, and not a timeout
+implementation, because this repository already has all three and a second one
+would be a second authority over the same physics.
+
+Specifically it COMPOSES:
+
+  * :class:`local_inference_director.LocalPrimeClient` -- which already
+    streams and already runs the Inter-Token Watchdog
+    (``asyncio.wait_for(..., _inter_token_timeout_s())`` raising
+    :class:`InterTokenStall`). Re-implementing that here would duplicate the
+    one guard the module's own comment calls "the sole guard".
+  * :class:`LatencyProfiler` + the physics ledger -- keyed per host since the
+    hardware-signature work, which is precisely what makes remote telemetry
+    safe to record at all.
+  * :class:`ThroughputGovernor` -- which turns those measurements into a lane
+    count.
+
+THE ONE TRANSPORT DEFECT IT DOES FIX
+------------------------------------
+``LocalPrimeClient.complete`` decides whether to stream like this::
+
+    _use_stream = stream if stream is not None else (
+        bool(self._cfg.num_ctx) and _streaming_enabled())
+
+So on any config WITHOUT a negotiated ``num_ctx`` the client takes the
+non-streaming path -- and the Inter-Token Watchdog lives inside
+``_complete_streaming``. The watchdog exists but is DISARMED, on exactly the
+path a LAN bridge uses before context negotiation has run. A remote host that
+accepts the connection and then wedges would hang this process against a
+socket, which is the failure the bridge exists to prevent.
+
+The gateway therefore passes ``stream=True`` EXPLICITLY for remote targets. A
+stall over a LAN is not slowness, it is a peer that stopped talking, and it
+must be severed rather than waited out.
+
+DEGRADATION IS A ROUTING DECISION, NOT AN ERROR
+-----------------------------------------------
+When the remote host is unreachable the correct behaviour is not to fail the
+op -- it is to run it somewhere else. Triage-class work has a local model that
+can do it. So host health drives a routing table, and an op only fails when
+NO target can serve it.
+
+Health counts INFRASTRUCTURE faults only. A model returning a bad completion
+is not evidence about the host, and letting it open the breaker would take a
+healthy 5090 out of service because a prompt was malformed.
+
+Python 3.9+. Every governance import is lazy and fail-soft.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.InferenceGateway")
+
+ENABLED_ENV = "JARVIS_GATEWAY_ENABLED"
+REMOTE_ENDPOINT_ENV = "JARVIS_REMOTE_INFERENCE_ENDPOINT"
+REMOTE_MODEL_ENV = "JARVIS_REMOTE_INFERENCE_MODEL"
+LOCAL_TRIAGE_MODEL_ENV = "JARVIS_LOCAL_TRIAGE_MODEL"
+FAILURE_THRESHOLD_ENV = "JARVIS_GATEWAY_FAILURE_THRESHOLD"
+COOLDOWN_ENV = "JARVIS_GATEWAY_COOLDOWN_S"
+PROBE_TIMEOUT_ENV = "JARVIS_GATEWAY_PROBE_TIMEOUT_S"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def gateway_enabled() -> bool:
+    """Master gate. Default ON, but inert without a configured remote -- see
+    :func:`remote_endpoint`. NEVER raises."""
+    try:
+        return os.environ.get(ENABLED_ENV, "1").strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def remote_endpoint() -> str:
+    """The remote inference host, or "" when none is configured.
+
+    NEVER a hardcoded address. An unset value is not a misconfiguration -- it
+    is the single-machine case, and the gateway degrades to local-only without
+    complaint. That is why the master flag can default ON: a developer who has
+    never heard of this module sees no behaviour change.
+    """
+    try:
+        return (os.environ.get(REMOTE_ENDPOINT_ENV, "") or "").strip()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def remote_model() -> str:
+    """Model to request on the remote host. Empty -> whatever the local config
+    names, which is right when both hosts serve the same model."""
+    try:
+        return (os.environ.get(REMOTE_MODEL_ENV, "") or "").strip()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def local_triage_model() -> str:
+    """The lightweight model this machine falls back to. Empty -> the local
+    config's own model."""
+    try:
+        return (os.environ.get(LOCAL_TRIAGE_MODEL_ENV, "") or "").strip()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def failure_threshold() -> int:
+    """Consecutive infrastructure faults before the LAN is bypassed. Default 3.
+
+    Not 1: a single dropped packet or a model load pause is not an outage, and
+    a breaker that opens on one fault would flap. Not 10: every fault costs a
+    real op its budget."""
+    try:
+        return max(1, int(os.environ.get(FAILURE_THRESHOLD_ENV, "3")))
+    except (TypeError, ValueError):
+        return 3
+
+
+def cooldown_s() -> float:
+    """How long the LAN stays bypassed before ONE probe is allowed. Default 60."""
+    try:
+        return max(1.0, float(os.environ.get(COOLDOWN_ENV, "60")))
+    except (TypeError, ValueError):
+        return 60.0
+
+
+def probe_timeout_s() -> float:
+    """Bound on the reachability probe. Default 3s -- a probe that can hang is
+    a second instance of the bug this module exists to fix."""
+    try:
+        return max(0.5, float(os.environ.get(PROBE_TIMEOUT_ENV, "3")))
+    except (TypeError, ValueError):
+        return 3.0
+
+
+class HostState(str, enum.Enum):
+    """Reachability of one inference host."""
+
+    UNKNOWN = "unknown"        # never contacted
+    HEALTHY = "healthy"        # last attempt succeeded
+    DEGRADED = "degraded"      # faults observed, still under threshold
+    UNREACHABLE = "unreachable"  # breaker OPEN -- bypass the LAN
+    PROBING = "probing"        # breaker HALF-OPEN -- one attempt allowed
+
+
+@dataclass(frozen=True)
+class GatewayTarget:
+    """Where an op should be dispatched, and why."""
+
+    base_url: str
+    model_name: str
+    #: "remote" or "local". Not cosmetic: it decides whether streaming is
+    #: FORCED (see the module docstring) and which physics ledger is written.
+    scope: str
+    state: HostState
+    reason: str
+
+    @property
+    def is_remote(self) -> bool:
+        return self.scope == "remote"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "base_url": self.base_url, "model_name": self.model_name,
+            "scope": self.scope, "state": self.state.value,
+            "reason": self.reason,
+        }
+
+
+class RemoteHostUnavailable(RuntimeError):
+    """No target could serve this op. An INFRASTRUCTURE failure class, so the
+    orchestrator's existing taxonomy attributes it to the host rather than to
+    the model's output."""
+
+    failure_class = "remote_host_unavailable"
+
+
+class _HostHealth:
+    """Three-state breaker for ONE endpoint.
+
+    CLOSED (healthy/degraded) -> OPEN (unreachable) -> HALF-OPEN (probing).
+
+    Half-open admits exactly ONE attempt. Without that gate every queued op
+    would stampede a recovering host the instant the cooldown expired, and the
+    first thing a recovering host does is load a model -- so the stampede
+    arrives precisely when it is least able to absorb it.
+    """
+
+    __slots__ = ("_lock", "_consecutive", "_state", "_opened_at", "_probe_taken",
+                 "_last_reason", "_successes", "_failures")
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._consecutive = 0
+        self._state = HostState.UNKNOWN
+        self._opened_at = 0.0
+        self._probe_taken = False
+        self._last_reason = ""
+        self._successes = 0
+        self._failures = 0
+
+    def state(self, *, now: Optional[float] = None) -> HostState:
+        _now = time.monotonic() if now is None else now
+        with self._lock:
+            if self._state is not HostState.UNREACHABLE:
+                return self._state
+            if (_now - self._opened_at) < cooldown_s():
+                return HostState.UNREACHABLE
+            # Cooldown elapsed: offer exactly one probe slot.
+            if not self._probe_taken:
+                return HostState.PROBING
+            return HostState.UNREACHABLE
+
+    def claim_probe(self, *, now: Optional[float] = None) -> bool:
+        """Take the single half-open slot. False if already taken."""
+        _now = time.monotonic() if now is None else now
+        with self._lock:
+            if self._state is not HostState.UNREACHABLE:
+                return True
+            if (_now - self._opened_at) < cooldown_s() or self._probe_taken:
+                return False
+            self._probe_taken = True
+            return True
+
+    def record_success(self) -> None:
+        with self._lock:
+            self._consecutive = 0
+            self._successes += 1
+            self._state = HostState.HEALTHY
+            self._probe_taken = False
+            self._last_reason = ""
+
+    def record_failure(self, reason: str, *, now: Optional[float] = None) -> None:
+        _now = time.monotonic() if now is None else now
+        with self._lock:
+            self._consecutive += 1
+            self._failures += 1
+            self._last_reason = reason
+            if self._consecutive >= failure_threshold():
+                # Re-stamp `_opened_at` on every failure at or past the
+                # threshold, INCLUDING a failed half-open probe -- otherwise a
+                # host that fails its probe would be retried immediately,
+                # because its cooldown had already elapsed.
+                self._state = HostState.UNREACHABLE
+                self._opened_at = _now
+                self._probe_taken = False
+            else:
+                self._state = HostState.DEGRADED
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "state": self._state.value,
+                "consecutive_failures": self._consecutive,
+                "successes": self._successes,
+                "failures": self._failures,
+                "last_reason": self._last_reason,
+            }
+
+
+#: Exception TYPE NAMES that are evidence about the HOST. Matched by name so
+#: this module never imports aiohttp, and so a transport library swap does not
+#: silently empty the set.
+_INFRA_FAULTS = frozenset({
+    "InterTokenStall", "LocalLatencyLockup", "UnrecoverableInferenceLatency",
+    "TimeoutError", "AsyncTimeoutError", "ClientConnectorError",
+    "ClientOSError", "ServerDisconnectedError", "ClientPayloadError",
+    "ConnectionResetError", "ConnectionRefusedError", "OSError",
+    "ClientConnectionError", "ServerTimeoutError",
+})
+
+
+def is_infrastructure_fault(exc: BaseException) -> bool:
+    """Is *exc* evidence about the HOST rather than about the request?
+
+    A model returning nonsense, or a 400 for a malformed body, says nothing
+    about whether the machine is up. Counting those would open the breaker on
+    a healthy 5090 because a prompt was wrong -- taking working hardware out
+    of service for a software bug. NEVER raises.
+    """
+    try:
+        names = {type(exc).__name__}
+        names.update(b.__name__ for b in type(exc).__mro__)
+        return bool(names & _INFRA_FAULTS)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+class InferenceGateway:
+    """Resolves a target, dispatches through the existing client, records health.
+
+    Not a singleton by construction -- :func:`get_default_gateway` provides the
+    process-wide one, and tests build their own.
+    """
+
+    def __init__(self, *, client_factory: Optional[Any] = None) -> None:
+        self._lock = threading.Lock()
+        self._health: Dict[str, _HostHealth] = {}
+        self._clients: Dict[str, Any] = {}
+        self._client_factory = client_factory
+
+    # -- resolution --------------------------------------------------------
+
+    def _health_for(self, endpoint: str) -> _HostHealth:
+        with self._lock:
+            h = self._health.get(endpoint)
+            if h is None:
+                h = _HostHealth()
+                self._health[endpoint] = h
+            return h
+
+    def target_for(self, *, route: Optional[str] = None,
+                   now: Optional[float] = None) -> GatewayTarget:
+        """Where should an op on *route* run right now? NEVER raises."""
+        try:
+            return self._target_for(route=route, now=now)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[InferenceGateway] resolution degraded", exc_info=True)
+            return self._local_target(f"resolution failed: {type(exc).__name__}")
+
+    def _local_target(self, reason: str) -> GatewayTarget:
+        from backend.core.ouroboros.governance import (  # noqa: PLC0415
+            local_inference_director as lid,
+        )
+        cfg = lid.LocalConfig.from_env()
+        return GatewayTarget(
+            base_url=str(getattr(cfg, "base_url", "") or ""),
+            model_name=local_triage_model() or str(
+                getattr(cfg, "model_name", "") or ""),
+            scope="local", state=HostState.HEALTHY, reason=reason,
+        )
+
+    def _target_for(self, *, route: Optional[str],
+                    now: Optional[float]) -> GatewayTarget:
+        endpoint = remote_endpoint()
+        if not gateway_enabled():
+            return self._local_target("gateway disabled")
+        if not endpoint:
+            # The single-machine case, not a misconfiguration.
+            return self._local_target("no remote endpoint configured")
+
+        health = self._health_for(endpoint)
+        state = health.state(now=now)
+        if state is HostState.UNREACHABLE:
+            return self._local_target(
+                f"remote {endpoint} unreachable — bypassing LAN")
+        if state is HostState.PROBING and not health.claim_probe(now=now):
+            # Someone else took the single half-open slot.
+            return self._local_target(
+                f"remote {endpoint} recovering — probe slot taken")
+
+        from backend.core.ouroboros.governance import (  # noqa: PLC0415
+            local_inference_director as lid,
+        )
+        cfg = lid.LocalConfig.from_env()
+        return GatewayTarget(
+            base_url=endpoint,
+            model_name=remote_model() or str(getattr(cfg, "model_name", "") or ""),
+            scope="remote", state=state,
+            reason="probing after cooldown" if state is HostState.PROBING
+            else "remote healthy",
+        )
+
+    # -- transport ---------------------------------------------------------
+
+    def _client_for(self, target: GatewayTarget) -> Tuple[Any, Any]:
+        """A client bound to *target*, with a profiler on THAT host's ledger.
+
+        The profiler is keyed by ``physics_key(cfg, endpoint=...)``, so a
+        remote 5090's measurements never land in this Mac's entry. Before the
+        hardware-signature work that key was ``model@ctx`` and this whole
+        method would have silently poisoned the local ledger with LAN numbers.
+        """
+        import dataclasses  # noqa: PLC0415
+
+        from backend.core.ouroboros.governance import (  # noqa: PLC0415
+            local_inference_director as lid,
+        )
+        with self._lock:
+            hit = self._clients.get(target.base_url)
+        if hit is not None:
+            return hit
+        base = lid.LocalConfig.from_env()
+        cfg = dataclasses.replace(
+            base, base_url=target.base_url, model_name=target.model_name)
+        profiler = lid.LatencyProfiler(
+            cfg, ledger_key=lid.physics_key(cfg, endpoint=target.base_url))
+        if self._client_factory is not None:
+            client = self._client_factory(cfg, profiler)
+        else:
+            client = lid.LocalPrimeClient(cfg, profiler=profiler)
+        pair = (client, profiler)
+        with self._lock:
+            self._clients[target.base_url] = pair
+        return pair
+
+    async def dispatch(
+        self,
+        *,
+        system: str,
+        user: str,
+        prompt_tokens: int,
+        route: Optional[str] = None,
+        temperature: float = 0.2,
+        max_tokens: Optional[int] = None,
+        now: Optional[float] = None,
+    ) -> Any:
+        """Run one completion on the best available host.
+
+        STREAMING TIMEOUT LOGIC, end to end:
+
+        1. ``stream=True`` is FORCED for remote targets. The client would
+           otherwise choose the non-streaming path whenever ``num_ctx`` is
+           unset, and the Inter-Token Watchdog lives inside the streaming
+           path. The guard exists; this arms it.
+        2. The watchdog is the client's, not ours: it awaits each chunk under
+           ``asyncio.wait_for(..., _inter_token_timeout_s())``. The model may
+           take as long as it likes overall, provided it keeps EMITTING --
+           which is the right shape for a 64K-context prompt whose first token
+           legitimately takes a minute, and the wrong shape for a total
+           deadline, which is why a total deadline is not used here.
+        3. A breach raises :class:`InterTokenStall` from inside the client,
+           which severs the connection as the ``async with`` unwinds. We do
+           not re-implement cancellation; we classify the result.
+        4. That fault counts against HOST health. Enough of them open the
+           breaker and the next op is routed locally instead of failing.
+        5. A retry on the local target happens ONLY for a remote infra fault,
+           and only once. A local fault has nowhere to fall back to and is
+           raised.
+        """
+        target = self.target_for(route=route, now=now)
+        try:
+            return await self._dispatch_to(
+                target, system=system, user=user, prompt_tokens=prompt_tokens,
+                temperature=temperature, max_tokens=max_tokens)
+        except Exception as exc:  # noqa: BLE001
+            if not target.is_remote:
+                raise
+            if not is_infrastructure_fault(exc):
+                # The host ANSWERED; the REQUEST was bad. Two consequences,
+                # and the ordering here is load-bearing:
+                #
+                #   * it is NOT recorded against host health. An earlier draft
+                #     recorded first and classified second, so a malformed
+                #     prompt opened the breaker and removed a perfectly
+                #     healthy 5090 from service for a software bug.
+                #   * it is not retried elsewhere. The same request would fail
+                #     identically on another machine and burn a second budget.
+                raise
+            self._health_for(target.base_url).record_failure(
+                f"{type(exc).__name__}: {str(exc)[:120]}", now=now)
+            logger.warning(
+                "[InferenceGateway] remote %s failed (%s) — falling back to "
+                "local for this op", target.base_url, type(exc).__name__)
+            fallback = self._local_target(
+                f"remote fault: {type(exc).__name__}")
+            return await self._dispatch_to(
+                fallback, system=system, user=user,
+                prompt_tokens=prompt_tokens, temperature=temperature,
+                max_tokens=max_tokens)
+
+    async def _dispatch_to(self, target: GatewayTarget, *, system: str,
+                           user: str, prompt_tokens: int, temperature: float,
+                           max_tokens: Optional[int]) -> Any:
+        client, _profiler = self._client_for(target)
+        result = await client.complete(
+            system=system, user=user, prompt_tokens=prompt_tokens,
+            temperature=temperature, max_tokens=max_tokens,
+            # See the docstring: forced for remote, left to the client's own
+            # policy locally (where a stall is slowness, not a dead peer).
+            stream=True if target.is_remote else None,
+        )
+        if target.is_remote:
+            self._health_for(target.base_url).record_success()
+        return result
+
+    # -- lifecycle + observability ----------------------------------------
+
+    async def aclose(self) -> None:
+        """Close every client this gateway OWNS. NEVER raises.
+
+        Ownership is explicit because an un-closed aiohttp session is a leak
+        this codebase has already paid for once -- the cognition-lanes
+        provider leak, where a per-call client was left for the GC.
+        """
+        with self._lock:
+            pairs = list(self._clients.values())
+            self._clients.clear()
+        for client, _prof in pairs:
+            try:
+                closer = getattr(client, "aclose", None)
+                if closer is not None:
+                    await closer()
+            except Exception:  # noqa: BLE001
+                logger.debug("[InferenceGateway] client close degraded",
+                             exc_info=True)
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Observability surface. NEVER raises."""
+        try:
+            endpoint = remote_endpoint()
+            out: Dict[str, Any] = {
+                "enabled": gateway_enabled(),
+                "remote_endpoint": endpoint or None,
+                "failure_threshold": failure_threshold(),
+                "cooldown_s": cooldown_s(),
+                "hosts": {},
+            }
+            with self._lock:
+                items = list(self._health.items())
+            for ep, h in items:
+                out["hosts"][ep] = h.snapshot()
+            out["active_target"] = self.target_for().to_dict()
+            return out
+        except Exception:  # noqa: BLE001
+            return {"enabled": False, "error": "snapshot degraded"}
+
+
+_SINGLETON: Optional[InferenceGateway] = None
+_SINGLETON_LOCK = threading.Lock()
+
+
+def get_default_gateway() -> InferenceGateway:
+    """Process-wide gateway. Mirrors `memory_pressure_gate.get_default_gate`."""
+    global _SINGLETON
+    with _SINGLETON_LOCK:
+        if _SINGLETON is None:
+            _SINGLETON = InferenceGateway()
+        return _SINGLETON
+
+
+def reset_for_tests() -> None:
+    global _SINGLETON
+    with _SINGLETON_LOCK:
+        _SINGLETON = None

--- a/backend/core/ouroboros/governance/inference_gateway.py
+++ b/backend/core/ouroboros/governance/inference_gateway.py
@@ -71,6 +71,9 @@ LOCAL_TRIAGE_MODEL_ENV = "JARVIS_LOCAL_TRIAGE_MODEL"
 FAILURE_THRESHOLD_ENV = "JARVIS_GATEWAY_FAILURE_THRESHOLD"
 COOLDOWN_ENV = "JARVIS_GATEWAY_COOLDOWN_S"
 PROBE_TIMEOUT_ENV = "JARVIS_GATEWAY_PROBE_TIMEOUT_S"
+PREFLIGHT_ENV = "JARVIS_GATEWAY_PREFLIGHT_ENABLED"
+RESIDENCY_TTL_ENV = "JARVIS_GATEWAY_RESIDENCY_TTL_S"
+SWAP_BUDGET_ENV = "JARVIS_GATEWAY_WARM_SWAP_BUDGET_S"
 
 _TRUTHY = ("1", "true", "yes", "on")
 
@@ -143,6 +146,40 @@ def probe_timeout_s() -> float:
         return max(0.5, float(os.environ.get(PROBE_TIMEOUT_ENV, "3")))
     except (TypeError, ValueError):
         return 3.0
+
+
+def preflight_enabled() -> bool:
+    """Master gate for the residency pre-flight. Default ON. NEVER raises."""
+    try:
+        return os.environ.get(PREFLIGHT_ENV, "1").strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def residency_ttl_s() -> float:
+    """How long a residency reading stays fresh. Default 30s.
+
+    Short, because residency is exactly the thing that changes underneath us:
+    another client can request a different model and evict ours. Long enough
+    that a burst of ops does not issue a probe each."""
+    try:
+        return max(0.0, float(os.environ.get(RESIDENCY_TTL_ENV, "30")))
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def warm_swap_budget_s() -> float:
+    """Wall-clock allowed for a cold load. Default 180s.
+
+    Generous ON PURPOSE and NOT derived from a route budget: this is the
+    cost of moving ~19GB across PCIe into VRAM, which has nothing to do with
+    how urgent the op is. Measured ~30s for a 1.9GB model on Apple Silicon;
+    a 30B on a discrete card is meaningfully longer. The whole point of
+    paying it here is that it is paid OUTSIDE the op's generation clock."""
+    try:
+        return max(1.0, float(os.environ.get(SWAP_BUDGET_ENV, "180")))
+    except (TypeError, ValueError):
+        return 180.0
 
 
 class HostState(str, enum.Enum):
@@ -309,6 +346,9 @@ class InferenceGateway:
         self._lock = threading.Lock()
         self._health: Dict[str, _HostHealth] = {}
         self._clients: Dict[str, Any] = {}
+        #: base_url -> (monotonic_at, resident_models_or_None). None is
+        #: "unknowable", which is NOT the same as an empty tuple.
+        self._residency: Dict[str, Tuple[float, Optional[Tuple[str, ...]]]] = {}
         self._client_factory = client_factory
 
     # -- resolution --------------------------------------------------------
@@ -441,6 +481,11 @@ class InferenceGateway:
            raised.
         """
         target = self.target_for(route=route, now=now)
+        if target.is_remote:
+            # Pre-flight OUTSIDE the try: a warm swap is not a dispatch
+            # attempt, so a slow load must not be classified as a host fault
+            # and must not open the breaker.
+            await self.ensure_model_resident(target)
         try:
             return await self._dispatch_to(
                 target, system=system, user=user, prompt_tokens=prompt_tokens,
@@ -485,6 +530,140 @@ class InferenceGateway:
         if target.is_remote:
             self._health_for(target.base_url).record_success()
         return result
+
+    # -- pre-flight residency ---------------------------------------------
+
+    async def resident_models(self, base_url: str) -> Optional[Tuple[str, ...]]:
+        """Models the remote currently holds IN VRAM, or None if unknowable.
+
+        ``/api/ps`` answers "what is loaded RIGHT NOW", which is a different
+        question from ``/api/tags`` ("what is installed") -- the latter is
+        already memoised elsewhere in this codebase and would answer the wrong
+        question here: a model can be installed and not resident, which is
+        precisely the case a warm swap exists to handle.
+
+        None is returned for "could not determine", NEVER an empty tuple. A
+        server that does not implement ``/api/ps`` (vLLM, an older ollama)
+        must not be read as "nothing is loaded" -- that would make every op
+        trigger a needless warm swap. Empty tuple means the endpoint answered
+        and genuinely holds nothing.
+
+        Bounded by :func:`probe_timeout_s`; a probe that can hang is a second
+        instance of the bug this whole module exists to prevent. NEVER raises.
+        """
+        try:
+            import aiohttp  # noqa: PLC0415
+        except Exception:  # noqa: BLE001
+            return None
+        url = base_url.rstrip("/") + "/api/ps"
+        try:
+            timeout = aiohttp.ClientTimeout(total=probe_timeout_s())
+            async with aiohttp.ClientSession(timeout=timeout) as sess:
+                async with sess.get(url) as resp:
+                    if resp.status != 200:
+                        return None
+                    payload = await resp.json(content_type=None)
+        except Exception:  # noqa: BLE001 — unreachable, unparseable, absent
+            return None
+        try:
+            rows = payload.get("models") or payload.get("data") or []
+            names = tuple(
+                str(r.get("name") or r.get("model") or "").strip()
+                for r in rows if isinstance(r, dict)
+            )
+            return tuple(n for n in names if n)
+        except Exception:  # noqa: BLE001
+            return None
+
+    @staticmethod
+    def _model_matches(wanted: str, resident: Tuple[str, ...]) -> bool:
+        """Is *wanted* among *resident*? Tolerates ollama's tag conventions.
+
+        ``qwen3-coder:30b`` and ``qwen3-coder:30b-instruct-q4_K_M`` are the
+        same weights to an operator and different strings to a registry, and
+        a bare ``qwen3-coder`` is reported as ``qwen3-coder:latest``. An
+        over-strict comparison would warm-swap a model that is already
+        resident -- burning a cold load to load what is loaded.
+        """
+        w = (wanted or "").strip().lower()
+        if not w:
+            return True          # nothing requested -> nothing to verify
+        w_base = w.split(":", 1)[0]
+        for r in resident:
+            r = r.strip().lower()
+            if r == w or r.startswith(w + "-"):
+                return True
+            if r.split(":", 1)[0] == w_base and (":" not in w or w.split(":", 1)[1] in r):
+                return True
+        return False
+
+    async def ensure_model_resident(self, target: "GatewayTarget") -> Dict[str, Any]:
+        """Pre-flight: verify the target model is loaded, warm-swapping if not.
+
+        WHY THIS EXISTS. Ollama loads a model on first use. If the resident
+        model is the 30B coder and an op asks for the 27B vision model, that
+        first request pays a multi-second-to-multi-minute cold load INSIDE its
+        own generation window -- and the route budget was calibrated for
+        generation, not for PCIe transfer. The op then fails on a deadline
+        that had nothing to do with the model's speed, which is the most
+        misleading failure this tier can produce.
+
+        So the swap is performed as an explicit handshake, BEFORE the op's
+        clock starts, against a budget of its own (:func:`warm_swap_budget_s`)
+        rather than against the route's.
+
+        Composes the EXISTING ``LocalPrimeClient.warmup()``, which already
+        forces weights into VRAM with a dedicated cold-start HTTP context.
+        Re-implementing it here would be a second cold-load path.
+
+        NEVER raises. Returns a small report for observability.
+        """
+        out: Dict[str, Any] = {"checked": False, "swapped": False,
+                               "resident": None, "reason": ""}
+        if not preflight_enabled():
+            out["reason"] = "preflight disabled"
+            return out
+        try:
+            now = time.monotonic()
+            with self._lock:
+                cached = self._residency.get(target.base_url)
+            if cached is not None and (now - cached[0]) < residency_ttl_s():
+                resident = cached[1]
+            else:
+                resident = await self.resident_models(target.base_url)
+                with self._lock:
+                    self._residency[target.base_url] = (now, resident)
+            out["checked"] = True
+            out["resident"] = list(resident) if resident is not None else None
+
+            if resident is None:
+                # Unknowable, not empty. Dispatch anyway: the client's own
+                # inter-token watchdog still bounds a slow first token, and
+                # swapping on every op would be worse than the problem.
+                out["reason"] = "residency unknown — dispatching without a swap"
+                return out
+            if self._model_matches(target.model_name, resident):
+                out["reason"] = "already resident"
+                return out
+
+            logger.info(
+                "[InferenceGateway] warm swap: %s is resident, op needs %s — "
+                "loading before the op clock starts (budget %.0fs)",
+                ", ".join(resident) or "<none>", target.model_name,
+                warm_swap_budget_s(),
+            )
+            client, _prof = self._client_for(target)
+            ok = await client.warmup(timeout_s=warm_swap_budget_s())
+            out["swapped"] = bool(ok)
+            out["reason"] = "warm swap completed" if ok else (
+                "warm swap did not confirm — dispatching anyway")
+            # The reading is now stale either way.
+            with self._lock:
+                self._residency.pop(target.base_url, None)
+            return out
+        except Exception as exc:  # noqa: BLE001 — pre-flight must never block dispatch
+            out["reason"] = f"preflight degraded: {type(exc).__name__}"
+            return out
 
     # -- lifecycle + observability ----------------------------------------
 

--- a/backend/core/ouroboros/governance/intake_dlq.py
+++ b/backend/core/ouroboros/governance/intake_dlq.py
@@ -48,15 +48,25 @@ def _default_path() -> str:
     return os.path.join(".jarvis", "intake_dlq.jsonl")
 
 
+#: Identity sources, most-specific first. `dedup_key` and `causal_id` were
+#: MISSING and that was a live defect, not an omission of taste: real
+#: IntentEnvelopes identify themselves with `dedup_key` (it is named for
+#: exactly this purpose) and often carry no `goal_id`. Since `replay_dlq`
+#: dedups first-wins on this value, an empty identity meant every such
+#: envelope collapsed into ONE survivor — genuine queued work silently
+#: discarded by the mechanism meant to preserve it.
+_IDENTITY_KEYS: tuple = ("goal_id", "op_id", "id", "dedup_key", "causal_id")
+
+
 def _goal_id(envelope: Any) -> str:
     """Extract a stable identifier from *envelope* (dict or object)."""
     if isinstance(envelope, dict):
-        for key in ("goal_id", "op_id", "id"):
+        for key in _IDENTITY_KEYS:
             val = envelope.get(key)
             if val is not None:
                 return str(val)
         return ""
-    for attr in ("goal_id", "op_id", "id"):
+    for attr in _IDENTITY_KEYS:
         val = getattr(envelope, attr, None)
         if val is not None:
             return str(val)
@@ -92,17 +102,123 @@ def _to_serializable(envelope: Any) -> Any:
 # ---------------------------------------------------------------------------
 
 
+#: Keys whose presence means the router could ACT on this record. Identity
+#: alone is not enough: `{"op_id": ..., "phase": "blast_radius"}` has an id and
+#: is still not work.
+_ACTIONABLE_KEYS: tuple = (
+    "description", "goal", "intent", "signal", "content", "prompt",
+    "target_files", "task",
+)
+
+
+def is_replayable(envelope: Any) -> bool:
+    """Could this record be re-ingested AS WORK? NEVER raises.
+
+    A dead-letter queue's entire contract is "work that failed and can be
+    retried". Replayability is therefore not a nicety — it is the membership
+    condition, and a record that fails it does not belong in the queue no
+    matter how much it deserves to be persisted somewhere.
+
+    Requires BOTH:
+      * an identity (`_goal_id`), so replay can dedup; and
+      * at least one ACTIONABLE field, so the router has something to do.
+
+    The second condition is what a diagnostic fails. Error telemetry has
+    `action`/`detail`/`error_class`/`surface` — informative to a human,
+    meaningless to an intake router, and indistinguishable from work if the
+    only check is "is it a dict".
+    """
+    try:
+        # IDENTITY **OR** ACTIONABLE CONTENT — deliberately permissive.
+        #
+        # An earlier draft required actionable content, and four existing
+        # tests caught it: a minimal `{"goal_id": "g1"}` is a legitimate
+        # envelope under the old contract, and rejecting it would have
+        # DIVERTED REAL WORK into the diagnostics file. That is the dangerous
+        # direction — strictly worse than the misfiling being fixed, because
+        # the misfiling never lost work and a false diversion would.
+        #
+        # So the rule diverts only what is positively NEITHER: no identity the
+        # router could dedup on, and no field it could act upon. Every one of
+        # the 153 misfiled records observed in production fails both tests —
+        # `{awakened_model, classification, instance, k}` and
+        # `{action, detail, error_class, event, note, surface}` carry neither
+        # an id nor a payload — so the offenders are still caught while
+        # anything ambiguous stays where it is.
+        if isinstance(envelope, dict):
+            return bool(_goal_id(envelope)) or any(
+                envelope.get(k) for k in _ACTIONABLE_KEYS)
+        return bool(_goal_id(envelope)) or any(
+            getattr(envelope, k, None) for k in _ACTIONABLE_KEYS)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _diagnostics_path(path: str | None = None) -> str:
+    """Sibling file for records that are worth persisting but not replaying."""
+    base = path if path is not None else _default_path()
+    root, _, _ = base.rpartition(".jsonl")
+    return (root or base) + "_diagnostics.jsonl"
+
+
+def append_diagnostic(payload: Any, *, reason: str,
+                      path: str | None = None) -> None:
+    """Persist a NON-replayable record. NEVER raises.
+
+    Exists so the contract on `append_dlq` can be enforced without losing
+    data. Rejecting a diagnostic outright would push callers to drop it, which
+    is worse than the misfiling this replaces.
+    """
+    if not _enabled():
+        return
+    p = _diagnostics_path(path)
+    record = {
+        "ts": time.time(),
+        "reason": reason,
+        "schema_version": _SCHEMA_VERSION,
+        "kind": "diagnostic",
+        "payload": _to_serializable(payload),
+    }
+    try:
+        os.makedirs(os.path.dirname(os.path.abspath(p)), exist_ok=True)
+        with open(p, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, sort_keys=True) + "\n")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[IntakeDLQ] diagnostic append failed: %s", exc)
+
+
 def append_dlq(
     envelope: Any,
     *,
     reason: str,
     path: str | None = None,
 ) -> None:
-    """Persist *envelope* to the DLQ and emit a CRITICAL log line.
+    """Persist a REPLAYABLE *envelope* to the DLQ and emit a CRITICAL log line.
 
     Never raises — any I/O error is caught and logged at WARNING.
+
+    THE CONTRACT IS NOW ENFORCED. This parameter was typed ``Any`` and the
+    queue accepted anything a caller happened to hold, so diagnostics were
+    filed alongside work: of 156 entries observed in production, 152 were
+    error telemetry and 3 were test fixtures. That is not merely untidy —
+    `replay_dlq` dedups by ``goal_id``, every diagnostic has an empty one, so
+    a replay would collapse them to a single entry and hand an error record
+    to the intake router AS WORK.
+
+    A record that cannot be replayed is routed to `append_diagnostic` instead
+    of being dropped: enforcing the contract must not cost data.
     """
     if not _enabled():
+        return
+    if not is_replayable(envelope):
+        # Named at WARNING with the reason, so a misrouting caller is visible
+        # rather than silently redirected. The record itself is preserved.
+        logger.warning(
+            "[IntakeDLQ] non-replayable record routed to diagnostics "
+            "(reason=%s) — a DLQ holds work that can be retried, and this "
+            "carries no actionable payload", reason,
+        )
+        append_diagnostic(envelope, reason=reason, path=path)
         return
     p = path if path is not None else _default_path()
     goal = _goal_id(envelope)
@@ -181,6 +297,19 @@ async def replay_dlq(
         return 0
     p = path if path is not None else _default_path()
     rows = read_dlq(p)
+    # DEFENSIVE SKIP for records written before the contract was enforced.
+    # 152 such rows exist in production today. Guarding only new writes would
+    # leave them armed: they all carry an empty goal_id, so replay would dedup
+    # them to one and feed a diagnostic to the router as work.
+    _total = len(rows)
+    rows = [r for r in rows
+            if is_replayable((r or {}).get("envelope"))]
+    if _total != len(rows):
+        logger.warning(
+            "[IntakeDLQ] skipping %d non-replayable legacy row(s) of %d — "
+            "diagnostics misfiled into the replay queue before the contract "
+            "was enforced", _total - len(rows), _total,
+        )
     if not rows:
         return 0
 

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -329,6 +329,27 @@ def physics_key(cfg: "LocalConfig", *, endpoint: str = "") -> str:
         # (cross-node failover) where it matters most.
         target = str(endpoint or getattr(cfg, "base_url", "") or "")
         digest = signature_for(target).digest
+        # TRANSPORT is a THIRD axis, distinct from hardware and from model.
+        #
+        # The same 5090 reached over a Tailscale direct link and over a DERP
+        # relay is the same silicon on two different networks: identical
+        # hardware signature, wildly different observed latency. Blending them
+        # into one entry would have the ThroughputGovernor size lanes for a
+        # hotel-wifi session from home-LAN measurements, and vice versa — the
+        # exact cross-contamination the hardware axis exists to prevent, one
+        # level down the stack.
+        #
+        # Empty when unmeasured: an unknown transport must not become a bucket
+        # that later real measurements are mixed into.
+        try:
+            from backend.core.ouroboros.governance.transport_profile import (
+                transport_class_for,
+            )
+            _tclass = transport_class_for(target)
+        except Exception:  # noqa: BLE001
+            _tclass = ""
+        if digest and _tclass:
+            return "%s@%s@%s" % (digest, _tclass, base)
         # An empty digest means the signature layer is off or declined to
         # guess. Fall back to the legacy shape rather than inventing a
         # placeholder segment -- a key containing "unknown" would silently
@@ -916,7 +937,25 @@ class LocalPrimeClient:
         # AND tight enough to declare a large legitimate prefill "wedged".
         # See LatencyProfiler.inter_token_budget_s.
         _first_token_s, _steady_token_s = self.profiler.inter_token_budget_s()
+        # TRANSPORT FLOOR — added, never substituted.
+        #
+        # A stall deadline must cover the time the MODEL needs plus the time
+        # the NETWORK takes to deliver it. The model term comes from the
+        # physics ledger; this one comes from measured inter-arrival variance
+        # and rises automatically when the path degrades mid-stream (Tailscale
+        # can flip direct -> DERP without warning). Without it, the ~2.0s
+        # steady deadline computed from a fast host would sever perfectly
+        # healthy streams the moment the operator left the LAN.
+        try:
+            from backend.core.ouroboros.governance.transport_profile import (
+                profile_for as _tprofile,
+            )
+            _tp = _tprofile(self._cfg.base_url)
+            _steady_token_s = _steady_token_s + _tp.floor_s()
+        except Exception:  # noqa: BLE001
+            _tp = None
         inter_token_s = _first_token_s
+        _last_chunk_at = time.monotonic()
         # Seed with the resume prefill so the assembled text continues the partial.
         parts: List[str] = [prefill] if prefill else []
         ttft_ms = 0.0
@@ -992,6 +1031,15 @@ class LocalPrimeClient:
                         return_when=asyncio.FIRST_COMPLETED,
                     )
                     if _read_task in done:
+                        # Feed the ARRIVAL back into the transport profile
+                        # before anything else. This is what makes the budget
+                        # roll: each inter-chunk gap is a sample, so a path
+                        # that degrades mid-stream widens the deadline within
+                        # a chunk or two rather than after the stream dies.
+                        if _tp is not None:
+                            _now_chunk = time.monotonic()
+                            _tp.observe((_now_chunk - _last_chunk_at) * 1000.0)
+                            _last_chunk_at = _now_chunk
                         # Generation is flowing: every subsequent wait is a
                         # STEADY-STATE gap, so tighten from the prefill budget
                         # to the measured inter-token one. Reassigned on each

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -285,15 +285,58 @@ def _physics_ledger_save(key: str, payload: dict) -> None:
         pass
 
 
-def physics_key(cfg: "LocalConfig") -> str:
-    """The DURABLE physics identity: (model, ctx-bucket) -- NOT the endpoint
-    (node IPs change every run; the physics belongs to the brain+window)."""
+def physics_key(cfg: "LocalConfig", *, endpoint: str = "") -> str:
+    """The DURABLE physics identity: (hardware, model, ctx-bucket).
+
+    NOT the endpoint -- node IPs change every run, and the physics belongs to
+    the brain+window. That original reasoning is preserved and is why the
+    address never appears here.
+
+    But it was incomplete. (model, ctx) alone CONFLATES MACHINES: the same
+    model name on a 16GB M1 and on an RTX 5090 wrote one ledger key, so
+    whichever measured last governed both -- and once a Mac dispatches to a
+    Windows inference host, the Mac's ~95ms/token would size the 5090's lane
+    count. The ThroughputGovernor would then compute a wrong answer from
+    perfectly honest data, which is the worst shape a defect can take.
+
+    So the identity gains a hardware axis: a hashed, machine-scoped signature
+    of the host SERVING this config (see `hardware_signature`), never of the
+    host timing it. Two machines now keep strictly separate ledgers for the
+    same model.
+
+    MIGRATION: this changes the key shape, so entries written under the old
+    shape become unreachable and each (hardware, model, ctx) triple
+    cold-starts once. That is the intended direction -- the unreachable
+    entries are exactly the conflated measurements this change exists to stop
+    trusting. `JARVIS_HARDWARE_SIGNATURE_ENABLED=0` restores the old shape
+    byte-for-byte.
+    """
     try:
         model = str(getattr(cfg, "model_name", "") or "unknown")
         ctx = int(getattr(cfg, "num_ctx", 0) or 0)
-        return "%s@%s" % (model, ctx if ctx > 0 else "cpu")
+        base = "%s@%s" % (model, ctx if ctx > 0 else "cpu")
     except Exception:  # noqa: BLE001
         return "unknown@cpu"
+    try:
+        from backend.core.ouroboros.governance.hardware_signature import (
+            signature_for,
+        )
+        # *endpoint* wins over cfg.base_url when supplied. The failover path
+        # holds one profiler per ENDPOINT while carrying a single cfg, so
+        # resolving the signature from cfg there would stamp every failover
+        # target with the base config's identity -- re-creating the exact
+        # host conflation this axis exists to remove, at the one seam
+        # (cross-node failover) where it matters most.
+        target = str(endpoint or getattr(cfg, "base_url", "") or "")
+        digest = signature_for(target).digest
+        # An empty digest means the signature layer is off or declined to
+        # guess. Fall back to the legacy shape rather than inventing a
+        # placeholder segment -- a key containing "unknown" would silently
+        # merge every unidentifiable host into one bucket, which is the very
+        # conflation being removed.
+        return "%s@%s" % (digest, base) if digest else base
+    except Exception:  # noqa: BLE001 — identity must never break dispatch
+        return base
 
 
 class LatencyProfiler:

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -472,6 +472,56 @@ class LatencyProfiler:
         except Exception:  # noqa: BLE001
             pass
 
+    def inter_token_budget_s(self) -> "Tuple[float, float]":
+        """``(first_token_s, steady_token_s)`` for the streaming watchdog.
+
+        TWO deadlines, because the two waits measure different physics and a
+        single constant is wrong for both:
+
+        * **first token** must cover PREFILL. A 64K-context prompt can
+          legitimately take tens of seconds before its first byte, and the
+          static 30s was applied to this wait too -- so a large prompt on a
+          slow host could be declared "wedged" while it was working normally.
+          This deadline is therefore derived from measured TTFT and may only
+          ever be LOOSER than the legacy value, never tighter.
+        * **steady state** is the gap BETWEEN chunks once generation is
+          flowing. Here the static 30s is wildly loose: at 220 tok/s the
+          normal gap is ~4.5ms, so a wedged peer would be given ~6,600 normal
+          gaps before anyone noticed. This deadline is derived from measured
+          per-token cost and may only ever be TIGHTER than the legacy value.
+
+        Cold profiler -> the static value for both, i.e. byte-identical
+        legacy behaviour. NEVER raises.
+        """
+        static = _inter_token_timeout_s()
+        try:
+            if not _inter_token_adaptive_enabled():
+                return (static, static)
+            with self._lock:
+                warm = len(self._total) >= self._cfg.min_samples
+                ttft_m = self._mean(self._ttft)
+                ttft_sd = self._stddev(self._ttft)
+                tok_m = self._mean(self._per_tok)
+                tok_sd = self._stddev(self._per_tok)
+            if not warm:
+                return (static, static)
+            sigma = float(getattr(self._cfg, "margin_sigma", 2.0) or 2.0)
+            mult = _inter_token_stall_multiple()
+
+            # First token: measured TTFT + margin, scaled. Clamped at or ABOVE
+            # the static value -- prefill is the one wait that legitimately
+            # grows with the prompt, so tightening it would manufacture stalls.
+            first = max(static, mult * (ttft_m + sigma * ttft_sd) / 1000.0)
+
+            # Steady state: measured per-token + margin, scaled, floored so
+            # jitter is not mistaken for a wedge, and capped at the static
+            # value so this path can only ever DETECT SOONER, never later.
+            steady = mult * (tok_m + sigma * tok_sd) / 1000.0
+            steady = max(_inter_token_floor_s(), min(steady, static))
+            return (first, steady)
+        except Exception:  # noqa: BLE001 — a watchdog must never fail to arm
+            return (static, static)
+
     def is_warm(self) -> bool:
         with self._lock:
             return len(self._total) >= self._cfg.min_samples
@@ -620,6 +670,30 @@ def _streaming_enabled() -> bool:
     generation path. Default TRUE. OFF -> legacy total-duration adaptive timeout."""
     return _envb("JARVIS_LOCAL_STREAMING_ENABLED", True) if os.environ.get(
         "JARVIS_LOCAL_STREAMING_ENABLED") is not None else True
+
+
+def _inter_token_adaptive_enabled() -> bool:
+    """Derive the stall deadline from MEASURED physics instead of a constant.
+    Default TRUE. OFF -> the static value for both deadlines (legacy)."""
+    return _envb("JARVIS_LOCAL_INTER_TOKEN_ADAPTIVE_ENABLED", True)
+
+
+def _inter_token_stall_multiple() -> float:
+    """How many normal inter-token gaps constitute a STALL. Default 12.
+
+    A stall is not "slow", it is "stopped". At 220 tok/s a normal gap is
+    ~4.5ms, so twelve of them is ~54ms -- which is why the floor below
+    exists and does the real work on fast hosts."""
+    return max(2.0, _f_env("JARVIS_LOCAL_INTER_TOKEN_STALL_MULTIPLE", 12.0))
+
+
+def _inter_token_floor_s() -> float:
+    """Tightest steady-state deadline the adaptive path may produce.
+
+    Default 2.0s. Below this, ordinary LAN jitter and server-side chunk
+    batching would be indistinguishable from a wedged peer, and a false
+    positive costs a real generation."""
+    return max(0.25, _f_env("JARVIS_LOCAL_INTER_TOKEN_FLOOR_S", 2.0))
 
 
 def _inter_token_timeout_s() -> float:
@@ -835,7 +909,14 @@ class LocalPrimeClient:
         from backend.core.ouroboros.governance import cooperative_shutdown as _coop  # noqa: PLC0415
         body = dict(body)
         body["stream"] = True
-        inter_token_s = _inter_token_timeout_s()
+        # TWO deadlines, not one. The wait before the first chunk measures
+        # PREFILL (grows with prompt size); every wait after it measures the
+        # gap between tokens (roughly constant). A single constant is loose
+        # enough to hide a wedged peer for 6,600 normal gaps on a fast host,
+        # AND tight enough to declare a large legitimate prefill "wedged".
+        # See LatencyProfiler.inter_token_budget_s.
+        _first_token_s, _steady_token_s = self.profiler.inter_token_budget_s()
+        inter_token_s = _first_token_s
         # Seed with the resume prefill so the assembled text continues the partial.
         parts: List[str] = [prefill] if prefill else []
         ttft_ms = 0.0
@@ -911,6 +992,12 @@ class LocalPrimeClient:
                         return_when=asyncio.FIRST_COMPLETED,
                     )
                     if _read_task in done:
+                        # Generation is flowing: every subsequent wait is a
+                        # STEADY-STATE gap, so tighten from the prefill budget
+                        # to the measured inter-token one. Reassigned on each
+                        # chunk (not once) so a mid-stream physics refresh is
+                        # picked up without restarting the stream.
+                        inter_token_s = _steady_token_s
                         # A chunk (or EOF) is already in hand -- NEVER drop it, even if
                         # shutdown fired in the same tick. We buffer it here; the
                         # cooperative check at the top of the NEXT iteration freezes
@@ -924,9 +1011,29 @@ class LocalPrimeClient:
                     else:
                         # Neither fired within the window -> the stream is wedged.
                         _read_task.cancel()
+                        # PENALISE THE LEDGER BEFORE RAISING.
+                        #
+                        # Without this the stall is invisible to the physics:
+                        # record() only fires on a clean finish, so a host that
+                        # wedges every op keeps its optimistic EWMA forever and
+                        # the ThroughputGovernor keeps sizing lanes for a
+                        # machine that is actively failing -- a wrong answer
+                        # derived from stale-but-honest data, which is the
+                        # hardest kind to notice. record_timeout_penalty is the
+                        # EXISTING asymmetric-escalation seam (the non-streaming
+                        # path already used it); this puts the streaming path,
+                        # which is the one the LAN bridge forces, on the same
+                        # footing. Fail-soft: telemetry must never mask the
+                        # stall it is describing.
+                        try:
+                            self.profiler.record_timeout_penalty(
+                                max(1.0, (time.monotonic() - t0) * 1000.0))
+                        except Exception:  # noqa: BLE001
+                            pass
                         raise InterTokenStall(
-                            "inter-token stall: no chunk within %.0fs (stream wedged)"
-                            % inter_token_s
+                            "inter-token stall: no chunk within %.1fs "
+                            "(stream wedged; first_token_budget=%.1fs)"
+                            % (inter_token_s, _first_token_s)
                         )
                     if not line:
                         break  # EOF -> stream complete

--- a/backend/core/ouroboros/governance/local_model_admission.py
+++ b/backend/core/ouroboros/governance/local_model_admission.py
@@ -114,6 +114,36 @@ def admission_enabled() -> bool:
             or "").strip().lower() not in ("0", "false", "no", "off")
 
 
+def accelerator_sharding_declared() -> bool:
+    """Does the serving stack split ONE model across MULTIPLE devices?
+
+    Default FALSE, and deliberately a declaration rather than an inference.
+
+    Whether a model can span two GPUs is a property of the SERVING STACK
+    (llama.cpp/Ollama layer split, vLLM tensor parallel), not of the host.
+    `compute_topology` can enumerate the devices but cannot see the stack, so
+    it reports the conservative collapsed view -- the largest single device --
+    and something that knows the stack has to say otherwise.
+
+    Getting this wrong in the optimistic direction is the expensive
+    direction: declaring sharding on a stack that does not shard admits a
+    model that then fails to load, having already passed the gate whose whole
+    job was to prevent that. Declaring it off on a stack that does merely
+    under-uses the second card.
+
+    Turn it ON for a host whose runtime is configured to split -- e.g. a
+    dual-GPU box running Ollama/llama.cpp with the layer splitter enabled,
+    where the two cards genuinely pool.
+
+    A future upgrade can PROVE this instead of trusting it: a serving stack
+    reporting a resident model larger than the largest single device has
+    demonstrated sharding. That is an observation, and would outrank this
+    flag. NEVER raises.
+    """
+    return (os.environ.get("JARVIS_LOCAL_ACCEL_SHARDING", "false")
+            or "").strip().lower() in ("1", "true", "yes", "on")
+
+
 def prune_floor_messages() -> int:
     """Messages never pruned, counted from the END. NEVER raises.
 
@@ -982,7 +1012,18 @@ def _assess_impl(
     margin = 0
     max_weight = 0
     if reading is not None and topology == "discrete" and weight_bytes > 0:
-        measured_free = int(getattr(reading, "usable_bytes", 0) or 0)
+        # Single-device by default; pooled ONLY under a declared sharding
+        # capability. `shardable_usable_bytes` returns the single-device
+        # answer for a single-device host even when sharding is declared,
+        # so the flag cannot invent capacity that is not there.
+        _sharding = accelerator_sharding_declared()
+        _shardable = getattr(reading, "shardable_usable_bytes", None)
+        if callable(_shardable):
+            measured_free = int(_shardable(sharding=_sharding) or 0)
+        else:
+            measured_free = int(getattr(reading, "usable_bytes", 0) or 0)
+        _pooled = bool(
+            _sharding and getattr(reading, "is_multi_device", False))
         # Subtract what OTHER workers have already been promised but have not
         # yet allocated. Without this, N concurrent workers each pass against
         # the same reading and collectively overcommit — the gate is correct
@@ -996,14 +1037,20 @@ def _assess_impl(
         if weight_bytes + margin > accel_free:
             return AdmissionDecision(
                 action=Admission.DEFER.value, level=level, free_pct=free_pct,
-                source=source, topology=topology, bound="accelerator",
+                source=source, topology=topology,
+                bound="accelerator_pooled" if _pooled else "accelerator",
                 accel_free_bytes=accel_free, weight_bytes=weight_bytes,
                 margin_bytes=margin, max_weight_bytes=max_weight,
                 reason=(
                     f"{weight_bytes / _GIB:.1f} GiB of weights plus a "
                     f"{margin / _GIB:.1f} GiB learned margin exceeds the "
-                    f"{accel_free / _GIB:.1f} GiB free on this accelerator "
-                    f"— largest admissible now is {max_weight / _GIB:.1f} GiB"
+                    f"{accel_free / _GIB:.1f} GiB free "
+                    + (
+                        f"pooled across {len(getattr(reading, 'devices', ()))} "
+                        f"accelerators (sharding declared)"
+                        if _pooled else "on this accelerator"
+                    )
+                    + f" — largest admissible now is {max_weight / _GIB:.1f} GiB"
                 ),
                 spoken_reason=("That model is larger than the free space on "
                                "my graphics card right now."))

--- a/backend/core/ouroboros/governance/local_model_admission.py
+++ b/backend/core/ouroboros/governance/local_model_admission.py
@@ -687,29 +687,20 @@ class _PagingSampler:
 
     @staticmethod
     def _read_swapin_bytes() -> Optional[int]:
-        """Cumulative swap-in bytes since boot, or None. NEVER raises."""
+        """Cumulative swap-in bytes since boot, or None. NEVER raises.
+
+        CONSUMED from `memory_pressure_gate`, never re-derived here. This
+        module is forbidden from reaching for a probe substrate directly (see
+        `test_dry_admission_derives_neither_reading_itself`) for the same
+        reason it does not compute `free_pct` itself: two readers of the same
+        substrate drift, and the one the operator sees is whichever ran last.
+        """
         try:
-            import psutil
-            return int(psutil.swap_memory().sin)
-        except Exception:  # noqa: BLE001 — OSError under sandbox, or absent
-            pass
-        try:
-            from backend.core.bounded_subprocess import run_bounded
-            completed = run_bounded(["vm_stat"], timeout=3.0, text=True)
-            if completed is None or completed.returncode != 0:
-                return None
-            page_size = 4096
-            m = re.search(r"page size of (\d+) bytes", completed.stdout or "")
-            if m:
-                page_size = int(m.group(1))
-            # `Pageins` is the closest cumulative analogue vm_stat exposes;
-            # it counts pages faulted in from backing store, which is the
-            # same event psutil reports as `sin`.
-            m = re.search(r"Pageins:\s+(\d+)", completed.stdout or "")
-            if not m:
-                return None
-            return int(m.group(1)) * page_size
-        except Exception:  # noqa: BLE001
+            from backend.core.ouroboros.governance.memory_pressure_gate import (
+                swap_in_bytes,
+            )
+            return swap_in_bytes()
+        except Exception:  # noqa: BLE001 — a probe must never break admission
             return None
 
     def rate_bps(self) -> Optional[float]:
@@ -929,6 +920,7 @@ def assess(
     *,
     weight_bytes: int = 0,
     model_id: Optional[str] = None,
+    route: Optional[str] = None,
 ) -> AdmissionDecision:
     """Should this generation be admitted right now?
 
@@ -942,7 +934,7 @@ def assess(
     """
     try:
         return _assess_impl(requested_ctx, weight_bytes=weight_bytes,
-                            model_id=model_id)
+                            model_id=model_id, route=route)
     except Exception as exc:  # noqa: BLE001
         logger.debug("[LocalModelAdmission] assess degraded: %s", exc,
                      exc_info=True)
@@ -957,6 +949,7 @@ def _assess_impl(
     *,
     weight_bytes: int = 0,
     model_id: Optional[str] = None,
+    route: Optional[str] = None,
 ) -> AdmissionDecision:
     """The decision itself. See :func:`assess` for the raise contract.
 
@@ -1024,6 +1017,57 @@ def _assess_impl(
             measured_free = int(getattr(reading, "usable_bytes", 0) or 0)
         _pooled = bool(
             _sharding and getattr(reading, "is_multi_device", False))
+
+        # ---- per-device validation (asymmetric lanes) --------------------
+        # A POOLED reading describes one model spanning several devices, so
+        # there is no per-device question to ask and the pooled bound below is
+        # the right one. Otherwise each device is an INDEPENDENT LANE and the
+        # payload must fit the specific device it lands on: weights are
+        # constant per model, but KV cache is linear in context, and at long
+        # context KV is the term that decides whether the 24GB card can take
+        # the op at all.
+        _devices = tuple(getattr(reading, "devices", ()) or ())
+        _sel = None
+        if not _pooled and _devices and requested_ctx and int(requested_ctx) > 0:
+            try:
+                from backend.core.ouroboros.governance.device_affinity import (
+                    select_device,
+                )
+                from backend.core.ouroboros.governance.compute_topology import (
+                    headroom_fraction,
+                )
+                _sel = select_device(
+                    _devices, ctx_tokens=int(requested_ctx),
+                    weight_bytes=weight_bytes, route=route, model_id=model_id,
+                )
+                if _sel.device is None:
+                    # Nothing on this host can hold it. DEFER carrying the
+                    # ceiling that WOULD fit -- "too big" is a fact, "the
+                    # largest context that fits is N" is a next step.
+                    return AdmissionDecision(
+                        action=Admission.DEFER.value, level=level,
+                        free_pct=free_pct, source=source, topology=topology,
+                        bound="accelerator_device",
+                        accel_free_bytes=0, weight_bytes=weight_bytes,
+                        margin_bytes=0, max_weight_bytes=0,
+                        reason=(
+                            f"{weight_bytes / _GIB:.1f} GiB of weights plus "
+                            f"{_sel.kv_bytes / _GIB:.1f} GiB of KV cache for a "
+                            f"{int(requested_ctx)}-token context exceeds every "
+                            f"accelerator on this host — the largest context "
+                            f"that fits is about {_sel.max_ctx_tokens} tokens"
+                        ),
+                        spoken_reason=("That context is too long for any of my "
+                                       "graphics cards right now."),
+                    )
+                # The chosen device's own free bytes REPLACE the pooled
+                # number, and the KV term joins the requirement. Same headroom
+                # fraction the pooled path uses -- one reserve policy, not two.
+                measured_free = max(0, int(
+                    _sel.device.free_bytes * (1.0 - headroom_fraction())))
+                weight_bytes = weight_bytes + _sel.kv_bytes
+            except Exception:  # noqa: BLE001 — a router must never break the gate
+                _sel = None
         # Subtract what OTHER workers have already been promised but have not
         # yet allocated. Without this, N concurrent workers each pass against
         # the same reading and collectively overcommit — the gate is correct
@@ -1038,7 +1082,9 @@ def _assess_impl(
             return AdmissionDecision(
                 action=Admission.DEFER.value, level=level, free_pct=free_pct,
                 source=source, topology=topology,
-                bound="accelerator_pooled" if _pooled else "accelerator",
+                bound=("accelerator_pooled" if _pooled
+                       else "accelerator_device" if _sel is not None
+                       else "accelerator"),
                 accel_free_bytes=accel_free, weight_bytes=weight_bytes,
                 margin_bytes=margin, max_weight_bytes=max_weight,
                 reason=(

--- a/backend/core/ouroboros/governance/memory_pressure_gate.py
+++ b/backend/core/ouroboros/governance/memory_pressure_gate.py
@@ -311,6 +311,45 @@ class FanoutDecision:
 # ---------------------------------------------------------------------------
 
 
+def swap_in_bytes() -> Optional[int]:
+    """Cumulative bytes faulted in from swap since boot, or None.
+
+    Lives HERE and not in a consumer because this module owns the
+    system-memory probe substrate -- the same reason `free_pct` is not
+    re-derived by every gate that wants it. `local_model_admission` had this
+    inline with a direct ``import psutil``, which its own DRY pin
+    (`test_dry_admission_derives_neither_reading_itself`) forbids precisely
+    so that "how do we read system memory" has one answer.
+
+    Cascade mirrors :func:`_probe_psutil` -> vm_stat, and returns None rather
+    than 0 when unknowable: a rate computed from a fabricated zero reads as
+    "no swapping" and would DISARM the caller's contention guard. NEVER raises.
+    """
+    try:
+        import psutil
+        return int(psutil.swap_memory().sin)
+    except Exception:  # noqa: BLE001 — OSError under sandbox, or absent
+        pass
+    try:
+        from backend.core.bounded_subprocess import run_bounded
+        completed = run_bounded(["vm_stat"], timeout=3.0, text=True)
+        if completed is None or completed.returncode != 0:
+            return None
+        page_size = 4096
+        m = re.search(r"page size of (\d+) bytes", completed.stdout or "")
+        if m:
+            page_size = int(m.group(1))
+        # `Pageins` is the closest cumulative analogue vm_stat exposes; it
+        # counts pages faulted in from backing store, which is the same event
+        # psutil reports as `sin`.
+        m = re.search(r"Pageins:\s+(\d+)", completed.stdout or "")
+        if not m:
+            return None
+        return int(m.group(1)) * page_size
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _probe_psutil() -> Optional[MemoryProbe]:
     try:
         import psutil  # noqa: F401

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -6045,18 +6045,10 @@ class GovernedOrchestrator:
                     # harnesses (e.g. live_fire_exploration_gate.py) can widen
                     # the architectural COMPLEX window without patching code.
                     # Defaults preserve the 2026-04-12 calibration.
-                    _route_timeouts = {
-                        "immediate": float(os.environ.get(
-                            "JARVIS_GEN_TIMEOUT_IMMEDIATE_S", "120")),
-                        "standard": float(os.environ.get(
-                            "JARVIS_GEN_TIMEOUT_STANDARD_S", "220")),
-                        "complex": float(os.environ.get(
-                            "JARVIS_GEN_TIMEOUT_COMPLEX_S", "240")),
-                        "background": float(os.environ.get(
-                            "JARVIS_GEN_TIMEOUT_BACKGROUND_S", "180")),
-                        "speculative": float(os.environ.get(
-                            "JARVIS_GEN_TIMEOUT_SPECULATIVE_S", "180")),
-                    }
+                    from backend.core.ouroboros.governance.route_budgets import (  # noqa: PLC0415,E501
+                        route_generation_budgets as _route_budgets,
+                    )
+                    _route_timeouts = _route_budgets()
                     # Slice 15 T4 — value-band adaptive allocation (parity
                     # twin of the live generate_runner seam). Fail-soft.
                     try:

--- a/backend/core/ouroboros/governance/phase_runners/generate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/generate_runner.py
@@ -730,18 +730,10 @@ class GENERATERunner(PhaseRunner):
                 # harnesses (e.g. live_fire_exploration_gate.py) can widen
                 # the architectural COMPLEX window without patching code.
                 # Defaults preserve the 2026-04-12 calibration.
-                _route_timeouts = {
-                    "immediate": float(os.environ.get(
-                        "JARVIS_GEN_TIMEOUT_IMMEDIATE_S", "120")),
-                    "standard": float(os.environ.get(
-                        "JARVIS_GEN_TIMEOUT_STANDARD_S", "220")),
-                    "complex": float(os.environ.get(
-                        "JARVIS_GEN_TIMEOUT_COMPLEX_S", "240")),
-                    "background": float(os.environ.get(
-                        "JARVIS_GEN_TIMEOUT_BACKGROUND_S", "180")),
-                    "speculative": float(os.environ.get(
-                        "JARVIS_GEN_TIMEOUT_SPECULATIVE_S", "180")),
-                }
+                from backend.core.ouroboros.governance.route_budgets import (  # noqa: PLC0415,E501
+                    route_generation_budgets as _route_budgets,
+                )
+                _route_timeouts = _route_budgets()
                 # Slice 15 T4 — value-band adaptive allocation: the REAL
                 # dispatch lever scales as a function of verifiable
                 # semantic weight (oracle-band repairs earn a wider

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -1343,7 +1343,12 @@ class Slice4bRunner(PhaseRunner):
                     return await _ckpt_mgr.working_tree_content_sha()
 
                 def _g2_dlq_fn(reason):
-                    _g2_dlq.append_dlq({"op_id": ctx.op_id, "phase": "blast_radius"}, reason=reason)
+                    # A phase marker is not work: it carries an id and no
+                    # actionable payload, so it can never be replayed. Filed
+                    # as a diagnostic rather than into the replay queue.
+                    _g2_dlq.append_diagnostic(
+                        {"op_id": ctx.op_id, "phase": "blast_radius"},
+                        reason=reason)
 
                 try:
                     _blast_tok = await acquire_blast_radius_token(

--- a/backend/core/ouroboros/governance/provider_heartbeat.py
+++ b/backend/core/ouroboros/governance/provider_heartbeat.py
@@ -277,13 +277,22 @@ def _default_dlq_emit(payload: Any) -> None:
         logger.critical("[AegisConfigDLQ] %s", json.dumps(payload, sort_keys=True))
     except Exception:  # noqa: BLE001
         logger.critical("[AegisConfigDLQ] %r", payload)
-    # Best-effort persisted DLQ entry (reuse the existing intake_dlq surface;
-    # append_dlq serializes a dict envelope via its _to_serializable path).
+    # Persist as a DIAGNOSTIC, not as queued work.
+    #
+    # This used to call `append_dlq`, with the rationale "reuse the existing
+    # intake_dlq surface" — i.e. a replay queue was borrowed as a persistence
+    # surface because it happened to serialize dicts. It accounted for 57 of
+    # the 156 rows found in the production DLQ, and it was not merely untidy:
+    # `replay_dlq` dedups by goal_id, an Aegis config error has none, so a
+    # replay would hand this record to the intake router AS WORK.
+    #
+    # The CRITICAL line above is already the durable floor (WAL -> debug.log
+    # -> GCS flight recorder), so nothing is lost by filing it correctly.
     try:
         from backend.core.ouroboros.governance.intake_dlq import (  # noqa: PLC0415
-            append_dlq,
+            append_diagnostic,
         )
-        append_dlq(payload, reason="aegis_configuration_error")
+        append_diagnostic(payload, reason="aegis_configuration_error")
     except Exception:  # noqa: BLE001 -- the WAL record above is the durable floor
         pass
 

--- a/backend/core/ouroboros/governance/route_budgets.py
+++ b/backend/core/ouroboros/governance/route_budgets.py
@@ -1,0 +1,74 @@
+"""The per-route generation window — ONE table, three readers.
+
+WHY THIS MODULE EXISTS
+----------------------
+The route→timeout table was written twice, byte-identical, in
+``orchestrator.py`` and ``phase_runners/generate_runner.py`` (the second
+carrying a comment calling itself a "parity twin" of the first). Two copies of
+a calibration is a latent drift: whichever one a reader finds is the one they
+believe, and only one of them is on the shipping path
+(``JARVIS_PHASE_RUNNER_GATE_EXTRACTED``).
+
+The throughput governor needs the same numbers to size lanes against the
+window an op will actually be given. Adding a third copy would make the drift
+certain, so the table moves here and the existing sites read it.
+
+WHAT IS AND IS NOT HERE
+-----------------------
+The BASE, env-tunable window only. The value-band scaling (Slice 15 T4) and
+telemetry-driven synthesis (Slice 231) stay at their call sites: they are
+multipliers applied to this table, not part of it, and they need op context
+this module deliberately does not take.
+
+Defaults preserve the 2026-04-12 calibration. Python 3.9+, stdlib only.
+"""
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+#: Route -> (env var, default seconds). The defaults are the 2026-04-12
+#: calibration and are the ONLY place they are written.
+_ROUTE_ENV: Dict[str, "tuple"] = {
+    "immediate": ("JARVIS_GEN_TIMEOUT_IMMEDIATE_S", "120"),
+    "standard": ("JARVIS_GEN_TIMEOUT_STANDARD_S", "220"),
+    "complex": ("JARVIS_GEN_TIMEOUT_COMPLEX_S", "240"),
+    "background": ("JARVIS_GEN_TIMEOUT_BACKGROUND_S", "180"),
+    "speculative": ("JARVIS_GEN_TIMEOUT_SPECULATIVE_S", "180"),
+}
+
+#: The route a pool-level (pre-dequeue) consumer sizes against when it does not
+#: yet hold an op. BackgroundAgentPool predominantly serves this route, and it
+#: is the widest of the two background-class windows, so sizing against it is
+#: the least-throttling honest choice.
+DEFAULT_POOL_ROUTE = "background"
+
+
+def route_generation_budgets() -> Dict[str, float]:
+    """The full route→seconds table, re-read from the environment each call.
+
+    Re-read (not cached) because the harnesses tune these vars at runtime; the
+    cost is five ``os.environ`` lookups. A malformed value falls back to its
+    own default rather than taking the table down. NEVER raises.
+    """
+    out: Dict[str, float] = {}
+    for route, (env, default) in _ROUTE_ENV.items():
+        try:
+            out[route] = float(os.environ.get(env, default))
+        except (TypeError, ValueError):
+            out[route] = float(default)
+    return out
+
+
+def route_generation_budget_s(route: str, default: float = 0.0) -> float:
+    """Window for *route*, or *default* when the route is unknown.
+
+    An unknown route returns *default* rather than guessing a window: callers
+    already hold a meaningful fallback (``config.generation_timeout_s``) and
+    inventing one here would silently overrule it. NEVER raises.
+    """
+    try:
+        key = str(route or "").strip().lower()
+    except Exception:  # noqa: BLE001
+        return default
+    return route_generation_budgets().get(key, default)

--- a/backend/core/ouroboros/governance/throughput_governor.py
+++ b/backend/core/ouroboros/governance/throughput_governor.py
@@ -231,11 +231,37 @@ class ThroughputGovernor:
         physics at process start and it would never see a re-measured model.
         """
         try:
+            import dataclasses  # noqa: PLC0415
+
             from backend.core.ouroboros.governance import (  # noqa: PLC0415
                 local_inference_director as lid,
             )
             cfg = lid.LocalConfig.from_env()
-            return (lid.LatencyProfiler(cfg, ledger_key=lid.physics_key(cfg)), cfg)
+            endpoint = ""
+            try:
+                # THE HOST THAT WILL SERVE THE OPS IS THE HOST TO SIZE AGAINST.
+                # When the gateway is dispatching to a remote GPU, this Mac's
+                # own physics is irrelevant to how many lanes the queue may
+                # run -- the serialisation happens on the REMOTE device. Ask
+                # the gateway which host is actually active, and profile that
+                # one. Fail-soft: no gateway, or a degraded one, leaves the
+                # local config in place, which is the pre-bridge behaviour.
+                from backend.core.ouroboros.governance.inference_gateway import (  # noqa: PLC0415,E501
+                    get_default_gateway,
+                )
+                target = get_default_gateway().target_for()
+                if target.base_url and target.base_url != cfg.base_url:
+                    endpoint = target.base_url
+                    cfg = dataclasses.replace(
+                        cfg, base_url=target.base_url,
+                        model_name=target.model_name or cfg.model_name)
+            except Exception:  # noqa: BLE001
+                endpoint = ""
+            return (
+                lid.LatencyProfiler(
+                    cfg, ledger_key=lid.physics_key(cfg, endpoint=endpoint)),
+                cfg,
+            )
         except Exception:  # noqa: BLE001
             return (None, None)
 

--- a/backend/core/ouroboros/governance/throughput_governor.py
+++ b/backend/core/ouroboros/governance/throughput_governor.py
@@ -1,0 +1,475 @@
+"""Measured throughput decides how many lanes may run — not a constant.
+
+THE DEFECT THIS CLOSES
+----------------------
+``BackgroundAgentPool`` runs ``JARVIS_BG_POOL_SIZE`` workers (default 3)
+against one serving endpoint. On a metered cloud provider that is fine: three
+concurrent requests are served concurrently. On a SINGLE LOCAL GPU they are
+not — one model instance serves them **serially**, so three lanes do not
+triple throughput, they triple each op's wall-clock. Every lane then races the
+same route budget (BACKGROUND: 180s + 5s grace) and the tail blows it, which
+this codebase already has a name for: ``tool_loop_deadline_exceeded``.
+
+The instruments to prevent that already exist and were never connected:
+
+  * :class:`local_inference_director.LatencyProfiler` MEASURES per-endpoint
+    TTFT and per-token cost, warm-started across runs from the physics ledger.
+  * :meth:`BackgroundAgentPool.set_target_pool_size` ACCEPTS a lane target.
+  * :mod:`memory_pressure_gate` already caps fan-out by memory level.
+
+Nothing bound the measurement to the target. This module is that binding, and
+deliberately nothing else — it owns no probe, no timer and no event loop.
+
+THE MATH, AND WHY IT IS THE ROOT CAUSE
+--------------------------------------
+One endpoint serving ``N`` concurrent ops gives each roughly ``N ×
+per_op_ms``. Requiring that to fit the route budget::
+
+    lanes = floor( (budget_ms × safety) / per_op_ms )
+
+``per_op_ms`` is NOT re-derived here — it is
+:meth:`LatencyProfiler.adaptive_timeout_ms`, the same estimator the dispatch
+path already trusts (measured TTFT + per-token × expected output + σ margin,
+clamped to its own floor/ceiling). Re-deriving it would be a second opinion
+about the same physics.
+
+COMPOSITION, NOT A SECOND AUTHORITY
+-----------------------------------
+The verdict is a CEILING that composes strictest-wins with every existing
+authority — fleet topology's lane count, the memory gate's fan-out cap, the
+configured pool size. It can only ever lower concurrency, never raise it above
+what another authority already allowed, and it can never reach zero: a lane
+count of 0 is a stalled queue, which is worse than a slow one.
+
+WHY IT DOES NOT JUST CALL set_target_pool_size
+----------------------------------------------
+That setter carries an Immutability Lock: ``source="fleet_topology"`` is
+hardware-derived truth and silently REJECTS other sources while held. Fighting
+it would make this module a no-op exactly when a serving mesh exists. Lane
+COUNT and lane DRIVABILITY are different axes: four nodes may exist while the
+local GPU can drive one. So the verdict is published for the pool to consult
+cooperatively, and when the lock is held the governor still reports — loudly —
+rather than silently losing.
+
+Python 3.9+. Stdlib only at import time; every governance import is lazy and
+fail-soft, so a broken probe degrades to today's behaviour instead of taking
+the pool down.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.ThroughputGovernor")
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+ENABLED_ENV = "JARVIS_THROUGHPUT_GOVERNOR_ENABLED"
+SAFETY_ENV = "JARVIS_THROUGHPUT_SAFETY_FRACTION"
+MAX_LANES_ENV = "JARVIS_THROUGHPUT_MAX_LANES"
+TTL_ENV = "JARVIS_THROUGHPUT_VERDICT_TTL_S"
+PROMPT_TOKENS_ENV = "JARVIS_THROUGHPUT_REFERENCE_PROMPT_TOKENS"
+
+
+def governor_enabled() -> bool:
+    """Master gate. Default ON; OFF returns UNGOVERNED and the pool is
+    byte-identical to its pre-governor behaviour. NEVER raises."""
+    try:
+        return os.environ.get(ENABLED_ENV, "1").strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def safety_fraction() -> float:
+    """How much of the route budget one op may consume. Default 0.6.
+
+    NOT a fudge factor. The budget must also cover everything the op does
+    BESIDES token generation — tool round-trips, VALIDATE, the Iron Gate,
+    SemanticGuardian's AST pass — and `adaptive_timeout_ms` estimates only the
+    generation leg. Spending the whole budget on generation would guarantee
+    the very deadline breach this exists to prevent. Clamped to (0, 1]."""
+    try:
+        raw = float(os.environ.get(SAFETY_ENV, "0.6"))
+    except (TypeError, ValueError):
+        return 0.6
+    if raw <= 0.0 or raw > 1.0:
+        return 0.6
+    return raw
+
+
+def max_lanes() -> int:
+    """Absolute ceiling the governor may recommend. Default 32.
+
+    A guard against a pathologically fast measurement (a cached or refused
+    response returning in ~0ms) proposing unbounded concurrency."""
+    try:
+        return max(1, int(os.environ.get(MAX_LANES_ENV, "32")))
+    except (TypeError, ValueError):
+        return 32
+
+
+def verdict_ttl_s() -> float:
+    """How long a verdict stays fresh. Default 30s.
+
+    Long enough that the pool is not recomputing per dequeue; short enough
+    that a model swap or a memory-pressure change is reflected within one
+    op. 0 disables caching."""
+    try:
+        return max(0.0, float(os.environ.get(TTL_ENV, "30")))
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def reference_prompt_tokens() -> int:
+    """Prompt size the lane estimate is taken at. Default 8000.
+
+    `adaptive_timeout_ms` is prompt-size dependent, so the governor must pick
+    a reference point. 8000 approximates a CONTEXT_EXPANSION-fed GENERATE
+    prompt — deliberately not a trivial one, because sizing lanes off a tiny
+    prompt would over-promise concurrency for the ops that actually matter."""
+    try:
+        return max(1, int(os.environ.get(PROMPT_TOKENS_ENV, "8000")))
+    except (TypeError, ValueError):
+        return 8000
+
+
+@dataclass(frozen=True)
+class ConcurrencyVerdict:
+    """One lane recommendation, carrying the reading that produced it.
+
+    Frozen and self-describing for the same reason every other verdict in this
+    codebase is: a number without its provenance cannot be audited, and
+    ``lanes=1`` means something very different when it came from a measurement
+    than when it came from a degraded probe."""
+
+    lanes: int
+    reason: str
+    #: False when no measurement was available — the pool must then leave its
+    #: own target alone rather than trust this.
+    governed: bool = False
+    per_op_ms: float = 0.0
+    budget_ms: float = 0.0
+    memory_level: str = "unknown"
+    #: True when the physics ledger held >= min_samples real measurements for
+    #: this model@ctx. NOT `LatencyProfiler.is_calibrated()` -- that is a
+    #: per-instance scout-lock flag the ledger does not persist, so a fresh
+    #: instance reports False even while serving genuinely measured numbers.
+    #: `is_warm()` counts the samples themselves, which DO survive.
+    measured: bool = False
+    #: How to read `per_op_ms`. Mirrors the Advisor's blast-provenance
+    #: vocabulary, for the same reason: a number whose provenance is unstated
+    #: gets read as a measurement even when it is a clamp.
+    #:   "measured"        -- the estimator's own value, unclamped
+    #:   "ceiling_clamped" -- the estimator SATURATED its ceiling, so this is a
+    #:                        LOWER BOUND; lanes derived from it are therefore
+    #:                        conservative (a lower bound on per-op cost can
+    #:                        only ever under-count lanes, never over-count)
+    #:   "seeded"          -- fewer than min_samples; the blind seed
+    #:   "wedged"          -- the estimator refused: runaway latency
+    provenance: str = "unknown"
+    detail: Dict[str, Any] = field(default_factory=dict)
+
+    def render(self) -> str:
+        if not self.governed:
+            return f"[ThroughputGovernor] UNGOVERNED — {self.reason}"
+        return (
+            f"[ThroughputGovernor] lanes={self.lanes} "
+            f"per_op={self.per_op_ms:.0f}ms budget={self.budget_ms:.0f}ms "
+            f"mem={self.memory_level} via={self.provenance} "
+            f"— {self.reason}"
+        )
+
+
+#: The single UNGOVERNED verdict shape. Every degraded path returns one of
+#: these rather than inventing a lane count, so "we could not measure" is
+#: never mistaken for "we measured 1".
+def _ungoverned(reason: str) -> ConcurrencyVerdict:
+    return ConcurrencyVerdict(lanes=0, reason=reason, governed=False)
+
+
+class ThroughputGovernor:
+    """Derives a lane CEILING from measured latency. Owns no loop, no probe.
+
+    Thread-safe: the pool consults it from worker coroutines while the
+    profiler is written from dispatch threads. Verdicts are cached for
+    :func:`verdict_ttl_s` so a per-dequeue consult costs a dict read.
+    """
+
+    __slots__ = ("_lock", "_cached", "_cached_at", "_last_rendered")
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._cached: Optional[ConcurrencyVerdict] = None
+        self._cached_at: float = 0.0
+        self._last_rendered: str = ""
+
+    # -- inputs, each lazily resolved and individually fail-soft -----------
+
+    @staticmethod
+    def _profiler_and_config() -> Tuple[Any, Any]:
+        """A profiler bound to the DURABLE physics ledger, or (None, None).
+
+        This does NOT construct a second opinion. ``LatencyProfiler`` keeps its
+        measured window in a file-backed ledger keyed by ``model@ctx``
+        (:func:`local_inference_director.physics_key`) — the samples the
+        dispatch path records are flushed there, and every new instance
+        warm-starts from them. So the numbers read here ARE the dispatch path's
+        measurements; only the object holding them is local.
+
+        The alternative, ``CandidateGenerator._failover_profiler_for``, is an
+        instance method needing a live endpoint and a live generator — neither
+        of which a pool worker has — and its per-instance EWMA is a cache of
+        the same ledger, not a separate truth.
+
+        Rebuilt per evaluation (behind the verdict TTL, so ~one small JSON read
+        per :func:`verdict_ttl_s`) precisely BECAUSE the ledger is read at
+        ``__init__``: holding one instance would freeze the governor's view of
+        physics at process start and it would never see a re-measured model.
+        """
+        try:
+            from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                local_inference_director as lid,
+            )
+            cfg = lid.LocalConfig.from_env()
+            return (lid.LatencyProfiler(cfg, ledger_key=lid.physics_key(cfg)), cfg)
+        except Exception:  # noqa: BLE001
+            return (None, None)
+
+    @staticmethod
+    def _memory_cap(current_ceiling: int) -> Tuple[int, str]:
+        """Compose the EXISTING memory gate. NEVER raises.
+
+        Asks the gate the question it already answers — ``can_fanout(n)`` — and
+        takes its ``n_allowed`` rather than re-reading a level and re-deriving
+        a cap. That keeps process-tree pressure, reservations and the free-pct
+        thresholds (all dimensions the gate weighs and this module does not
+        know about) authoritative.
+
+        Returns ``(cap, level_name)``. An unavailable gate returns the incoming
+        ceiling unchanged — the governor must not invent memory pressure it did
+        not observe.
+        """
+        try:
+            from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                memory_pressure_gate as mpg,
+            )
+            if not mpg.is_enabled():
+                return (current_ceiling, "disabled")
+            decision = mpg.get_default_gate().can_fanout(int(current_ceiling))
+            level = str(
+                getattr(getattr(decision, "level", None), "value", "")
+                or getattr(decision, "level", "")
+                or "unknown"
+            )
+            allowed = getattr(decision, "n_allowed", None)
+            if isinstance(allowed, int) and allowed > 0:
+                # min() and not a bare assignment: the gate is a CEILING
+                # authority like this one, and a gate that ever answered
+                # higher than it was asked must not raise our lane count.
+                return (min(current_ceiling, allowed), level)
+            return (current_ceiling, level)
+        except Exception:  # noqa: BLE001
+            return (current_ceiling, "unknown")
+
+    @staticmethod
+    def _applicable_ceiling_ms(cfg: Any) -> float:
+        """The ceiling `adaptive_timeout_ms` would clamp to for *cfg*, or 0.0.
+
+        This reads the estimator's OWN branch condition (`cfg.num_ctx` selects
+        the survival/CPU path from the heavy/GPU path) rather than re-deriving
+        any part of the estimate. It exists solely so a SATURATED estimate can
+        be labelled as the lower bound it is."""
+        try:
+            if not getattr(cfg, "num_ctx", None):
+                return float(getattr(cfg, "timeout_ceiling_ms", 0.0) or 0.0)
+            from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                local_inference_director as lid,
+            )
+            return float(lid._absolute_ceiling_ms())  # noqa: SLF001
+        except Exception:  # noqa: BLE001
+            return 0.0
+
+    # -- the decision ------------------------------------------------------
+
+    def evaluate(
+        self,
+        *,
+        budget_s: float,
+        prompt_tokens: Optional[int] = None,
+        now: Optional[float] = None,
+    ) -> ConcurrencyVerdict:
+        """Lane ceiling for a route whose per-op budget is *budget_s*.
+
+        NEVER raises. Every failure path returns an UNGOVERNED verdict, which
+        instructs the caller to keep its existing target — degrading to
+        today's behaviour rather than to a guess.
+        """
+        if not governor_enabled():
+            return _ungoverned("master flag off")
+        try:
+            return self._evaluate_inner(
+                budget_s=budget_s,
+                prompt_tokens=prompt_tokens,
+                now=now,
+            )
+        except Exception as exc:  # noqa: BLE001 — a governor must never break dispatch
+            logger.debug("[ThroughputGovernor] degraded", exc_info=True)
+            return _ungoverned(f"evaluation failed: {type(exc).__name__}")
+
+    def _evaluate_inner(
+        self,
+        *,
+        budget_s: float,
+        prompt_tokens: Optional[int],
+        now: Optional[float],
+    ) -> ConcurrencyVerdict:
+        _now = time.monotonic() if now is None else float(now)
+        ttl = verdict_ttl_s()
+        with self._lock:
+            if (
+                ttl > 0.0
+                and self._cached is not None
+                and (_now - self._cached_at) < ttl
+            ):
+                return self._cached
+
+        try:
+            budget_ms = float(budget_s) * 1000.0
+        except (TypeError, ValueError):
+            return _ungoverned("budget not numeric")
+        if budget_ms <= 0.0:
+            return _ungoverned("budget non-positive")
+
+        profiler, _cfg = self._profiler_and_config()
+        if profiler is None:
+            return _ungoverned("no profiler available")
+
+        tokens = reference_prompt_tokens() if prompt_tokens is None else max(
+            1, int(prompt_tokens))
+        try:
+            per_op_ms = float(profiler.adaptive_timeout_ms(prompt_tokens=tokens))
+        except Exception as exc:  # noqa: BLE001
+            # A runaway-latency refusal is INFORMATION, not an absence of it:
+            # the model is wedged, so the honest lane count is the minimum, not
+            # "keep whatever you had". Only a genuinely unreadable profiler
+            # degrades to UNGOVERNED.
+            if type(exc).__name__ == "UnrecoverableInferenceLatency":
+                return ConcurrencyVerdict(
+                    lanes=1, reason="estimator refused: runaway latency",
+                    governed=True, budget_ms=budget_ms, provenance="wedged",
+                    detail={"error": str(exc)[:200]},
+                )
+            return _ungoverned("profiler could not estimate")
+        if per_op_ms <= 0.0:
+            # A zero/negative estimate is a broken reading, not infinite speed.
+            return _ungoverned("estimate non-positive")
+
+        try:
+            measured = bool(profiler.is_warm())
+        except Exception:  # noqa: BLE001
+            measured = False
+
+        # THE MATH. One endpoint serving N ops gives each ~N × per_op.
+        allowance_ms = budget_ms * safety_fraction()
+        raw_lanes = int(allowance_ms // per_op_ms)
+
+        # Floor of 1: a zero-lane verdict is a stalled queue, which is a worse
+        # failure than a slow one. When even ONE op cannot fit the budget the
+        # honest answer is "run one and let the existing deadline machinery
+        # record the breach" — not "run none and stall silently".
+        lanes = max(1, min(raw_lanes, max_lanes()))
+        ceiling_ms = self._applicable_ceiling_ms(_cfg)
+        saturated = ceiling_ms > 0.0 and per_op_ms >= ceiling_ms
+        if not measured:
+            provenance, reason = "seeded", (
+                "seeded (fewer than min_samples in the physics ledger)")
+        elif saturated:
+            provenance, reason = "ceiling_clamped", (
+                "estimate saturated its ceiling — per-op cost is a LOWER BOUND, "
+                "so this lane count is conservative")
+        else:
+            provenance, reason = "measured", "measured"
+        if raw_lanes < 1:
+            reason += " | single op exceeds the safety allowance — floored to 1"
+
+        lanes, mem_level = self._memory_cap(lanes)
+        lanes = max(1, lanes)
+
+        verdict = ConcurrencyVerdict(
+            lanes=lanes,
+            reason=reason,
+            governed=True,
+            per_op_ms=per_op_ms,
+            budget_ms=budget_ms,
+            memory_level=mem_level,
+            measured=measured,
+            provenance=provenance,
+            detail={
+                "raw_lanes": raw_lanes,
+                "safety_fraction": safety_fraction(),
+                "reference_prompt_tokens": tokens,
+                "max_lanes": max_lanes(),
+                "ceiling_ms": ceiling_ms,
+                "saturated": saturated,
+            },
+        )
+        with self._lock:
+            self._cached = verdict
+            self._cached_at = _now
+            rendered = verdict.render()
+            changed = rendered != self._last_rendered
+            self._last_rendered = rendered
+        # Log on CHANGE only — a per-dequeue consult must not become a log
+        # storm, and an unchanged verdict carries no new information.
+        if changed:
+            logger.info("%s", rendered)
+        return verdict
+
+    def invalidate(self) -> None:
+        """Drop the cached verdict — for a model swap or a test."""
+        with self._lock:
+            self._cached = None
+            self._cached_at = 0.0
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Observability surface. NEVER raises."""
+        with self._lock:
+            v = self._cached
+        if v is None:
+            return {"cached": False, "enabled": governor_enabled()}
+        return {
+            "cached": True,
+            "enabled": governor_enabled(),
+            "lanes": v.lanes,
+            "governed": v.governed,
+            "per_op_ms": round(v.per_op_ms, 1),
+            "budget_ms": round(v.budget_ms, 1),
+            "memory_level": v.memory_level,
+            "measured": v.measured,
+            "provenance": v.provenance,
+            "reason": v.reason,
+            **v.detail,
+        }
+
+
+_SINGLETON: Optional[ThroughputGovernor] = None
+_SINGLETON_LOCK = threading.Lock()
+
+
+def get_default_governor() -> ThroughputGovernor:
+    """Process-wide governor. Mirrors `memory_pressure_gate.get_default_gate`."""
+    global _SINGLETON
+    with _SINGLETON_LOCK:
+        if _SINGLETON is None:
+            _SINGLETON = ThroughputGovernor()
+        return _SINGLETON
+
+
+def reset_for_tests() -> None:
+    global _SINGLETON
+    with _SINGLETON_LOCK:
+        _SINGLETON = None

--- a/backend/core/ouroboros/governance/transport_profile.py
+++ b/backend/core/ouroboros/governance/transport_profile.py
@@ -1,0 +1,308 @@
+"""How far away is the serving host, and how erratically does it deliver?
+
+THE DEFECT THIS PREVENTS
+------------------------
+The streaming watchdog derives its steady-state deadline from MEASURED
+per-token cost, and on a fast host that computes to ~2.0s. Over a Tailscale
+DERP relay a 2-second gap between chunks can be entirely legitimate: WireGuard
+over TCP relays bunch packets, so tokens arrive in bursts separated by silence
+that has nothing to do with the model. The watchdog would sever a healthy
+stream, penalise the physics ledger, and fail over to the laptop -- because
+the operator was on hotel wifi.
+
+Worse, the same host has TWO transports. Tailscale negotiates direct when it
+can and relays when it cannot, and it can switch MID-STREAM. So a single
+pre-flight RTT ping is not enough: a stream that begins direct at 0.4ms can be
+relayed at 90ms three chunks later, and a deadline computed once at the start
+would be wrong for the rest of the stream.
+
+WHY JACOBSON/KARELS AND NOT A NEW ESTIMATOR
+-------------------------------------------
+This is exactly TCP's retransmission-timeout problem: pick a wait threshold
+from noisy round-trip samples such that normal jitter never trips it. That
+algorithm has been load-bearing on every TCP stack since 1988::
+
+    rttvar = (1 - beta) * rttvar + beta * |srtt - sample|      (beta = 1/4)
+    srtt   = (1 - alpha) * srtt  + alpha * sample              (alpha = 1/8)
+    budget = srtt + K * rttvar                                 (K = 4)
+
+`rttvar` is a mean-deviation tracker, and it is the part that handles
+BURSTING. Packet bunching produces samples far from `srtt` in both directions;
+each one inflates `rttvar`, which widens the budget superlinearly relative to
+the mean. A relay that delivers 5 chunks instantly then pauses 800ms does not
+move `srtt` much, but it moves `rttvar` a lot -- which is the correct response,
+because the thing that changed is the VARIANCE, not the average.
+
+MID-STREAM DEGRADATION, AND WHY THE ADAPTATION IS ASYMMETRIC
+------------------------------------------------------------
+Standard Jacobson/Karels adapts at one rate. Here the two directions have
+different costs:
+
+  * a budget that is too LOOSE delays detection of a genuinely wedged peer --
+    recoverable, and the op still completes or fails on its own route budget;
+  * a budget that is too TIGHT severs a HEALTHY stream, writes a timeout
+    penalty into the physics ledger for a host that was fine, and re-routes
+    work that did not need re-routing. That corruption then outlives the
+    network event that caused it.
+
+So samples that ARGUE FOR A WIDER budget are applied at a faster alpha than
+samples that argue for a narrower one. Concretely: when the path degrades
+direct -> DERP, the first few oversized gaps expand the budget within one or
+two chunks. When it recovers DERP -> direct, the budget contracts slowly over
+many chunks. Fast to distrust the network, slow to trust it again -- the same
+asymmetry as the profiler's EWMA, chosen for the same reason.
+
+THE TRANSPORT CLASS IS MEASURED, NOT DECLARED
+---------------------------------------------
+`transport_class()` buckets the smoothed RTT rather than shelling out to
+`tailscale status --json`. Three reasons, in order of weight:
+
+  1. it is a MEASUREMENT of the property that actually matters (latency),
+     not a declaration about the tool that happens to provide it;
+  2. it needs no Tailscale CLI on PATH, no subprocess on a hot path, and no
+     parsing of another program's JSON contract;
+  3. it generalises -- plain LAN, a different VPN, or a future transport all
+     bucket correctly without new code.
+
+Buckets carry HYSTERESIS. Without it an RTT hovering on a boundary would flip
+the class every few seconds, and since the class is part of the physics-ledger
+key, that would shred one host's measurements across two entries -- the same
+conflation bug the hardware signature exists to prevent, one level down.
+
+Python 3.9+, stdlib only. Never raises.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.TransportProfile")
+
+ENABLED_ENV = "JARVIS_TRANSPORT_PROFILE_ENABLED"
+K_ENV = "JARVIS_TRANSPORT_VARIANCE_K"
+FLOOR_ENV = "JARVIS_TRANSPORT_MIN_FLOOR_S"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+#: Jacobson/Karels constants. Named rather than inlined so the provenance of
+#: each is visible: these are RFC 6298's values, not tuning we invented.
+_ALPHA = 1.0 / 8.0          # smoothing for the mean
+_BETA = 1.0 / 4.0           # smoothing for the mean deviation
+_ALPHA_EXPAND = 1.0 / 2.0   # OUR addition: faster when widening (see docstring)
+
+#: (upper_bound_ms, class). Ordered. A smoothed RTT below the bound lands in
+#: that class. Chosen to separate the transports that actually behave
+#: differently, not to be pretty.
+_CLASS_BUCKETS: Tuple[Tuple[float, str], ...] = (
+    (2.0, "local"),    # loopback / same machine
+    (15.0, "lan"),     # same subnet, or Tailscale direct on a LAN
+    (60.0, "near"),    # direct over WAN, or a close relay
+    (float("inf"), "far"),   # DERP relay, cellular, hotel wifi
+)
+
+#: Fraction of a bucket's width a sample must cross BEFORE the class changes.
+#: Pure hysteresis: prevents a boundary-hugging RTT from splitting one host's
+#: physics across two ledger keys.
+_CLASS_HYSTERESIS = 0.25
+
+
+def transport_profile_enabled() -> bool:
+    """Master gate. Default ON. OFF returns a neutral profile whose floor is
+    the static base, i.e. byte-identical prior behaviour. NEVER raises."""
+    try:
+        return os.environ.get(ENABLED_ENV, "1").strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def variance_k() -> float:
+    """Multiplier on the mean deviation. Default 4.0 (RFC 6298's K).
+
+    Raising it buys tolerance for bursty transports at the cost of slower
+    stall detection. 4 is the value TCP has used for decades against exactly
+    this kind of noise."""
+    try:
+        return max(1.0, float(os.environ.get(K_ENV, "4.0")))
+    except (TypeError, ValueError):
+        return 4.0
+
+
+def min_floor_s() -> float:
+    """Absolute lower bound on the transport contribution. Default 0.25s."""
+    try:
+        return max(0.0, float(os.environ.get(FLOOR_ENV, "0.25")))
+    except (TypeError, ValueError):
+        return 0.25
+
+
+@dataclass(frozen=True)
+class TransportReading:
+    srtt_ms: float
+    rttvar_ms: float
+    budget_ms: float
+    transport_class: str
+    samples: int
+    provenance: str          # "measured" | "seeded"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "srtt_ms": round(self.srtt_ms, 2),
+            "rttvar_ms": round(self.rttvar_ms, 2),
+            "budget_ms": round(self.budget_ms, 2),
+            "transport_class": self.transport_class,
+            "samples": self.samples,
+            "provenance": self.provenance,
+        }
+
+
+class TransportProfile:
+    """Rolling latency + jitter tracker for ONE endpoint. Thread-safe."""
+
+    __slots__ = ("_lock", "_srtt", "_rttvar", "_n", "_class", "_endpoint")
+
+    def __init__(self, endpoint: str = "") -> None:
+        self._lock = threading.Lock()
+        self._srtt: Optional[float] = None
+        self._rttvar: float = 0.0
+        self._n: int = 0
+        self._class: str = ""
+        self._endpoint = endpoint
+
+    def observe(self, sample_ms: float) -> None:
+        """Fold one inter-arrival (or RTT) sample in. NEVER raises.
+
+        Called per streamed chunk, so it must stay O(1) and allocation-free.
+        """
+        try:
+            s = float(sample_ms)
+            if s < 0.0:
+                return
+            with self._lock:
+                if self._srtt is None:
+                    # RFC 6298 first-sample rule.
+                    self._srtt = s
+                    self._rttvar = s / 2.0
+                else:
+                    deviation = abs(self._srtt - s)
+                    self._rttvar = ((1 - _BETA) * self._rttvar
+                                    + _BETA * deviation)
+                    # ASYMMETRY. A sample above the current mean argues that
+                    # the path got worse; adopt it fast so a direct -> DERP
+                    # switch widens the budget within a chunk or two. A sample
+                    # below argues it got better; adopt it slowly, because
+                    # being wrong in that direction severs healthy streams.
+                    alpha = _ALPHA_EXPAND if s > self._srtt else _ALPHA
+                    self._srtt = (1 - alpha) * self._srtt + alpha * s
+                self._n += 1
+        except Exception:  # noqa: BLE001
+            pass
+
+    def reading(self) -> TransportReading:
+        """Current smoothed view. NEVER raises."""
+        try:
+            with self._lock:
+                srtt = self._srtt
+                rttvar = self._rttvar
+                n = self._n
+            if srtt is None:
+                return TransportReading(0.0, 0.0, 0.0, "unknown", 0, "seeded")
+            budget = srtt + variance_k() * rttvar
+            return TransportReading(srtt, rttvar, budget,
+                                    self._classify(srtt), n, "measured")
+        except Exception:  # noqa: BLE001
+            return TransportReading(0.0, 0.0, 0.0, "unknown", 0, "seeded")
+
+    def _classify(self, srtt_ms: float) -> str:
+        """Bucket the smoothed RTT, WITH HYSTERESIS.
+
+        A class that flips on a boundary-hugging RTT would split one host's
+        measurements across two physics-ledger keys — the same conflation the
+        hardware signature exists to prevent, one level down. So a sample must
+        cross a boundary by a margin before the class follows it.
+        """
+        try:
+            with self._lock:
+                current = self._class
+            chosen = "far"
+            for bound, name in _CLASS_BUCKETS:
+                if srtt_ms < bound:
+                    chosen = name
+                    break
+            if current and chosen != current:
+                # Find the boundary between current and chosen, and require
+                # the sample to be clearly past it.
+                for i, (bound, name) in enumerate(_CLASS_BUCKETS):
+                    if name == current and bound != float("inf"):
+                        lo = _CLASS_BUCKETS[i - 1][0] if i else 0.0
+                        width = max(1.0, bound - lo)
+                        margin = width * _CLASS_HYSTERESIS
+                        if lo - margin <= srtt_ms <= bound + margin:
+                            return current      # inside the sticky band
+                        break
+            with self._lock:
+                self._class = chosen
+            return chosen
+        except Exception:  # noqa: BLE001
+            return "unknown"
+
+    def floor_s(self) -> float:
+        """Transport contribution to the inter-token stall floor, in seconds.
+
+        This is ADDED to (not substituted for) the model-derived budget: a
+        stall deadline must cover the time the model needs AND the time the
+        network takes to deliver it. NEVER raises.
+        """
+        try:
+            if not transport_profile_enabled():
+                return 0.0
+            r = self.reading()
+            if r.provenance != "measured":
+                return 0.0
+            return max(min_floor_s(), r.budget_ms / 1000.0)
+        except Exception:  # noqa: BLE001
+            return 0.0
+
+    def snapshot(self) -> Dict[str, Any]:
+        d = self.reading().to_dict()
+        d["endpoint"] = self._endpoint
+        d["floor_s"] = round(self.floor_s(), 3)
+        return d
+
+
+_PROFILES: Dict[str, TransportProfile] = {}
+_LOCK = threading.Lock()
+
+
+def profile_for(endpoint: str) -> TransportProfile:
+    """Per-endpoint profile. Two hosts have two networks. NEVER raises."""
+    key = str(endpoint or "local")
+    with _LOCK:
+        p = _PROFILES.get(key)
+        if p is None:
+            p = TransportProfile(key)
+            _PROFILES[key] = p
+        return p
+
+
+def transport_class_for(endpoint: str) -> str:
+    """Measured transport class, or "" when unknown.
+
+    Returned EMPTY rather than guessing, so a caller building a ledger key can
+    omit the dimension instead of inventing one — an unmeasured transport must
+    not silently become a bucket that later real measurements are mixed into.
+    """
+    try:
+        if not transport_profile_enabled():
+            return ""
+        r = profile_for(endpoint).reading()
+        return "" if r.provenance != "measured" else r.transport_class
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def reset_for_tests() -> None:
+    with _LOCK:
+        _PROFILES.clear()

--- a/backend/core/ouroboros/ui/crest_animator.py
+++ b/backend/core/ouroboros/ui/crest_animator.py
@@ -1067,6 +1067,42 @@ def render_cockpit_header(
         text_rows: List[Any] = [
             ln if not isinstance(ln, str) else Text(ln) for ln in lines
         ]
+        # BOUND EACH IDENTITY ROW TO THE COLUMN IT LIVES IN.
+        #
+        # The rows are appended after the crest and a two-space gutter, and
+        # were previously appended WHOLE. A row longer than the remaining
+        # width therefore wrapped — and a wrapped continuation starts at
+        # column ZERO, i.e. on top of the crest. The capability reason
+        # ("doubleword is out of credit — add credits, or configure a local
+        # lane to keep background work moving") is exactly long enough to do
+        # it, so the nameplate collided with the artwork.
+        #
+        # This function's own docstring already states the principle — it is
+        # "the only place that knows the terminal width", and it degrades
+        # "instead of wrapping into a broken layout" — but applied it only to
+        # the gutter. The same bound belongs on the rows themselves, using the
+        # same arithmetic, which is why it is computed once here rather than
+        # guessed by the caller.
+        #
+        # Truncation over wrapping is deliberate: the header is a NAMEPLATE,
+        # a fixed number of rows beside a fixed-height crest. Letting it grow
+        # would push the layout around every time a provider state changed,
+        # and the full text is always available in the banner below.
+        _text_avail = max(8, int(width) - (
+            mini.cols if (mini is not None and crest_rows) else 0) - 2)
+        _bounded: List[Any] = []
+        for _ln in text_rows:
+            try:
+                # Copy before truncating: `lines` belongs to the caller and is
+                # rebuilt per frame, but mutating a shared Text would make the
+                # first narrow frame permanent.
+                _c = _ln.copy() if hasattr(_ln, "copy") else _ln
+                if hasattr(_c, "truncate"):
+                    _c.truncate(_text_avail, overflow="ellipsis")
+                _bounded.append(_c)
+            except Exception:  # noqa: BLE001 — a bound never breaks the header
+                _bounded.append(_ln)
+        text_rows = _bounded
         # Top-align the text beside the crest (the CC layout) with a
         # 1-row optical inset. Computed from the ORIGINAL text rows, BEFORE a
         # "below" gutter is appended: otherwise arming the audio plane would

--- a/backend/core/ouroboros/ui/crest_animator.py
+++ b/backend/core/ouroboros/ui/crest_animator.py
@@ -350,6 +350,9 @@ class CrestAnimator:
             plus_lead_deg if plus_lead_deg is not None else _plus_lead_deg_env()
         )
         self._logs: "deque[str]" = deque(maxlen=max(1, int(log_lines)))
+        #: The single live progress line, rendered under the transcript. A
+        #: value, not a history — see `set_progress`.
+        self._progress: str = ""
         self._lock = threading.Lock()
         # The resting emblem — the static crest's OWN raster (full fidelity).
         self._base: Dict[Tuple[int, int], Tuple[int, int, int]] = {}
@@ -512,6 +515,35 @@ class CrestAnimator:
 
     # -- the bottom log partition (thread-safe) --------------------------
 
+    def set_progress(self, line: str) -> None:
+        """Set the ONE live progress line under the boot log. Thread-safe.
+
+        Distinct from `add_log` on purpose. The log deque is a TRANSCRIPT —
+        each entry is an event that happened and must stay. Progress is a
+        GAUGE: one value that supersedes its predecessor, and appending it
+        produced the stack of six identical bars the operator saw.
+
+        No repaint is triggered here. `Live` re-renders `render(phase)` on
+        every frame anyway, so a mutated slot is picked up by the next one —
+        which is precisely why the progress line must live INSIDE this
+        renderable. Written to the terminal directly it lands underneath the
+        Live and is erased by the following frame, which is what made it
+        appear to flicker.
+        """
+        try:
+            with self._lock:
+                self._progress = str(line)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def clear_progress(self) -> None:
+        """Drop the progress line — the boot is over and the gauge is spent."""
+        try:
+            with self._lock:
+                self._progress = ""
+        except Exception:  # noqa: BLE001
+            pass
+
     def add_log(self, line: str) -> None:
         """Append one async boot log to the BOTTOM partition — never touches the
         crest matrix. Thread-safe; never raises."""
@@ -526,11 +558,17 @@ class CrestAnimator:
             from rich.text import Text
             with self._lock:
                 lines = list(self._logs)
+            with self._lock:
+                progress = self._progress
             t = Text()
             for i, ln in enumerate(lines):
                 t.append(ln, style=_LOG_RGB)
-                if i < len(lines) - 1:
+                if i < len(lines) - 1 or progress:
                     t.append("\n")
+            # LAST, and always last: the gauge sits beneath the transcript so
+            # new log entries push it down rather than scrolling past it.
+            if progress:
+                t.append(progress, style=_LOG_RGB)
             return t
         except Exception:  # noqa: BLE001
             return ""

--- a/deploy/local_tier_windows.env
+++ b/deploy/local_tier_windows.env
@@ -1,0 +1,124 @@
+# ======================================================================
+# local_tier_windows.env -- THE LOCAL SOVEREIGNTY TIER ACTIVATION PROFILE
+# ----------------------------------------------------------------------
+# Bridges the macOS M1 development host to the Windows RTX 5090 inference
+# host over the LAN. Everything here is gated default-OFF or default-inert
+# in code, so this file is the SINGLE place the activation lives -- unset it
+# and the system reverts to byte-identical local-only behaviour.
+#
+# HARDWARE THIS PROFILE ASSUMES (measured 2026-08-18, PRD §31.2.2):
+#   Windows host : AMD Ryzen 9 9950X3D, 64 GB DDR5-6000 (2/2 DIMM slots),
+#                  NVIDIA RTX 5090 32 GB GDDR7  <- the ONLY inference device.
+#                  GPU 1 in Task Manager is the 9950X3D's AMD Radeon iGPU
+#                  (2 CU RDNA2). It is NOT a CUDA device and NOT a lane.
+#   Mac host     : Apple M1, 16 GB unified. Measured: ONE drivable lane.
+#
+# ======================================================================
+# ⚠️  READ THIS FIRST -- TWO MACHINES, TWO KINDS OF SETTING
+# ----------------------------------------------------------------------
+# The OLLAMA_* variables below are read by the `ollama serve` PROCESS ON THE
+# WINDOWS MACHINE. JARVIS cannot set them remotely, and sourcing this file on
+# the Mac will NOT apply them. They are documented here so the profile is one
+# artifact rather than two, but they must be set on the Windows host itself
+# (System Properties -> Environment Variables, then restart the Ollama
+# service) and verified there.
+#
+# The JARVIS_* variables are read by the JARVIS process on whichever machine
+# runs the orchestration -- normally the Mac.
+# ======================================================================
+
+
+# ======================================================================
+# PART A -- SET THESE ON THE WINDOWS HOST (they configure `ollama serve`)
+# ======================================================================
+
+# Never evict the resident model. A cold load was MEASURED at ~30s for a
+# 1.9GB model on Apple Silicon; a 19GB 30B across PCIe is meaningfully
+# longer. The BACKGROUND route budget is 180s, so an eviction between ops
+# spends a large fraction of the next op's window on PCIe transfer -- a
+# deadline breach that has nothing to do with the model's speed, which is the
+# most misleading failure this tier can produce.
+OLLAMA_KEEP_ALIVE=-1
+
+# Exactly one model resident at a time. 19 GB (Qwen3-Coder-30B-A3B) plus
+# 17.8 GB (Qwen3.8-27B) is 36.8 GB against a 32 GB card BEFORE either one's
+# KV cache, so co-residency is not merely discouraged -- it is impossible.
+# Pinning this to 1 makes the eviction DETERMINISTIC instead of leaving the
+# server to discover the constraint under memory pressure.
+OLLAMA_MAX_LOADED_MODELS=1
+
+# Quantise the KV cache to 8-bit. Qwen3.8-27B measures ~62.5 KiB/token, so a
+# full 262,144-token context is ~16.4 GiB at fp16 -- which, on top of ~18 GiB
+# of weights, does NOT fit 32 GB. At q8_0 the cache roughly halves and the
+# full native context fits with room to spare. Quality cost at q8 is
+# negligible; this is the standard trade.
+OLLAMA_KV_CACHE_TYPE=q8_0
+
+# Bind beyond loopback so the Mac can reach it. Restrict by firewall to the
+# LAN -- this endpoint is UNAUTHENTICATED.
+OLLAMA_HOST=0.0.0.0:11434
+
+
+# ======================================================================
+# PART B -- SET THESE WHERE JARVIS RUNS (normally the Mac)
+# ======================================================================
+
+# ---- the bridge ------------------------------------------------------
+# Replace with the Windows host's LAN address. Deliberately not defaulted in
+# code: an unset value is the single-machine case, not a misconfiguration.
+JARVIS_REMOTE_INFERENCE_ENDPOINT=http://192.168.1.50:11434
+
+# The resident background workhorse. Chosen over the dense Qwen3.8-27B
+# because it is MoE: 3.3B ACTIVE of 30B total, so it reads ~1.9 GB per token
+# instead of ~17.8 GB. Same VRAM cost, ~9x less memory traffic -- which on a
+# card with capacity to spare and finite bandwidth is the whole ballgame.
+# See PRD §31.4 for the lane arithmetic (3 lanes vs 1).
+JARVIS_REMOTE_INFERENCE_MODEL=qwen3-coder:30b
+
+# ---- the M1 triage fallback -----------------------------------------
+# What this machine runs when the LAN is unreachable. Small on purpose: the
+# M1 was MEASURED at one drivable lane, so the fallback exists to keep triage
+# moving during an outage, not to match the 5090.
+JARVIS_LOCAL_TRIAGE_MODEL=qwen2.5-coder:3b
+
+# Never unload locally either. Reaches ollama as `keep_alive: -1` in the
+# request body (the aiohttp connector keepalive clamps to 30s independently,
+# so this cannot starve the socket pool).
+JARVIS_LOCAL_MODEL_KEEP_ALIVE_SECONDS=-1
+
+# ---- failover posture ------------------------------------------------
+# Three consecutive INFRASTRUCTURE faults open the breaker. Not 1 (a dropped
+# packet or a model load is not an outage, and a breaker that opens on one
+# fault flaps); not 10 (every fault costs a real op its budget).
+JARVIS_GATEWAY_FAILURE_THRESHOLD=3
+JARVIS_GATEWAY_COOLDOWN_S=60
+JARVIS_GATEWAY_PROBE_TIMEOUT_S=3
+
+# ---- pre-flight warm swap -------------------------------------------
+# Verify the required model is RESIDENT (/api/ps) before dispatching, and
+# warm-swap it against a budget of its own if not. The point is that a cold
+# load is paid OUTSIDE the op's generation clock -- the route budget was
+# calibrated for generation, not for PCIe transfer.
+JARVIS_GATEWAY_PREFLIGHT_ENABLED=1
+JARVIS_GATEWAY_RESIDENCY_TTL_S=30
+JARVIS_GATEWAY_WARM_SWAP_BUDGET_S=180
+
+# ---- physics + admission --------------------------------------------
+# Measured KV rate for Qwen3.8-27B (it caches only 16 of its 64 layers, which
+# is why it is unusually cheap). NO MEASURED FIGURE EXISTS YET for
+# qwen3-coder:30b -- MoE models often use conventional attention, which would
+# be pricier. Measure it and add it here; until then the pessimistic default
+# (131072 B/token) applies, which DEFERS more than necessary rather than
+# admitting a context that then OOMs.
+JARVIS_KV_BYTES_PER_TOKEN_BY_MODEL=qwen3.8:27b=64000
+
+# One inference GPU on this host, so there is nothing to pool. Left explicit
+# because the default-false choice is load-bearing: declaring sharding on a
+# non-sharding stack admits a model that then fails to load, having already
+# passed the gate whose whole job was to prevent that.
+JARVIS_LOCAL_ACCEL_SHARDING=0
+
+# The governor sizes lanes from MEASURED per-token latency. Left ON so the
+# 5090's real throughput -- not this file's estimates -- decides concurrency.
+JARVIS_THROUGHPUT_GOVERNOR_ENABLED=1
+JARVIS_HARDWARE_SIGNATURE_ENABLED=1

--- a/deploy/local_tier_windows.env
+++ b/deploy/local_tier_windows.env
@@ -54,9 +54,28 @@ OLLAMA_MAX_LOADED_MODELS=1
 # negligible; this is the standard trade.
 OLLAMA_KV_CACHE_TYPE=q8_0
 
-# Bind beyond loopback so the Mac can reach it. Restrict by firewall to the
-# LAN -- this endpoint is UNAUTHENTICATED.
-OLLAMA_HOST=0.0.0.0:11434
+# ZERO-TRUST BIND — the tailnet is the auth boundary, not the LAN.
+#
+# An earlier draft of this profile said `0.0.0.0:11434` with a "firewall it"
+# note. That is worse than it looks: Ollama has NO AUTHENTICATION, so binding
+# to all interfaces exposes model execution to every device on whatever
+# network the machine is attached to -- including a café or hotel LAN, where
+# "restrict by firewall" is advice nobody applies in the moment.
+#
+# Bind to the Tailscale interface address instead. Reachability then requires
+# membership of YOUR tailnet, which is authenticated and encrypted by
+# WireGuard, and the port is invisible to the local subnet entirely. Nothing
+# is lost: the Mac reaches the host over the same tailnet from home, from a
+# café, or over a relay.
+#
+# Find the address on the Windows host:
+#     tailscale ip -4          ->  e.g. 100.64.1.20
+# then set (PowerShell, then restart the Ollama service):
+#     setx OLLAMA_HOST "100.64.1.20:11434"
+#
+# Leave the value below as the tailnet IP, NOT 0.0.0.0. If you genuinely need
+# LAN-local access as well, prefer a second explicit bind over a wildcard.
+OLLAMA_HOST=100.64.1.20:11434
 
 
 # ======================================================================
@@ -66,7 +85,10 @@ OLLAMA_HOST=0.0.0.0:11434
 # ---- the bridge ------------------------------------------------------
 # Replace with the Windows host's LAN address. Deliberately not defaulted in
 # code: an unset value is the single-machine case, not a misconfiguration.
-JARVIS_REMOTE_INFERENCE_ENDPOINT=http://192.168.1.50:11434
+# The TAILNET address (100.x.x.x from `tailscale ip -4`), not a LAN IP.
+# Stable across reboots, DHCP and location changes -- which also makes it a
+# durable identity for the physics ledger, unlike a DHCP lease.
+JARVIS_REMOTE_INFERENCE_ENDPOINT=http://100.64.1.20:11434
 
 # The resident background workhorse. Chosen over the dense Qwen3.8-27B
 # because it is MoE: 3.3B ACTIVE of 30B total, so it reads ~1.9 GB per token
@@ -120,5 +142,17 @@ JARVIS_LOCAL_ACCEL_SHARDING=0
 
 # The governor sizes lanes from MEASURED per-token latency. Left ON so the
 # 5090's real throughput -- not this file's estimates -- decides concurrency.
+# ---- transport-aware stall budgeting --------------------------------
+# Tailscale negotiates DIRECT when it can and relays through DERP when it
+# cannot, and it can switch MID-STREAM. A stall deadline derived only from
+# model physics would sever healthy streams the moment the path degrades, so
+# inter-chunk arrival variance is tracked with the Jacobson/Karels estimator
+# (TCP's own RTO algorithm) and ADDED to the model term. The transport class
+# is also a dimension of the physics-ledger key, so home-LAN and hotel-wifi
+# measurements never blend.
+JARVIS_TRANSPORT_PROFILE_ENABLED=1
+JARVIS_TRANSPORT_VARIANCE_K=4.0
+JARVIS_TRANSPORT_MIN_FLOOR_S=0.25
+
 JARVIS_THROUGHPUT_GOVERNOR_ENABLED=1
 JARVIS_HARDWARE_SIGNATURE_ENABLED=1

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -4629,23 +4629,44 @@ Two profiler distortions worth recording, both pre-existing:
 #### 31.2.2 Windows inference host — the target
 
 ```
-CPU  AMD Ryzen 9 9950X3D
-GPU  NVIDIA RTX 5090 Founders Edition   32 GB GDDR7
-GPU  second NVIDIA card                 24 GB
-RAM  64 GB DDR5 (dual channel)
+CPU  AMD Ryzen 9 9950X3D   16C/32T, 4.30 GHz base, 128 MB L3 (3D V-Cache)
+GPU  NVIDIA RTX 5090 Founders Edition   32 GB GDDR7   <- the ONLY inference device
+iGPU AMD Radeon (integrated in the 9950X3D)  2 GB dedicated + 45.7 GB shared
+RAM  64 GB DDR5-6000, 2 of 2 DIMM slots used, 61.7 GB usable (2.3 GB reserved)
 ```
+
+> **CORRECTED 2026-08-18 from Task Manager screenshots.** An earlier draft of
+> this section recorded a *second NVIDIA card at 24 GB* and a pooled 56 GB.
+> That is wrong. `GPU 1` is the **AMD Radeon iGPU integrated into the
+> 9950X3D**, and its "45.7 GB shared" is system RAM addressed through the
+> display driver, not video memory. It is not a CUDA device: `nvidia-smi` and
+> `torch.cuda` do not enumerate it, and no llama.cpp/vLLM CUDA build will use
+> it. **There is exactly one inference GPU on this host.**
 
 | pool | bytes |
 |---|---|
-| largest single device | **32 GB** |
-| pooled VRAM (sharding declared) | **56 GB** |
-| VRAM + system RAM (weights may live in either) | **120 GB** |
+| the single inference device (RTX 5090) | **32 GB** |
+| pooled VRAM | **n/a — nothing to pool with** |
+| VRAM + usable system RAM (weights may live in either) | **~94 GB** |
 
-This is precisely the host the §31.1.2 work exists for: without it, the
-admission gate sees 32 GB and refuses a model that would fit across both
-cards; with sharding blindly summed, it would admit models that cannot land on
-a non-sharding stack. Both failure modes are now avoidable, and which one
-applies is stated rather than assumed.
+Two consequences follow, and both are load-bearing:
+
+1. **`JARVIS_LOCAL_ACCEL_SHARDING` is not merely left off — there is nothing
+   to declare.** The default-false choice in §31.1.2 turns out to have been
+   the difference between a correct gate and one that authorised a 56 GB load
+   onto a 32 GB card.
+2. **§31.1.2's `shardable_usable_bytes` guard is now exercised rather than
+   hypothetical**: on a single-device host it returns the single-device answer
+   *even when sharding is declared*, so a mistaken flag cannot invent the
+   card that is not there. Verified against this exact hardware shape.
+
+The §31.1.2 work still earns its place here, but for the opposite reason to
+the one first written down: not because two cards must be pooled, but because
+a probe that *cannot enumerate a second device* must say so rather than let a
+declaration fabricate one. `is_multi_device` keys off `len(devices)`, so on
+this host it is False and the affinity layer becomes a no-op — while the
+per-device **capacity** check (§31.6.1 #4a) still runs, which is the half that
+matters on a single 32 GB card.
 
 ### 31.3 Can a 1T–2.4T model run on that box? — answered with arithmetic
 
@@ -4669,14 +4690,18 @@ Published sizes:
 | IQ1_S | 508 GB | Unsloth |
 | **Unsloth Dynamic 1-bit GGUF (smallest that exists)** | **397 GB** | Unsloth |
 
-Against 120 GB of addressable memory on the target box:
+Against the ~94 GB actually addressable on the target box (32 GB VRAM +
+61.7 GB usable RAM — see the correction in §31.2.2):
 
 ```
 397 GB  smallest quantized form in existence
-120 GB  VRAM + system RAM
+ 94 GB  VRAM + usable system RAM
 -----
-277 GB  short  ->  3.3x over, at ~1.32 bits per parameter
+303 GB  short  ->  4.2x over, at ~1.32 bits per parameter
 ```
+
+The RAM ceiling is also harder than it looks: **both DIMM slots are already
+occupied**, so more memory means replacing the pair, not adding to it.
 
 There is no quantization below ~1 bit. The deficit cannot be closed by
 compression.
@@ -4768,8 +4793,8 @@ replace them with real numbers on first contact, and that is the point.
 |---|---|---|---|---|---|---|
 | **Qwen3-Coder-30B-A3B** | 30B / 3.3B MoE | ~19 GB | 256K → 1M | yes, with room | **220 tok/s** (reported) | **Best fit.** Clears the 3-lane bar with margin. The active-parameter count is what makes it fast. |
 | **Qwen3.8-27B** | 28B dense + vision | **17.8 GB** (Q4_K_M) | 256K native | yes | ~50–70 tok/s (est.) | **Best quality that still clears 1 lane.** Hybrid attention caches only 16 of 64 layers: KV is 0.5 GB @8K, 2.0 GB @32K, 16.4 GB @262K — unusually cheap. Apache-2.0. |
-| **Llama-3.3-70B** | 70B dense | ~40 GB | 128K | no — needs both cards | ~15–20 tok/s (est.) | **Below the bar.** Dense 70B cannot sustain 40 tok/s on this hardware. |
-| **gpt-oss-120b** | 117B / 5.1B MoE | **~60 GB** MXFP4 | 128K | no — 60 GB > 56 GB pooled | fast if resident (5.1B active) | **Marginal.** Weights alone exceed pooled VRAM; needs RAM spill plus KV cache, and vendor guidance says 80–96 GB. Revisit if a third card or 96 GB-class VRAM appears. |
+| **Llama-3.3-70B** | 70B dense | ~40 GB | 128K | no — 40 GB > 32 GB | ~15–20 tok/s (est.) | **Below the bar.** Dense 70B cannot sustain 40 tok/s here, and no longer fits VRAM at all. |
+| **gpt-oss-120b** | 117B / 5.1B MoE | **~60 GB** MXFP4 | 128K | no — 60 GB > 32 GB | usable ONLY with CPU-MoE offload | **The one case the 64 GB of RAM earns its keep.** Weights exceed VRAM, but with just **5.1B active** params the experts tolerate CPU offload (`--n-cpu-moe`) far better than a dense model would: attention stays on the 5090, experts stream from DDR5-6000. Worth measuring; the governor will price it honestly. |
 | **Kimi K2 / DeepSeek-class 1T** | 1T / 32B | 245 GB @1.8-bit | — | no | ~5 tok/s at best | **Out of scope** — see §31.3. |
 | **Qwen3.8-Max (2.4T-A95B)** | 2.4T / 95B | **397 GB** @1-bit | 256K–1M | no — 3.3x over | 0.18–0.45 tok/s streamed | **Impossible on this box, and unusable for O+V even on hardware that fits it.** |
 
@@ -4782,14 +4807,27 @@ replace them with real numbers on first contact, and that is the point.
    where one lane at higher fidelity beats three at lower. Its vision encoder
    also lines up with the existing multi-modal ingest path
    (`ctx.attachments` → GENERATE) and VisionSensor.
-3. Both fit the 5090 **alone**, which means `JARVIS_LOCAL_ACCEL_SHARDING` can
-   stay **off** and the second card is free to host the other model
-   concurrently — two resident models, no layer splitting, no pooled-capacity
-   risk. That is a strictly better use of 56 GB than one model spanning both.
+3. **They cannot both be resident.** 19 GB + 17.8 GB = 36.8 GB against a
+   32 GB card, before either one's KV cache. With a single inference GPU the
+   choice is exclusive, and swapping between them is not free: a cold model
+   load measured **~30 s** on this project's own hardware, which is a third of
+   a BACKGROUND budget spent before a single token is generated.
 
-> Note the shape of that recommendation: the second GPU's value here is
-> **another independent lane**, not a bigger model. Which is the same
-> conclusion §31.1.1 reached from the other direction.
+**So the deployment is one resident model, and it should be
+`Qwen3-Coder-30B-A3B`:** 19 GB of weights leaves ~11 GB of the 5090's free
+VRAM for KV, which at Qwen-class KV rates is roughly a **127K-token working
+context** — more than O+V ever asks for — while being the only candidate whose
+throughput clears the 3-lane bar in §31.4.1. Reach for `Qwen3.8-27B` instead
+only if a specific workload needs its vision encoder (which does line up with
+the existing `ctx.attachments` → GENERATE path and VisionSensor), accepting
+one lane instead of three.
+
+> The earlier draft of this section concluded that "the second GPU's value is
+> another independent lane, not a bigger model." The conclusion survives the
+> hardware correction; only the subject changes. There is no second GPU, so
+> the lane count now comes entirely from **how fast the one card is** — which
+> is precisely the quantity §31.1.1's governor measures, and precisely why it
+> had to be a measurement rather than a setting.
 
 Sources: [Qwen3.8-27B GGUF sizes](https://ofox.ai/blog/qwen-3-8-27b-run-locally-vram-gguf-2026/) ·
 [Qwen3-Coder-30B](https://www.morphllm.com/best-ollama-models) ·
@@ -4828,8 +4866,8 @@ Ranked by *leverage per line changed*, the §28 criterion.
 | # | Item | Why it is here | Cost | Blocked on |
 |---|---|---|---|---|
 | **1** | **`physics_key` hardware-class component** (§31.5.1) | Without it the bridge governs a 5090 with an M1's physics. This is a correctness bug that only appears under the exact configuration we are building toward. | S | nothing |
-| **2** | **Deploy `Qwen3-Coder-30B-A3B` + `Qwen3.8-27B` on the Windows host**, one per card | Turns the second GPU into a second lane. Makes the governor's arithmetic testable against hardware that can actually clear the bar. | S | machine powered on |
-| **3** | **Prove the dual-GPU probe end to end** — `nvidia-smi` enumeration, `is_multi_device`, admission with sharding both on and off | §31.1.2 is unit-proven and live-unproven. Every capability in this repo that shipped unproven eventually shipped broken. | S | machine powered on |
+| **2** | **Deploy `Qwen3-Coder-30B-A3B` as the single resident model** on the RTX 5090 | The one candidate that clears the 3-lane bar (§31.4.1), and the first hardware capable of testing the governor's arithmetic against real throughput rather than a 1-lane M1. | S | machine powered on |
+| **3** | **Prove the probe end to end on real silicon** — `nvidia-smi` enumeration (expect **one** device), `is_multi_device=False`, and admission refusing an over-long context with an actionable ceiling | §31.1.2 is unit-proven and live-unproven. The hardware correction *narrows* this: there is no pooling path to exercise, so what must be proven is that the single-device path is right — including that a declared `SHARDING=1` changes nothing. | S | machine powered on |
 | **4** | **Route-aware lane ceiling** (§31.5.2) | Re-gate after dequeue using the op's own route, reusing the existing re-enqueue idiom. | M | #2 |
 | **5** | **Observed sharding outranks the declared flag** | A stack reporting a resident model larger than its largest single device has **proven** sharding. Turns a trusted flag into a measurement — the same upgrade the physics ledger already represents. | M | #3 |
 | **6** | **Cold-load outlier isolation** (§31.2.1) | Recording model-load as per-token cost pins the estimator at its ceiling for a full sample window, which currently makes every M1 verdict `ceiling_clamped`. Record load separately. | M | nothing |
@@ -4848,7 +4886,7 @@ addressed lane COUNT while this addresses lane CHOICE.
 | 4a | Heterogeneous device routing + per-device KV admission | **closed (unit-proven only)** — `device_affinity.py` |
 | 7 | `psutil` DRY red | **closed** — `swap_in_bytes()` moved to `memory_pressure_gate` |
 | — | ToC dead anchors | **closed** — 124 broken links replaced with a companion-document map |
-| 2, 3 | Deploy the models; prove the dual-GPU probe live | **blocked on the Windows host being powered on** |
+| 2, 3 | Deploy the model; prove the probe live | **blocked on the Windows host being powered on** (scope narrowed by the §31.2.2 hardware correction — single GPU, so no pooling path to exercise) |
 
 **Three design decisions worth recording, because each rejected an easier
 answer:**
@@ -4872,10 +4910,22 @@ answer:**
    one rather than being deferred. Declining work a present device could do
    would be policy defeating the system it exists to tune.
 
-> **Honesty note.** §31.6 #4a is proven against synthetic `DeviceReading`s
-> only. No dual-GPU hardware has executed this path. Every capability in this
-> repository that shipped unproven eventually shipped broken, so #3 remains a
-> gate on trusting it, not a formality.
+> **Honesty note, updated 2026-08-18.** §31.6 #4a is proven against synthetic
+> `DeviceReading`s only, and the hardware correction in §31.2.2 means the
+> **routing half of it will never execute on this host** — one inference GPU
+> means `is_multi_device` is False and affinity is a no-op. What does execute,
+> and what therefore has to be right, is the per-device **capacity** half:
+> weights + KV at the reachable context against the single 32 GB card, and the
+> refusal path that reports an actionable ceiling. Verified against this exact
+> shape in-repo; still unproven on real silicon.
+>
+> Worth recording plainly: this section was written around a second GPU that
+> does not exist. The code survived the correction unchanged because two of
+> its guards were written to distrust exactly this class of mistake —
+> `is_multi_device` keys off enumerated devices rather than a reported count,
+> and `shardable_usable_bytes` returns the single-device answer even when
+> sharding is declared. **A design that assumes its own inputs may be wrong is
+> the only reason a wrong input cost nothing here.**
 
 **Not scheduled, and deliberately so:** anything aimed at running a 1T+ model
 locally. §31.3 shows the ceiling is not a hardware-budget problem but a

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -5155,6 +5155,81 @@ to `_local_target()` → and on the next evaluation the governor reads a
 penalised ledger and sizes fewer lanes. The event loop is never blocked and the
 op is never lost.
 
+#### 31.8.7 Live-fire status — what is proven, and what remains *(2026-08-18)*
+
+`scripts/live_fire_local_tier.py` drives the REAL gateway, ledger and governor
+against a real endpoint. There is no separate diagnostic channel: every number
+it prints is read back out of the objects the running system consults, because
+a diagnostic that observes a parallel copy of the state proves nothing about
+the state.
+
+**It found a bug on its first run that 300+ unit tests had not** — see
+§31.8.8. That is the argument for this milestone in one sentence.
+
+##### Proven on real infrastructure (loopback, Apple Silicon)
+
+| Capability | Evidence |
+|---|---|
+| `/api/ps` residency probe | answered in **165 ms**; `()` before load, `('qwen2.5-coder:3b',)` after, `None` unreachable |
+| Autonomous warm-swap handshake | 3b → 7b completed in **25.6 s**, paid OUTSIDE the op clock |
+| Adaptive stall detection | `InterTokenStall` at **2.1 s** against the adaptive 2.0 s deadline — **14× faster** than the static 30 s, against a real socket |
+| Fault classification | `InterTokenStall` → INFRASTRUCTURE; a request fault → not counted |
+| Breaker + recovery | opens after 3 stalls; exactly one probe offered after cooldown |
+| Non-fatal degradation event | `provider_state_changed` published after re-route |
+| Local triage fallback | resolves to the configured model |
+| **Closed telemetry loop** | ledger 0 → 4 → 7 samples under the correct model key; governor `seeded` → **`measured=True`**; deadlines re-derived live to `first=30.0 s / steady=7.7 s` |
+
+##### NOT proven — and the list is short and specific
+
+**Nothing has crossed a LAN.** Every figure above is loopback on a 16 GB M1.
+The remaining work is not more code; it is the same script, unchanged, pointed
+at the Windows host:
+
+| # | What | Blocked on | Command |
+|---|---|---|---|
+| **L1** | LAN reachability + residency of `qwen3-coder:30b` | Windows host powered on, Ollama bound `0.0.0.0`, firewall open on 11434 | `--phase 1 --endpoint http://<WIN-IP>:11434 --model qwen3-coder:30b` |
+| **L2** | Remote telemetry lands under a **remote** hardware signature (`provenance=endpoint`, distinct digest) | L1 | `--phase 2 --rounds 8` |
+| **L3** | Governor sizes **3 lanes** from measured 5090 throughput (the §31.4 prediction) | L2 | read `governor post:` line |
+| **L4** | Warm swap `qwen3-coder:30b` → `qwen3.8:27b` on a 32 GB card with `OLLAMA_MAX_LOADED_MODELS=1` — proving eviction is deterministic, not emergent | L1 | `--phase 1 --swap-model qwen3.8:27b` |
+| **L5** | Real LAN partition (unplug / stop the service) vs. the synthetic wedged peer | L1 | `--phase 3` then physically interrupt |
+| **L6** | Measured KV rate for `qwen3-coder:30b` → `JARVIS_KV_BYTES_PER_TOKEN_BY_MODEL` | L2 | compare `/api/ps` `size_vram` against weight size at two context sizes |
+| **L7** | Unattended soak under `ov` + `BackgroundAgentPool` with the governor live | L3 | existing battle-test harness, `--max-wall-seconds 2400` |
+
+**Two predictions this will falsify or confirm**, both currently estimates
+rather than measurements: `qwen3-coder:30b` at **~220 tok/s** (reported, not
+measured here) and the resulting **3-lane** verdict. The governor replaces both
+on first contact — which is the entire reason it was built as a measurement.
+
+#### 31.8.8 The bug live-fire found — cache identity
+
+`_client_for` cached clients keyed by `base_url` **alone**. But a client is
+bound to a MODEL: its cfg carries `model_name` and its profiler is keyed by a
+`physics_key` that includes the model. So after a warm swap to a second model
+on the same host, every subsequent dispatch got the **first** model's client
+back — the requested model was silently ignored, the op ran on the wrong
+weights, and its telemetry landed under the wrong physics key.
+
+Observed directly: phase 1 swapped to `qwen2.5-coder:7b`, then phase 2
+requested `qwen2.5-coder:3b` and ran four successful generations with real
+latencies — and the 3b ledger entry stayed at **zero** while the 7b entry
+gained exactly four. Nothing raised. Nothing logged. The only visible symptom
+was a telemetry key that stayed empty.
+
+On this deployment that reads as: one vision one-off swaps to the 27B, and
+every BACKGROUND op afterwards quietly runs on it at a third of the
+throughput, blowing route budgets with no error anywhere — while the governor
+sizes lanes from a ledger describing a model the ops are not using.
+
+> **Why the unit tests could not catch it.** Every one of them used a single
+> model per gateway, so the cache key and the model identity were the same
+> thing by construction. The defect needed two models on one host — which is
+> exactly what the deployment does and what a mock does not. **This is the
+> case for live-fire stated as a finding rather than as a principle.**
+
+Fixed by keying on `(base_url, model_name)`; five regression tests pin it,
+including that the cache is still a cache (a client per dispatch would leak a
+session per op) and that two models never share one ledger entry.
+
 ### 31.7 Invariants this section adds
 
 1. **A lane count must be derived or declared, never assumed.** A constant in

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -67,130 +67,26 @@
     - [23.10 Pass A → Pass B → Pass C — the Three-Pass Sequence](#2310-pass-a--pass-b--pass-c--the-three-pass-sequence)
     - [23.11 Operator Decisions Ratified 2026-04-26](#2311-operator-decisions-ratified-2026-04-26)
     - [23.12 Implementation Discipline + Cross-References](#2312-implementation-discipline--cross-references)
-24. [Brutal Architectural Review v3 — Convergence-Phase (2026-04-28)](#24-brutal-architectural-review-v3--convergence-phase-2026-04-28) *(superseded in part by §25)*
-    - [24.1 Context & Scope of Review](#241-context--scope-of-review)
-    - [24.2 Capability Matrix — current vs A-level sovereign developer](#242-capability-matrix--current-vs-a-level-sovereign-developer)
-    - [24.3 Cognitive & Epistemic Delta — what CC paradigms O+V lacks](#243-cognitive--epistemic-delta--what-cc-paradigms-ov-lacks)
-    - [24.4 The HypothesisProbe Primitive — autonomous ambiguity resolution](#244-the-hypothesisprobe-primitive--autonomous-ambiguity-resolution)
-    - [24.5 Temporal Observability — state reconstruction surface](#245-temporal-observability--state-reconstruction-surface)
-    - [24.6 Systemic Fragility — race conditions in async phase-runners](#246-systemic-fragility--race-conditions-in-async-phase-runners)
-    - [24.7 Cascading state-failure vectors over long horizons](#247-cascading-state-failure-vectors-over-long-horizons)
-    - [24.8 Antivenom bypass vectors — Quine-class hallucinations](#248-antivenom-bypass-vectors--quine-class-hallucinations)
-    - [24.9 Letter grade — B+ trending A-, defended](#249-letter-grade--b-trending-a-defended) *(superseded by §25.4 — current grade B-)*
-    - [24.10 Critical Path to A-Level RSI — top 3 systemic upgrades](#2410-critical-path-to-a-level-rsi--top-3-systemic-upgrades) *(superseded by §25.5 — top 5 priorities)*
-    - [24.11 In-flight alignment — Phase 12 / 12.2 maps to the critical path](#2411-in-flight-alignment--phase-12--122-maps-to-the-critical-path)
-    - [24.12 What this review explicitly does NOT prescribe](#2412-what-this-review-explicitly-does-not-prescribe)
-25. [Brutal Architectural Review v4 — Post-Phase-2-Production-Verification (2026-04-29)](#25-brutal-architectural-review-v4--post-phase-2-production-verification-2026-04-29) *(superseded by §26 — Priorities A–F all closed)*
-    - [25.1 What soak #3 actually proved (and didn't)](#251-what-soak-3-actually-proved-and-didnt)
-    - [25.2 The Cognitive & Epistemic Delta — refined post-Phase-2](#252-the-cognitive--epistemic-delta--refined-post-phase-2)
-    - [25.3 Deep Observability — Temporal surface refined](#253-deep-observability--temporal-surface-refined)
-    - [25.4 Brutal grade — current state: **B-**](#254-brutal-grade--current-state-b-)
-    - [25.5 Critical Path to A-Level RSI — top 5 systemic upgrades](#255-critical-path-to-a-level-rsi--top-5-systemic-upgrades)
-    - [25.6 In-flight alignment — what's on main right now that helps](#256-in-flight-alignment--whats-on-main-right-now-that-helps)
-    - [25.7 Reverse Russian Doll alignment](#257-reverse-russian-doll-alignment)
-    - [25.8 What this review explicitly does NOT prescribe](#258-what-this-review-explicitly-does-not-prescribe)
-    - [25.9 Summary](#259-summary)
-26. [Brutal Architectural Review v5 — Post-Phase-12-DW-Resilience-Closure (2026-04-29)](#26-brutal-architectural-review-v5--post-phase-12-dw-resilience-closure-2026-04-29) *(superseded by §27 — Pass B + Pass C + Priorities 1+2 all closed; autonomy question re-graded)*
-    - [26.1 What soak #7 actually proved (and what §25 priorities A–F now closed)](#261-what-soak-7-actually-proved-and-what-25-priorities-af-now-closed)
-    - [26.2 Refined Cognitive & Epistemic Delta — what CC still has that O+V doesn't](#262-refined-cognitive--epistemic-delta--what-cc-still-has-that-ov-doesnt)
-    - [26.3 Refined Deep Observability — temporal reconstruction is the missing depth](#263-refined-deep-observability--temporal-reconstruction-is-the-missing-depth)
-    - [26.4 Brutal grade — current state: **B+ / B−**](#264-brutal-grade--current-state-b--b-)
-    - [26.5 Critical Path to A-Level RSI — top 3 systemic upgrades (post-Phase-12)](#265-critical-path-to-a-level-rsi--top-3-systemic-upgrades-post-phase-12)
-    - [26.6 Cost contract structural reinforcement — BG never cascades to Claude (bulletproofing)](#266-cost-contract-structural-reinforcement--bg-never-cascades-to-claude-bulletproofing)
-    - [26.7 In-flight alignment + sequencing](#267-in-flight-alignment--sequencing)
-    - [26.8 What this review explicitly does NOT prescribe](#268-what-this-review-explicitly-does-not-prescribe)
-    - [26.9 Summary — the path from B+ to A](#269-summary--the-path-from-b-to-a)
-27. [Brutal Architectural Review v6 — The Autonomy Question (2026-04-29)](#27-brutal-architectural-review-v6--the-autonomy-question-2026-04-29)
-    - [27.1 What's actually shipped (vs the §26 v5 framing which is now stale)](#271-whats-actually-shipped-vs-the-26-v5-framing-which-is-now-stale)
-    - [27.2 The 8 capability dimensions of "autonomous coding"](#272-the-8-capability-dimensions-of-autonomous-coding)
-    - [27.3 Brutal letter grade — answering the autonomy question directly](#273-brutal-letter-grade--answering-the-autonomy-question-directly)
-    - [27.4 Critical path to actual autonomy — top 3 systemic moves](#274-critical-path-to-actual-autonomy--top-3-systemic-moves)
-    - [27.5 What this review explicitly does NOT prescribe](#275-what-this-review-explicitly-does-not-prescribe)
-    - [27.6 Summary — answering the operator's question directly](#276-summary--answering-the-operators-question-directly)
-30. [ASCO Mapping — What's True, What's Not, What's Buildable (2026-05-04)](#30-asco-mapping--whats-true-whats-not-whats-buildable-2026-05-04) *(latest section)*
-    - [30.1 The ASCO Definition (operator-supplied source)](#301-the-asco-definition-operator-supplied-source)
-    - [30.2 The Honest 4-Axis Mapping](#302-the-honest-4-axis-mapping)
-    - [30.3 Synthesis Table (one-screen summary)](#303-synthesis-table-one-screen-summary)
-    - [30.4 The Most Defensible Label](#304-the-most-defensible-label)
-    - [30.5 Buildability — The Three Buildable Arcs (Near/Medium-Term)](#305-buildability--the-three-buildable-arcs-nearmedium-term)
-    - [30.6 Buildability — The Long-Horizon Arc (J-Prime LoRA)](#306-buildability--the-long-horizon-arc-j-prime-lora)
-    - [30.7 What's NOT Worth Building (Honest List)](#307-whats-not-worth-building-honest-list)
-    - [30.8 CLI UI/UX Discipline — Lessons from the Claude Code Article](#308-cli-uiux-discipline--lessons-from-the-claude-code-article-operator-supplied)
-    - [30.9 Updated Capability Matrix vs CC + ASCO](#309-updated-capability-matrix-vs-cc--asco)
-    - [30.10 Sequencing Recommendation (operator-binding)](#3010-sequencing-recommendation-operator-binding)
-    - [30.11 Cross-References](#3011-cross-references)
-    - [30.12 Summary — Honest Answer to the Operator's Question](#3012-summary--honest-answer-to-the-operators-question)
-31. [Critical Path Systemic Upgrades v3 — Bounded Epistemic Loop + Decision Causality + Failure-Mode Memory (2026-05-04)](#31-critical-path-systemic-upgrades-v3--bounded-epistemic-loop--decision-causality--failure-mode-memory-2026-05-04) *(newest section)*
-    - [31.1 Why "systemic upgrades" not "features"](#311-why-systemic-upgrades-not-features)
-    - [31.2 Upgrade 1 — Bounded Epistemic Loop](#312-upgrade-1--bounded-epistemic-loop)
-    - [31.3 Upgrade 2 — DecisionRecord Causality Graph](#313-upgrade-2--decisionrecord-causality-graph)
-    - [31.4 Upgrade 3 — Failure-Mode Memory at GENERATE-prompt-construction](#314-upgrade-3--failure-mode-memory-at-generate-prompt-construction)
-    - [31.5 Synthesis Table — How the 3 Upgrades Compose](#315-synthesis-table--how-the-3-upgrades-compose)
-    - [31.6 Sequencing Recommendation (operator-binding)](#316-sequencing-recommendation-operator-binding)
-    - [31.7 What Each Upgrade Does NOT Do (Anti-Goals)](#317-what-each-upgrade-does-not-do-anti-goals)
-    - [31.8 Cross-References](#318-cross-references)
-    - [31.9 Summary — Why These Three (and Why Now)](#319-summary--why-these-three-and-why-now)
-32. [`graduation_orchestrator.py` Salvage + M10 Refinement + Targeted Venom Enhancements + GitHub Recon (2026-05-04)](#32-graduation_orchestratorpy-salvage--m10-refinement--targeted-venom-enhancements--github-recon-2026-05-04) *(latest section)*
-    - [32.1 Why this section exists](#321-why-this-section-exists)
-    - [32.2 `graduation_orchestrator.py` — Bit-Rot Assessment](#322-graduation_orchestratorpy--bit-rot-assessment)
-    - [32.3 Verdict — Design Reference, Not Direct Integration](#323-verdict--design-reference-not-direct-integration)
-    - [32.4 M10 ArchitectureProposer — Refined Slice Plan (Supersedes §30.5.2)](#324-m10-architectureproposer--refined-slice-plan-supersedes-3052)
-    - [32.5 Cleanup Arc — `graduation_orchestrator.py` Removal](#325-cleanup-arc--graduation_orchestratorpy-removal)
-    - [32.6 Targeted Venom Enhancements — Agent SDK Architecture, NOT Migration](#326-targeted-venom-enhancements--agent-sdk-architecture-not-migration)
-    - [32.7 `anthropics/claude-code` GitHub Repo Recon — 3 Patterns Worth Porting](#327-anthropicsclaude-code-github-repo-recon--3-patterns-worth-porting)
-    - [32.8 Sequencing — Where §32 Fits in §31.6 (Updated 11-Item Operator-Binding Order)](#328-sequencing--where-32-fits-in-316-updated-10-item-operator-binding-order)
-    - [32.9 Cross-References](#329-cross-references)
-    - [32.10 Summary — Three Investigations, One Architectural Conclusion](#3210-summary--three-investigations-one-architectural-conclusion)
-    - [32.11 Slice 5b Consolidation Arc — CLOSED 2026-05-04](#3211-slice-5b-consolidation-arc--closed-2026-05-04)
-33. [Reusable Meta-Patterns](#33-reusable-meta-patterns-new-2026-05-05--derived-from-coverage-audit)
-34. [VisionSensor + Multi-modal Subsystem](#34-visionsensor--multi-modal-subsystem-new-2026-05-05--anchored-from-claudemd)
-35. [Open Strategic Moves Registry](#35-open-strategic-moves-registry-new-2026-05-05--consolidates-2863--294-scattered-moves)
-36. [Brutal Architectural Review v10 + Forward Priority Roadmap](#36-brutal-architectural-review-v10--forward-priority-roadmap-new-2026-05-05--operator-driven-post-move-7move-8wave-3285133-catalog-closures)
-37. [Operator UX/UI v10 Brutal Review + Comprehensive CC-Feature Catalog](#37-operator-uxui-v10-brutal-review--comprehensive-cc-feature-catalog-new-2026-05-05--operator-driven-post-phase-9-day-1-graduation)
-39. [Ultra Next-Level Autonomy-Native UX Brainstorm (NEW 2026-05-07)](#39-ultra-next-level-autonomy-native-ux-brainstorm-new-2026-05-07--operator-driven-make-ov-super-duper-advanced--coolest-sickest-uiux)
-38. [Karen's Voice + UX/UI Future Roadmap (NEW 2026-05-07)](#38-karens-voice--uxui-future-roadmap-new-2026-05-07--operator-driven-post-phase-1--3-closures)
-    - [38.1 Why this section exists](#381-why-this-section-exists)
-    - [38.2 The real visibility problem (operator awareness gap)](#382-the-real-visibility-problem-operator-awareness-gap)
-    - [38.3 Karen's Voice — full architecture + risk analysis](#383-karens-voice--full-architecture--risk-analysis)
-    - [38.4 Already-unique features that should be the visual centerpiece](#384-already-unique-features-that-should-be-the-visual-centerpiece)
-    - [38.5 CC features worth porting (parity polish)](#385-cc-features-worth-porting-parity-polish)
-    - [38.6 Edge cases + defensive handling](#386-edge-cases--defensive-handling)
-    - [38.7 Deliberate differentiation — what NOT to port](#387-deliberate-differentiation--what-not-to-port)
-    - [38.8 13 creative ideas ranked by uniqueness × effort](#388-13-creative-ideas-ranked-by-uniqueness--effort)
-    - [38.9 Sequencing recommendation (path to A++ professional)](#389-sequencing-recommendation-path-to-a-professional)
-    - [38.10 Operator-binding alignment per arc](#3810-operator-binding-alignment-per-arc)
-    - [38.11 Proactive-only UX features (CC structurally cannot have these)](#3811-proactive-only-ux-features-cc-structurally-cannot-have-these-new-2026-05-07)
-40. [Advanced Forward Roadmap (post-tonight, operator-paced) (NEW 2026-05-10)](#40-advanced-forward-roadmap-post-tonight-operator-paced) *(22-item prioritization across 5 chronological waves + academic-research grounding)*
-    - [40.1 Tier 1 — Recursion-bounding (load-bearing for second-order doll)](#401-tier-1--recursion-bounding-load-bearing-for-second-order-doll)
-    - [40.2 Tier 2 — Antivenom completeness + cross-session coherence](#402-tier-2--antivenom-completeness--cross-session-coherence)
-    - [40.3 Tier 3 — Calibration, learning, second-order metrics](#403-tier-3--calibration-learning-second-order-metrics)
-    - [40.4 Truly experimental (research-grade, deferred)](#404-truly-experimental-research-grade-deferred)
-    - [40.5 Chronological prioritization — all 22 items ranked by impact + sequencing (5 waves)](#405-chronological-prioritization--all-22-items-ranked-by-impact--sequencing)
-        - [40.5.1 Top-3 if you want to start TODAY](#4051-top-3-if-you-want-to-start-today)
-        - [40.5.2 Anti-recommendation](#4052-anti-recommendation)
-    - [40.6 Status — operational, not engineering](#406-status--operational-not-engineering)
-    - [40.7 Academic foundations & related work (prestigious-university research grounding)](#407-academic-foundations--related-work-prestigious-university-research-grounding)
-        - [40.7.1 — Recursive Self-Improvement (RRD architectural foundation)](#4071--recursive-self-improvement-rrd-architectural-foundation)
-        - [40.7.2 — Formal verification + AST safety (Antivenom foundation)](#4072--formal-verification--ast-safety-antivenom-foundation)
-        - [40.7.3 — Multi-agent consensus + speculative execution (Move 6.5 foundation)](#4073--multi-agent-consensus--speculative-execution-move-65-foundation)
-        - [40.7.4 — AI Safety + Constitutional Cage (Antivenom philosophical foundation)](#4074--ai-safety--constitutional-cage-antivenom-philosophical-foundation)
-        - [40.7.5 — Benchmarks (Phase 9 cadence empirical foundation)](#4075--benchmarks-phase-9-cadence-empirical-foundation)
-        - [40.7.6 — Why this matters](#4076--why-this-matters)
-41. [Critical Path to Tier D — Fully Autonomous JARVIS Development (NEW 2026-05-11)](#41-critical-path-to-tier-d--fully-autonomous-jarvis-development-new-2026-05-11) *(the load-bearing North Star: O+V develops JARVIS proactively + fully autonomously, safely + governance-bounded — 18-30 month phased roadmap)*
-    - [41.1 The Stated Goal (Verbatim)](#411-the-stated-goal-verbatim)
-    - [41.2 The Tier Framework: A → B → C → D](#412-the-tier-framework-a--b--c--d)
-    - [41.3 UX Polish Gap (Updated Post-Slice 1)](#413-ux-polish-gap-updated-post-slice-1)
-    - [41.4 Layer 2 — Engineering Capability Gaps](#414-layer-2--engineering-capability-gaps)
-    - [41.5 NEW Operator-Flagged Gap — Web Search & Browsing Capability](#415-new-operator-flagged-gap--web-search--browsing-capability)
-    - [41.6 Layer 3 — Empirical Evidence Requirements (Wall-Clock)](#416-layer-3--empirical-evidence-requirements-wall-clock)
-    - [41.7 Layer 4 — The Architectural Decision (Tier C → Tier D)](#417-layer-4--the-architectural-decision-tier-c--tier-d)
-    - [41.8 Roadmap to Tier D — Phased 18-30 Month Plan](#418-roadmap-to-tier-d--phased-18-30-month-plan)
-    - [41.9 Prioritization Framework — Highest Leverage at Each Horizon](#419-prioritization-framework--highest-leverage-at-each-horizon)
-    - [41.10 Honest Framing & Decision Points](#4110-honest-framing--decision-points)
-- [Appendix A — Glossary](#appendix-a--glossary)
-- [Appendix B — Reference Documents Map](#appendix-b--reference-documents-map)
-- [Appendix C — Phase Gate Criteria (entry/exit conditions)](#appendix-c--phase-gate-criteria-entryexit-conditions)
-- [Appendix D — Document History](#appendix-d--document-history)
+
+### Sections §24–§41 and Appendices A–D — moved, not deleted
+
+> These 124 entries pointed at anchors this file no longer contains. The
+> sections were not removed: commit `9f8625a775` (Slice 226) split a 2.2MB
+> PRD into four files so GitHub would render them, and the table of contents
+> was never repointed. Every link below was therefore broken — navigation
+> that silently fails is worse than navigation that is absent, because a
+> reader concludes the content is gone.
+
+| Looking for | Now lives in |
+|---|---|
+| §24–§28 Brutal Architectural Reviews v3–v9, §30 ASCO Mapping, §31–§39 critical-path/UX/meta-pattern sections, Appendices A–C | [`OUROBOROS_VENOM_PRD_SPEC_DETAIL.md`](./OUROBOROS_VENOM_PRD_SPEC_DETAIL.md) |
+| §40 Advanced Forward Roadmap, §41 Critical Path to Tier D, wave-closure banners and the session cross-off table | [`OUROBOROS_VENOM_PRD_HISTORY.md`](./OUROBOROS_VENOM_PRD_HISTORY.md) |
+| §51 The North Star Galaxy, Appendix D Document History | [`OUROBOROS_VENOM_NORTH_STAR.md`](./OUROBOROS_VENOM_NORTH_STAR.md) |
+
+> **Numbering note.** Section numbers §24 and up were REUSED in this file
+> after the split, so `§24` here means Voice I/O (2026-07-26) while `§24` in
+> the spec-detail document means Brutal Architectural Review v3 (2026-04-28).
+> Cite the file, not just the number.
 
 ---
 24. [Voice I/O — the `ov` Conversational Loop](#24-voice-io--the-ov-conversational-loop-new-2026-07-26)
@@ -4939,6 +4835,47 @@ Ranked by *leverage per line changed*, the §28 criterion.
 | **6** | **Cold-load outlier isolation** (§31.2.1) | Recording model-load as per-token cost pins the estimator at its ceiling for a full sample window, which currently makes every M1 verdict `ceiling_clamped`. Record load separately. | M | nothing |
 | **7** | **Fix the pre-existing DRY red** — `local_model_admission._read_swapin_bytes` imports `psutil` directly (`f2c3974ddc`), which `test_dry_admission_derives_neither_reading_itself` forbids. Expose swap-in via `memory_pressure_gate`. | Red on `main` today; it will fail every PR touching that file. | S | nothing |
 | **8** | **`InferenceGateway` abstraction** — one seam for local/remote endpoint selection, health, and backpressure | The original Gap 3 ask. Deliberately last: three of its inputs (lane ceiling, pooled capacity, per-endpoint physics) had to exist first, and two of them now do. | L | #1, #4 |
+
+#### 31.6.1 Execution log — 2026-08-18 (operator-directed)
+
+Items **1**, **7** and the ToC cleanup are CLOSED; the heterogeneous-routing
+work the operator specified became a new item **4a** (below), since §31.6 #4
+addressed lane COUNT while this addresses lane CHOICE.
+
+| # | Item | State |
+|---|---|---|
+| 1 | `physics_key` hardware axis | **closed** — `hardware_signature.py`; key is now `hardware_sig@model@ctx` |
+| 4a | Heterogeneous device routing + per-device KV admission | **closed (unit-proven only)** — `device_affinity.py` |
+| 7 | `psutil` DRY red | **closed** — `swap_in_bytes()` moved to `memory_pressure_gate` |
+| — | ToC dead anchors | **closed** — 124 broken links replaced with a companion-document map |
+| 2, 3 | Deploy the models; prove the dual-GPU probe live | **blocked on the Windows host being powered on** |
+
+**Three design decisions worth recording, because each rejected an easier
+answer:**
+
+1. **The signature has ONE SPINE.** An early draft appended GPU components to
+   the machine id, which made the digest depend on
+   `JARVIS_COMPUTE_TOPOLOGY_ENABLED` — flipping that flag re-keyed the ledger
+   and orphaned every prior measurement on a machine that had not changed.
+   GPU identity is now a SUBSTITUTE for a missing spine, never an addition to
+   a present one. **A signature must change only when the machine does.**
+
+2. **The endpoint beats the config.** `_failover_profiler_for(endpoint, cfg)`
+   keys its in-memory store by ENDPOINT but derived its ledger key from CFG.
+   Resolving the machine from `cfg` there would have stamped every failover
+   target with the base config's identity — re-creating the conflation at the
+   one seam, cross-node failover, where it matters most. `physics_key` now
+   takes an explicit `endpoint=`.
+
+3. **Capacity is a constraint; affinity is a preference.** SPECULATIVE prefers
+   the smaller card, but a payload that does not fit there goes to the larger
+   one rather than being deferred. Declining work a present device could do
+   would be policy defeating the system it exists to tune.
+
+> **Honesty note.** §31.6 #4a is proven against synthetic `DeviceReading`s
+> only. No dual-GPU hardware has executed this path. Every capability in this
+> repository that shipped unproven eventually shipped broken, so #3 remains a
+> gate on trusting it, not a formality.
 
 **Not scheduled, and deliberately so:** anything aimed at running a 1T+ model
 locally. §31.3 shows the ceiling is not a hardware-budget problem but a

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -5087,6 +5087,74 @@ including a structural pin that **every `JARVIS_*` setting in the profile is
 read by code** — a profile documenting a knob nothing consults is the same
 defect class as a capability with no caller.
 
+#### 31.8.6 The streaming handshake and the closed telemetry loop *(2026-08-18)*
+
+The final phase found **two defects that only became reachable once the bridge
+forced the streaming path**, and one requirement that was already satisfied.
+
+**Already closed:** the telemetry loop. `_complete_streaming` records
+`ttft/total/output_tokens` into the injected profiler on a clean finish, the
+gateway binds each target a profiler keyed by
+`physics_key(cfg, endpoint=...)`, and the governor profiles the ACTIVE target.
+Remote measurements therefore already reached the lane calculation. Nothing to
+build; the loop was closed by the hardware-signature work.
+
+**Defect 1 — one constant for two different physics.** The watchdog applied a
+single 30s budget to BOTH waits:
+
+| wait | what it measures | 30s is... |
+|---|---|---|
+| before the first chunk | **prefill** — grows with prompt size | too TIGHT: a 64K prompt whose first byte legitimately takes 40s is declared "wedged" while working normally |
+| between chunks | **inter-token gap** — roughly constant | too LOOSE: at 220 tok/s the normal gap is ~4.5ms, so a wedged peer gets ~6,600 normal gaps before anyone notices |
+
+`LatencyProfiler.inter_token_budget_s()` now returns **two** deadlines derived
+from measured TTFT and per-token cost, with directional clamps that make the
+change strictly safe:
+
+* the **first-token** deadline may only ever be **looser** than the legacy
+  value (prefill is the one wait that legitimately grows);
+* the **steady-state** deadline may only ever be **tighter** (it may detect a
+  wedge sooner, never later), and is floored so ordinary LAN jitter and
+  server-side chunk batching are not mistaken for a stopped peer — a false
+  positive aborts a real generation.
+
+Measured on this host: cold → `(30.0, 30.0)` (byte-identical legacy); a fast
+host → `(30.0, 2.0)`; a slow host with heavy prefill → `(108.0, 3.72)`. Every
+term is env-tunable; no network parameter is a literal in the decision path.
+
+**Defect 2 — a stall taught the ledger nothing.** `record()` fires only on a
+clean finish, and `record_timeout_penalty` was called only from the
+NON-streaming path. So a remote that wedged every op kept its optimistic EWMA
+forever, and the ThroughputGovernor kept sizing lanes for a machine that was
+actively failing — **a wrong answer derived from stale-but-honest data, which
+is the hardest kind to notice.** The streaming path now penalises the ledger
+before raising, through the existing asymmetric-escalation seam.
+
+> **A nuance worth stating rather than assuming.** `adaptive_timeout_ms` has
+> two branches, and the survival/CPU branch (no negotiated `num_ctx`) is
+> explicitly "byte-identical legacy — no EWMA escalation". So the penalty is
+> recorded there but not consulted. That is fortunate rather than accidental
+> for this work: the LAN bridge negotiates `num_ctx`, so **the host whose
+> stalls must move the estimate is exactly the host whose branch reads it.**
+> Measured: 16,580 ms → 135,000 ms with `num_ctx` set, unchanged without.
+> Pinned by test so a future edit to either branch confronts the asymmetry.
+
+**The degradation event** reuses `provider_state_changed` — already this
+codebase's DEGRADED↔HEALTHY signal — rather than minting a type. New SSE types
+must be added to the canonical `_VALID_EVENT_TYPES` frozenset or they are
+**silently dropped**, so inventing one would have produced a degradation signal
+that degrades silently. It is emitted best-effort AFTER the op has already been
+re-routed locally, so a publish failure cannot turn a handled degradation into
+an unhandled one.
+
+**Error boundaries, end to end.** A remote fault now travels: `InterTokenStall`
+raised inside the client (severing the socket as `async with` unwinds) →
+ledger penalised → classified as INFRASTRUCTURE by the gateway → host health
+recorded → `provider_state_changed` published non-fatally → the op re-dispatched
+to `_local_target()` → and on the next evaluation the governor reads a
+penalised ledger and sizes fewer lanes. The event loop is never blocked and the
+op is never lost.
+
 ### 31.7 Invariants this section adds
 
 1. **A lane count must be derived or declared, never assumed.** A constant in

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -212,6 +212,16 @@
     - [28.4 Findings withdrawn under verification](#284-findings-withdrawn-under-verification)
     - [28.5 Measured affordance costs](#285-measured-affordance-costs)
     - [28.6 Remediation, ranked by leverage per line changed](#286-remediation-ranked-by-leverage-per-line-changed)
+29. [The Distributed Body/Engine Link](#29-the-distributed-bodyengine-link-new-2026-08-15)
+30. [Proactive Mode](#30-proactive-mode-new-2026-08-15)
+31. [The Local Sovereignty Tier — Physics as a Governance Input](#31-the-local-sovereignty-tier--physics-as-a-governance-input-new-2026-08-18) *(latest section)*
+    - [31.1 What shipped](#311-what-shipped)
+    - [31.2 The measured envelope](#312-the-measured-envelope)
+    - [31.3 Can a 1T–2.4T model run on that box? — answered with arithmetic](#313-can-a-1t24t-model-run-on-that-box--answered-with-arithmetic)
+    - [31.4 Which models suit O+V — derived from the budget, not from a leaderboard](#314-which-models-suit-ov--derived-from-the-budget-not-from-a-leaderboard)
+    - [31.5 What the bridge exposes — latent defects to close before Gap 3](#315-what-the-bridge-exposes--latent-defects-to-close-before-gap-3)
+    - [31.6 Priorities — what to do next, ranked](#316-priorities--what-to-do-next-ranked)
+    - [31.7 Invariants this section adds](#317-invariants-this-section-adds)
 
 ## 1. Executive Summary
 
@@ -4498,3 +4508,458 @@ op (§26.5). (d) `watch` and hibernation render distinguishably.
    already stores.)*
 
 ---
+
+---
+
+## 31. The Local Sovereignty Tier — Physics as a Governance Input *(NEW 2026-08-18)*
+
+> **Operator binding (2026-08-18)**: *"Execute the integration of this local
+> sovereignty tier, specifically bridging my current macOS M1 (16GB)
+> development environment with the Windows RTX 5090 inference host."* — and,
+> on lane sizing: *"do not just hardcode `JARVIS_BG_POOL_SIZE=1`."*
+
+### 31.0 The thesis — a budget is a claim about hardware
+
+Every route budget in this document (§9, and the table in `route_budgets.py`)
+is a promise: *an op of this class completes in this many seconds*. That
+promise was written against a **metered remote provider**, where concurrency
+is somebody else's problem — three requests to Claude or DoubleWord are served
+by three different machines.
+
+A local serving tier breaks that assumption silently. **One GPU serving three
+concurrent requests serves them SERIALLY.** The three lanes do not triple
+throughput; they triple each op's wall-clock. The budget is unchanged, so the
+tail blows it, and the loop records a failure class it already has a name for:
+`tool_loop_deadline_exceeded`.
+
+Nothing in the codebase was wrong. `JARVIS_BG_POOL_SIZE=3` was correct for the
+regime it was calibrated in. What was missing is that **the pool had no way to
+know which regime it was in** — and the fix for that is not a smaller
+constant. A smaller constant is the same defect with a different number: still
+a guess, still blind to the hardware it runs on, and now also wrong on the
+Windows host where three lanes may be entirely reasonable.
+
+The governing principle this section adds to §8:
+
+> **Concurrency is not a configuration value. It is a measurement about the
+> serving substrate, and it belongs to whoever measured it.**
+
+### 31.1 What shipped
+
+Two commits on `feat/throughput-governor-and-multi-device-topology`.
+
+#### 31.1.1 `9c322f380e` — ThroughputGovernor: lanes derived from measured latency
+
+`governance/throughput_governor.py`. The whole module is a binding between
+instruments that already existed and had never been connected:
+
+| Instrument | Already did | Was never used for |
+|---|---|---|
+| `LatencyProfiler` | measures TTFT + per-token cost, warm-started across runs from the file-backed physics ledger | sizing concurrency |
+| `MemoryPressureGate` | caps fan-out by memory level | the worker pool's lane count |
+| `BackgroundAgentPool.set_target_pool_size` | accepts a lane target | anything but fleet topology |
+
+The math:
+
+```
+lanes = floor( (budget_ms x safety_fraction) / per_op_ms )
+```
+
+`per_op_ms` is **not re-derived**. It is `LatencyProfiler.adaptive_timeout_ms`
+— the same estimator the dispatch path already trusts (measured TTFT +
+per-token x expected output + sigma margin, clamped to its own floor and
+ceiling). Re-deriving it would have created a second opinion about one set of
+physics, which is the drift class §12 exists to prevent.
+
+`safety_fraction` (default 0.6) is not a fudge factor. The route budget must
+also cover everything the op does BESIDES token generation — Venom tool
+round-trips, VALIDATE, the Iron Gate, SemanticGuardian's AST pass — while
+`adaptive_timeout_ms` estimates only the generation leg. Spending the whole
+budget on generation would guarantee the breach this exists to prevent.
+
+**Composition, not a second authority.** The verdict is deliberately NOT
+pushed through `set_target_pool_size`. That setter carries the Immutability
+Lock: `source="fleet_topology"` is hardware-derived truth and silently rejects
+every other source while held. A throughput number pushed through it would
+either vanish exactly where a serving mesh exists, or would have to outrank
+hardware truth — and it must not. The two are **different axes and both are
+real**:
+
+- **topology** answers *how many lanes exist* (nodes in the serving mesh);
+- **throughput** answers *how many can be driven* inside the route window.
+
+Four nodes can exist while a 16GB M1 drives one. The pool consults the
+governor cooperatively and composes strictest-wins, so each stays
+authoritative on its own axis.
+
+**Hold, never retire.** A topology retire is a permanent `break` and correct —
+a node either exists or it does not. A throughput ceiling comes from a reading
+with a ~30s TTL, so breaking on it would make a transient measurement (a cold
+model load, a memory spike) an irreversible decision. Excess lanes `await` and
+re-check, and grow back for free when physics improves. Named *hold* and not
+*park* because `ParkRequested` / `ParkedOpStore` already mean OP-level
+suspend-and-resume in that module.
+
+**Every verdict states its provenance.** `adaptive_timeout_ms` CLAMPS to its
+ceiling, and a clamp reported as a measurement is a fabricated reading — the
+same class the Advisor's blast-radius provenance work exists to prevent
+(`localized_lower_bound` vs `synthetic_cap`). Verdicts carry:
+
+| provenance | meaning | consequence |
+|---|---|---|
+| `measured` | the estimator's own value, unclamped | trust it |
+| `ceiling_clamped` | the estimate SATURATED its ceiling | per-op cost is a **lower bound**, so the lane count is conservative |
+| `seeded` | fewer than `min_samples` in the ledger | the blind seed, not physics |
+| `wedged` | the estimator refused (runaway latency) | governed lanes=1 — information, not absence |
+
+The `measured` flag keys off `is_warm()` and **not** `is_calibrated()`. That
+distinction is load-bearing: `_calibrated` is a per-instance scout-lock flag
+the physics ledger does not persist, so a fresh instance reports `False` while
+serving genuinely measured numbers. `is_warm()` counts samples, which the
+ledger repopulates at `__init__`.
+
+**One route table, not three.** The route-to-timeout table had been written
+twice, byte-identical, in `orchestrator.py` and `phase_runners/generate_runner.py`
+(the second carrying a comment calling itself a "parity twin" of the first).
+The governor needed the same numbers. Rather than add a third copy, the table
+moved to `governance/route_budgets.py` and both sites read it.
+
+Masters: `JARVIS_THROUGHPUT_GOVERNOR_ENABLED` (default on; off is
+byte-identical to prior behaviour), `_SAFETY_FRACTION`, `_MAX_LANES`,
+`_VERDICT_TTL_S`, `_REFERENCE_PROMPT_TOKENS`.
+
+#### 31.1.2 `8485b819c5` — multi-device capacity made expressible
+
+`compute_topology.py` collapsed a multi-GPU host to its **largest single
+device**, with a rationale that is correct and stays the default:
+
+> *"A model must fit on one device unless it was sharded, and sharding is a
+> property of the serving stack rather than of the host; summing would
+> authorize a load that cannot physically land."*
+
+**This was therefore not a bug.** The gap is representational: the probe could
+not express that two devices exist and a sharding runtime could pool them, so
+the single number it reported was wrong for somebody. An RTX 5090 (32GiB)
+beside a 24GiB card is **32GiB to a stack that does not shard and 56GiB to one
+that does**.
+
+Both facts are now carried:
+
+- `DeviceReading` per device (index, name, total, free), enumerated by **both**
+  the torch and nvidia-smi stages;
+- `free_bytes` / `total_bytes` keep their exact prior semantics, so every
+  existing consumer is byte-identical;
+- `aggregate_free_bytes` / `aggregate_total_bytes` sum the enumerated devices;
+- `shardable_usable_bytes(sharding=)` composes them, and returns the
+  single-device answer for a single-device host **even when sharding is
+  declared**, so the flag cannot invent a card that is not there.
+
+`is_multi_device` keys off `len(devices)`, **not** `device_count > 1`: a probe
+stage can report a count while failing to enumerate, and an aggregate over
+devices never read would be a fabrication — the same discipline
+`free_is_measured` already enforces for derived free bytes.
+
+**Sharding is a declaration, not an inference.** Whether a model can span two
+GPUs is a property of the serving stack (llama.cpp/Ollama layer split, vLLM
+tensor parallel), which `compute_topology` deliberately knows nothing about.
+So `local_model_admission.accelerator_sharding_declared()` reads
+`JARVIS_LOCAL_ACCEL_SHARDING`, **default false**. The asymmetry sets the
+default: declaring sharding on a stack that does not shard admits a model that
+then fails to load, having already passed the gate whose whole job was to
+prevent that; declaring it off on a stack that does merely under-uses the
+second card.
+
+Decisions now say which bound they used — `bound="accelerator_pooled"` and a
+reason naming the device count when pooling applied.
+
+#### 31.1.3 Verification
+
+50 new tests. 350 green across the affected surface, identified by an AST
+sweep of the entire `tests/` tree for the changed module and symbol names
+(73 files touched the throughput surface, 4 the topology surface). One
+genuine orphan was found and repaired: `test_sovereign_override` asserted an
+env var's presence in orchestrator **source** — a test of spelling, which the
+extraction broke while the behaviour was untouched. It now asserts the
+property its own docstring claims.
+
+Live-fire, not unit-green: the governor was driven against a real
+`qwen2.5-coder:3b` on a running Ollama, and the pool was observed holding
+workers 1 and 2 alive while a subsequent topology retire killed them.
+
+> **Two defects in this change's own code, caught by its own tests.** (1) The
+> consult first reached a route budget via `self._config`, which
+> `BackgroundAgentPool` does not own — every call raised, the broad `except`
+> swallowed it, and the wiring was **dead while looking live**. (2) The
+> log-dedup key was pool-level, so the second and third held workers were
+> deduped away and the log read as one held lane when three were. Both are
+> instances of the class §28 named: a capability needs a live caller on the
+> default path, and an observability surface that under-reports is not
+> observability.
+
+### 31.2 The measured envelope
+
+#### 31.2.1 macOS M1, 16GB unified — the development host
+
+Measured 2026-08-18 against live `qwen2.5-coder:3b` via the real
+`LocalPrimeClient.complete()` seam:
+
+| sample | TTFT | total | out | note |
+|---|---|---|---|---|
+| 1 | 3232 ms | 32321 ms | 25 tok | cold — model load |
+| 2 | 193 ms | 1933 ms | 23 tok | warm |
+| 3 | 311 ms | 3112 ms | 28 tok | warm |
+| 4 | 418 ms | 4177 ms | 31 tok | warm |
+| 5 | 350 ms | 3503 ms | 33 tok | warm |
+
+Derived: ~95 ms/token warm. With `output_ratio = 0.5`, an 8000-token
+CONTEXT_EXPANSION prompt predicts **4000 output tokens ≈ 380 s of generation
+alone** against a 180 s BACKGROUND window.
+
+> **Verdict: this host drives ONE lane, and the governor derives that number
+> rather than being told it.** The `3` in `JARVIS_BG_POOL_SIZE` was never a
+> statement about this machine.
+
+Two profiler distortions worth recording, both pre-existing:
+
+1. **Cold-load amortization.** `record()` computes
+   `per_tok = (total - ttft) / output_tokens`. A cold op with small output
+   folds MODEL-LOAD time into per-token cost — measured 1163 ms/tok cold
+   versus ~95 ms/tok warm, a 12x outlier that pins the estimate at its ceiling
+   for the length of the sample window.
+2. **Ceiling saturation.** Consequently `adaptive_timeout_ms(8000)` returns
+   exactly `timeout_ceiling_ms` (120000). The governor now labels that
+   `ceiling_clamped` rather than reporting a clamp as a measurement.
+
+#### 31.2.2 Windows inference host — the target
+
+```
+CPU  AMD Ryzen 9 9950X3D
+GPU  NVIDIA RTX 5090 Founders Edition   32 GB GDDR7
+GPU  second NVIDIA card                 24 GB
+RAM  64 GB DDR5 (dual channel)
+```
+
+| pool | bytes |
+|---|---|
+| largest single device | **32 GB** |
+| pooled VRAM (sharding declared) | **56 GB** |
+| VRAM + system RAM (weights may live in either) | **120 GB** |
+
+This is precisely the host the §31.1.2 work exists for: without it, the
+admission gate sees 32 GB and refuses a model that would fit across both
+cards; with sharding blindly summed, it would admit models that cannot land on
+a non-sharding stack. Both failure modes are now avoidable, and which one
+applies is stated rather than assumed.
+
+### 31.3 Can a 1T–2.4T model run on that box? — answered with arithmetic
+
+**Short answer: no, and the gap is not close enough to engineer around.**
+
+`Qwen3.8-Max` is `Qwen3.8-2.4T-A95B`: **2.4T total parameters, 95B active**,
+512 experts (10 routed + 1 shared per token), 92 layers, 256K native context
+extensible to ~1M.
+
+The single most common MoE sizing error is reading the active count as the
+memory footprint. **Active parameters set SPEED; total parameters set
+RESIDENCY.** Every one of the 512 experts must be reachable, because routing
+picks different ones each token.
+
+Published sizes:
+
+| format | size | source |
+|---|---|---|
+| BF16 (native) | **4.9 TB** | Unsloth |
+| INT4 | 600 GB – 1 TB | MindStudio |
+| IQ1_S | 508 GB | Unsloth |
+| **Unsloth Dynamic 1-bit GGUF (smallest that exists)** | **397 GB** | Unsloth |
+
+Against 120 GB of addressable memory on the target box:
+
+```
+397 GB  smallest quantized form in existence
+120 GB  VRAM + system RAM
+-----
+277 GB  short  ->  3.3x over, at ~1.32 bits per parameter
+```
+
+There is no quantization below ~1 bit. The deficit cannot be closed by
+compression.
+
+**Could it stream from NVMe?** `llama.cpp` will mmap a model larger than RAM
+and page from disk, so it would technically emit tokens. The arithmetic:
+
+- 95B active x ~1.32 bpw ≈ **15.7 GB read per forward pass**
+- ~30% of the file is resident (120 of 397 GB), so ~11 GB per token from NVMe
+- MoE routing scatters those reads across 512 experts x 92 layers — poor
+  locality, so a PCIe 5.0 drive's ~14 GB/s sequential figure does not apply;
+  2–5 GB/s effective is the realistic band
+- **≈ 2.2–5.5 s per token → 0.18–0.45 tok/s**
+
+A 500-token reply is 18–46 minutes. The 4000-token generation O+V's own
+`output_ratio` predicts for an 8K prompt is **2.5–6 hours**.
+
+**Calibration against a model that does work.** Kimi K2 (1T total, **32B
+active**) at Unsloth Dynamic 1.8-bit is 245 GB and reports ~5 tok/s on 24 GB
+VRAM + 256 GB RAM. Note why: 280 GB of memory holds a 245 GB file — it
+**fits**. The target box does not fit even the 1-bit Qwen, and Qwen3.8-Max has
+**3x the active parameters** of Kimi K2, so it moves 3x the bytes per token at
+equivalent residency.
+
+**What would actually be required** to run Qwen3.8-Max locally at all:
+
+| requirement | implication |
+|---|---|
+| ≥ 448 GB RAM+VRAM (397 GB weights + KV cache + headroom) | 512 GB DDR5 RDIMM on Threadripper PRO / EPYC — a different machine class, not an upgrade |
+| ≥ 8 memory channels | 95B active x 1.32 bpw = 15.7 GB/token; dual-channel DDR5 (~96 GB/s) caps at ~6 tok/s theoretical before overheads |
+| realistic outcome | ~4–8 tok/s |
+
+**And here is the conclusion that matters for O+V**, which no amount of
+hardware fixes: at 5 tok/s, the 4000-token generation predicted for a standard
+CONTEXT_EXPANSION prompt takes **800 s**. Every route budget — IMMEDIATE 120 s,
+STANDARD 220 s, COMPLEX 240 s, BACKGROUND 180 s — is blown by a single
+response, on hardware costing five figures.
+
+> **The local tier's job is not to run the biggest model. It is to run a model
+> whose per-op cost fits a route budget.** A 2.4T model is not "too big for
+> the GPU"; it is too slow for the loop, and would remain so after the GPU
+> problem was solved. This is exactly the property §31.1.1's governor now
+> measures and enforces — pointed at such a model it would return
+> `provenance=ceiling_clamped, lanes=1` and the deadline machinery would
+> record the breach honestly.
+
+Sources: [Unsloth Qwen3.8 GGUF](https://huggingface.co/unsloth/Qwen3.8-2.4T-A95B-GGUF) ·
+[vLLM recipe (2.4T/95B)](https://recipes.vllm.ai/Qwen/Qwen3.8-2.4T-A95B) ·
+[MindStudio hardware analysis](https://www.mindstudio.ai/blog/run-qwen3-8-locally-hardware) ·
+[Unsloth Kimi K2](https://huggingface.co/unsloth/Kimi-K2-Instruct-GGUF) ·
+[Trillion-parameter-at-home guide](https://hackmd.io/msiciwuST9mn3sgSPSyENw)
+
+### 31.4 Which models suit O+V — derived from the budget, not from a leaderboard
+
+#### 31.4.1 The selection criterion is arithmetic, not taste
+
+O+V's local tier serves the BACKGROUND and SPECULATIVE routes (§5 —
+OpportunityMiner, DocStaleness, TODOs, backlog, IntentDiscovery). Its budget is
+**180 s**, of which the governor allows `safety_fraction = 0.6` for generation:
+**108 s**. `output_ratio = 0.5` predicts **4000 output tokens** for an 8000-token
+CONTEXT_EXPANSION prompt. Therefore:
+
+```
+lanes = 1  requires  per_token <= 108s / 4000 tok  ~=  27 ms   ->  >=  40 tok/s
+lanes = 3  requires  per_token <=  36s / 4000 tok  ~=   9 ms   ->  >= 120 tok/s
+```
+
+> **A local model is admissible for O+V if and only if it sustains ~40 tok/s at
+> the target context.** Below that, it cannot complete one BACKGROUND op inside
+> the window no matter how good its code is. This is the number to shop for —
+> not parameter count, and not SWE-bench alone.
+
+Second hard requirement: **tool-calling fidelity.** Venom is a multi-turn loop
+over 16 built-in tools plus MCP-forwarded external tools, and the Iron Gate
+requires ≥2 exploration calls before any patch is accepted. A model that emits
+malformed tool calls does not degrade gracefully here — it fails the
+exploration gate, routes through GENERATE_RETRY, and burns the budget twice.
+
+Third: **context.** Tool results accumulate until compaction fires at 75% of
+budget. 128K+ is comfortable; 256K removes the concern.
+
+#### 31.4.2 The shortlist
+
+Sizes are Q4-class quantized weights. **Throughput figures marked (est.) are
+derived from memory bandwidth and are not measurements** — the governor will
+replace them with real numbers on first contact, and that is the point.
+
+| Model | Total / active | Q4 size | Context | Fits 5090 alone (32GB)? | Throughput | O+V verdict |
+|---|---|---|---|---|---|---|
+| **Qwen3-Coder-30B-A3B** | 30B / 3.3B MoE | ~19 GB | 256K → 1M | yes, with room | **220 tok/s** (reported) | **Best fit.** Clears the 3-lane bar with margin. The active-parameter count is what makes it fast. |
+| **Qwen3.8-27B** | 28B dense + vision | **17.8 GB** (Q4_K_M) | 256K native | yes | ~50–70 tok/s (est.) | **Best quality that still clears 1 lane.** Hybrid attention caches only 16 of 64 layers: KV is 0.5 GB @8K, 2.0 GB @32K, 16.4 GB @262K — unusually cheap. Apache-2.0. |
+| **Llama-3.3-70B** | 70B dense | ~40 GB | 128K | no — needs both cards | ~15–20 tok/s (est.) | **Below the bar.** Dense 70B cannot sustain 40 tok/s on this hardware. |
+| **gpt-oss-120b** | 117B / 5.1B MoE | **~60 GB** MXFP4 | 128K | no — 60 GB > 56 GB pooled | fast if resident (5.1B active) | **Marginal.** Weights alone exceed pooled VRAM; needs RAM spill plus KV cache, and vendor guidance says 80–96 GB. Revisit if a third card or 96 GB-class VRAM appears. |
+| **Kimi K2 / DeepSeek-class 1T** | 1T / 32B | 245 GB @1.8-bit | — | no | ~5 tok/s at best | **Out of scope** — see §31.3. |
+| **Qwen3.8-Max (2.4T-A95B)** | 2.4T / 95B | **397 GB** @1-bit | 256K–1M | no — 3.3x over | 0.18–0.45 tok/s streamed | **Impossible on this box, and unusable for O+V even on hardware that fits it.** |
+
+**Recommendation for the Windows host, in deployment order:**
+
+1. **`Qwen3-Coder-30B-A3B`** as the BACKGROUND/SPECULATIVE workhorse — it is
+   the only entry that clears the 3-lane bar, so it is the one that makes the
+   pool's parallelism real rather than nominal.
+2. **`Qwen3.8-27B`** as the quality tier for COMPLEX-adjacent local work,
+   where one lane at higher fidelity beats three at lower. Its vision encoder
+   also lines up with the existing multi-modal ingest path
+   (`ctx.attachments` → GENERATE) and VisionSensor.
+3. Both fit the 5090 **alone**, which means `JARVIS_LOCAL_ACCEL_SHARDING` can
+   stay **off** and the second card is free to host the other model
+   concurrently — two resident models, no layer splitting, no pooled-capacity
+   risk. That is a strictly better use of 56 GB than one model spanning both.
+
+> Note the shape of that recommendation: the second GPU's value here is
+> **another independent lane**, not a bigger model. Which is the same
+> conclusion §31.1.1 reached from the other direction.
+
+Sources: [Qwen3.8-27B GGUF sizes](https://ofox.ai/blog/qwen-3-8-27b-run-locally-vram-gguf-2026/) ·
+[Qwen3-Coder-30B](https://www.morphllm.com/best-ollama-models) ·
+[gpt-oss-120b requirements](https://yingtu.ai/en/blog/gpt-oss-120b-memory-requirements)
+
+### 31.5 What the bridge exposes — latent defects to close before Gap 3
+
+The M1→Windows bridge is mostly configuration (`JARVIS_LOCAL_MODEL_BASE_URL`,
+default `http://127.0.0.1:11434`). But routing one host's governor at another
+host's GPU surfaces three real issues that do not exist while everything is
+local:
+
+1. **`physics_key` conflates hosts.** It is `model_name@num_ctx` —
+   deliberately not the endpoint, because *"node IPs change every run; the
+   physics belongs to the brain+window."* That reasoning holds for a mesh of
+   like machines. It does **not** hold across a 16 GB M1 and a 5090: the same
+   model name on both writes to one ledger key, and the M1's ~95 ms/token
+   would govern the 5090's lane count. **The key needs a hardware-class
+   component before the bridge carries load** — and the class, not the IP, so
+   the original rationale survives.
+2. **The lane ceiling is pool-level, not route-level.** The pre-dequeue gate
+   sizes against `DEFAULT_POOL_ROUTE` (background) because it does not yet
+   hold an op. Correct for a pool that predominantly serves that route;
+   wrong once a remote host makes SPECULATIVE genuinely cheap and IMMEDIATE
+   genuinely viable.
+3. **Network latency is inside `per_op_ms` but is not model physics.** Once
+   the M1 measures a remote endpoint, TTFT includes the LAN round trip. That
+   is honest for lane sizing (the wall-clock is real), but it pollutes the
+   ledger's claim to be *model* physics. Worth a `transport` dimension before
+   the ledger is trusted for anything else.
+
+### 31.6 Priorities — what to do next, ranked
+
+Ranked by *leverage per line changed*, the §28 criterion.
+
+| # | Item | Why it is here | Cost | Blocked on |
+|---|---|---|---|---|
+| **1** | **`physics_key` hardware-class component** (§31.5.1) | Without it the bridge governs a 5090 with an M1's physics. This is a correctness bug that only appears under the exact configuration we are building toward. | S | nothing |
+| **2** | **Deploy `Qwen3-Coder-30B-A3B` + `Qwen3.8-27B` on the Windows host**, one per card | Turns the second GPU into a second lane. Makes the governor's arithmetic testable against hardware that can actually clear the bar. | S | machine powered on |
+| **3** | **Prove the dual-GPU probe end to end** — `nvidia-smi` enumeration, `is_multi_device`, admission with sharding both on and off | §31.1.2 is unit-proven and live-unproven. Every capability in this repo that shipped unproven eventually shipped broken. | S | machine powered on |
+| **4** | **Route-aware lane ceiling** (§31.5.2) | Re-gate after dequeue using the op's own route, reusing the existing re-enqueue idiom. | M | #2 |
+| **5** | **Observed sharding outranks the declared flag** | A stack reporting a resident model larger than its largest single device has **proven** sharding. Turns a trusted flag into a measurement — the same upgrade the physics ledger already represents. | M | #3 |
+| **6** | **Cold-load outlier isolation** (§31.2.1) | Recording model-load as per-token cost pins the estimator at its ceiling for a full sample window, which currently makes every M1 verdict `ceiling_clamped`. Record load separately. | M | nothing |
+| **7** | **Fix the pre-existing DRY red** — `local_model_admission._read_swapin_bytes` imports `psutil` directly (`f2c3974ddc`), which `test_dry_admission_derives_neither_reading_itself` forbids. Expose swap-in via `memory_pressure_gate`. | Red on `main` today; it will fail every PR touching that file. | S | nothing |
+| **8** | **`InferenceGateway` abstraction** — one seam for local/remote endpoint selection, health, and backpressure | The original Gap 3 ask. Deliberately last: three of its inputs (lane ceiling, pooled capacity, per-endpoint physics) had to exist first, and two of them now do. | L | #1, #4 |
+
+**Not scheduled, and deliberately so:** anything aimed at running a 1T+ model
+locally. §31.3 shows the ceiling is not a hardware-budget problem but a
+tokens-per-second problem that persists on hardware costing five figures. The
+capability O+V gains from a bigger local model is smaller than the capability
+it gains from item #2.
+
+### 31.7 Invariants this section adds
+
+1. **A lane count must be derived or declared, never assumed.** A constant in
+   an env var is a measurement someone took once, on a machine that may not be
+   this one.
+2. **Topology and throughput are separate authorities.** Neither may overwrite
+   the other; they compose strictest-wins. A capability that has to defeat an
+   existing authority to function is modelled wrong.
+3. **A clamped estimate is a lower bound and must say so.** Extends the
+   Advisor's blast-provenance rule (§26) to latency.
+4. **Pooled capacity requires a declared or observed sharding capability.**
+   Summing device memory without one authorizes a load that cannot land.
+5. **A reversible constraint must use a reversible mechanism.** A ~30 s
+   reading may hold a worker; only a permanent fact may retire one.
+6. **The local tier is bounded by the route budget, not by VRAM.** A model is
+   admissible when its per-op cost fits the window — see §31.4.1 for the
+   arithmetic that turns this into a purchasing criterion.

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -118,6 +118,7 @@
     - [31.5 What the bridge exposes — latent defects to close before Gap 3](#315-what-the-bridge-exposes--latent-defects-to-close-before-gap-3)
     - [31.6 Priorities — what to do next, ranked](#316-priorities--what-to-do-next-ranked)
     - [31.7 Invariants this section adds](#317-invariants-this-section-adds)
+    - [31.8 The local tier, configured — deployment profile and warm-swap protocol](#318-the-local-tier-configured--deployment-profile-and-warm-swap-protocol-2026-08-18)
 
 ## 1. Executive Summary
 
@@ -4932,6 +4933,159 @@ locally. §31.3 shows the ceiling is not a hardware-budget problem but a
 tokens-per-second problem that persists on hardware costing five figures. The
 capability O+V gains from a bigger local model is smaller than the capability
 it gains from item #2.
+
+### 31.8 The local tier, configured — deployment profile and warm-swap protocol *(2026-08-18)*
+
+> **Operator binding**: *"We will adopt Qwen3-Coder-30B-A3B as the resident
+> background workhorse on the Windows RTX 5090, keeping Qwen3.8-27B on disk
+> for specialized visual or high-fidelity one-offs."*
+
+#### 31.8.1 Why the MoE wins on THIS card
+
+The decision is hardware-specific and does not generalise. Both candidates
+cost roughly the same VRAM; they cost wildly different **memory traffic per
+token**, which is what sets decode speed:
+
+| | Qwen3-Coder-30B-A3B | Qwen3.8-27B |
+|---|---|---|
+| Architecture | **MoE** — 30B total, **3.3B active** | **Dense** — 28B, all active |
+| VRAM to load (Q4) | ~19 GB | ~17.8 GB |
+| **Bytes read per token** | **~1.9 GB** | **~17.8 GB** |
+| Decode on the 5090 | **~220 tok/s** (reported) | ~50–70 tok/s (est.) |
+
+A dense model reads every weight for every token; an MoE routes each token
+through a few experts while all experts stay resident. **The MoE pays the
+capacity price of 30B and the bandwidth price of 3.3B.**
+
+The 5090 has 32 GB of capacity and ~1.8 TB/s of bandwidth. Either model
+leaves ~13 GB unused, so **capacity is the surplus and bandwidth is the
+constraint** — and MoE is precisely the architecture that trades the abundant
+resource for the scarce one. The same choice would be *wrong* on a 16 GB card,
+where the 30B MoE does not fit at all; this is not a general preference.
+
+Against the §31.4.1 lane arithmetic (108 s of generation allowance, ~4000
+predicted output tokens):
+
+| | Time per op | Lanes |
+|---|---|---|
+| Coder-30B-A3B | ~18 s | ⌊108/18⌋ = 5 → capped to **3** |
+| Qwen3.8-27B | ~67 s | ⌊108/67⌋ = **1** |
+
+Three lanes is meaningful on ONE card because the governor's math already
+accounts for serialisation: 3 × 18 s = 54 s of GPU time fits inside the 108 s
+allowance, so all three finish within budget. Two dense ops would need 134 s
+and **both** would breach.
+
+#### 31.8.2 The argument that actually decides it — retry economics
+
+O+V is by design a **high-rejection architecture**. The Iron Gate,
+the ASCII gate, AST/placeholder validation, SemanticGuardian and the
+multi-file coverage gate can each independently force a full regeneration.
+Rejection is a routine path, not an exception.
+
+That inverts the usual "smarter model wins" reasoning: **where regeneration is
+common, a 3.7× faster model makes every rejection 3.7× cheaper.** For a
+realistic BACKGROUND op — 6 tool rounds plus a final patch, ~3,300 output
+tokens against a growing prompt:
+
+| | Coder-30B-A3B | Qwen3.8-27B |
+|---|---|---|
+| Decode + prefill across the op | ~30 s | ~95 s |
+| Left inside the 108 s allowance | **~78 s** | **~13 s** |
+| Must still cover | VALIDATE (pytest), Iron Gate, SemanticGuardian, **and any retry** | same |
+
+13 s does not cover a pytest run, let alone a retry. The dense model does not
+merely run slower — **it cannot absorb a single rejection inside a BACKGROUND
+budget.**
+
+> **Benchmark caution.** Qwen3.8-27B's 163/164 HumanEval is close to
+> irrelevant here: HumanEval measures single-function synthesis from a
+> docstring, and O+V never does that. It does multi-round, tool-driven,
+> multi-file repo edits behind five rejection gates. Different skill,
+> different bottleneck.
+
+What the dense model retains: better per-response quality, and a **vision
+encoder**. The latter matters less than it appears — VisionSensor's Tier 2
+already uses Qwen3-VL-235B, so local vision is not on the coding model's
+critical path. It stays on disk for that work, at the cost of a swap.
+
+#### 31.8.3 Two machines, two kinds of setting
+
+`deploy/local_tier_windows.env` is the single activation artifact, and it is
+explicit about a distinction that is easy to get wrong:
+
+* **`OLLAMA_*` are read by `ollama serve` ON THE WINDOWS HOST.** JARVIS cannot
+  set them remotely, and sourcing the profile on the Mac does not apply them.
+  `OLLAMA_KEEP_ALIVE=-1` (never evict), `OLLAMA_MAX_LOADED_MODELS=1`
+  (co-residency is impossible anyway: 19 + 17.8 = 36.8 GB against 32 GB before
+  KV, so pinning it makes eviction deterministic rather than emergent), and
+  `OLLAMA_KV_CACHE_TYPE=q8_0` (Qwen3.8-27B's ~62.5 KiB/token means a full
+  262 K context is ~16.4 GiB at fp16 and does **not** fit alongside weights;
+  q8 roughly halves it and the native window fits).
+* **`JARVIS_*` are read where the orchestration runs**, normally the Mac.
+
+Client-side keep-alive needed **no new code**: `LocalConfig.keep_alive_seconds`
+already flows into the request body as ollama's `keep_alive`, and `-1` survives
+parsing verbatim. The one hazard is that the same value also feeds the aiohttp
+connector; `max(30, keep_alive_seconds)` is what stops one env var from meaning
+two incompatible things, and is pinned by test.
+
+#### 31.8.4 The pre-flight warm-swap protocol
+
+**The failure it prevents.** Ollama loads a model on first use. If the resident
+model is the 30B coder and an op requests the 27B, that request pays a cold
+load **inside its own generation window** — a window calibrated for generation,
+not for PCIe transfer. The op then dies on a deadline that says nothing about
+the model's speed, which is the most misleading failure this tier can produce.
+
+So residency is verified and repaired as an explicit handshake **before the
+op's clock starts**, against a budget of its own
+(`JARVIS_GATEWAY_WARM_SWAP_BUDGET_S`, default 180 s) rather than the route's.
+
+Four design points, each rejecting an easier answer:
+
+1. **`/api/ps`, not `/api/tags`.** Tags answers "what is installed"; ps answers
+   "what is loaded". The former is already memoised elsewhere in this codebase
+   and would answer the wrong question — a model can be installed and not
+   resident, which is exactly the case a swap exists to handle.
+2. **`None` is not `()`.** A server that does not implement `/api/ps` (vLLM, an
+   older ollama) returns unknowable. Reading that as "nothing is loaded" would
+   make every op trigger a needless swap. Empty tuple means the endpoint
+   answered and genuinely holds nothing. *Live-verified against a real ollama:
+   `()` before any load, `('qwen2.5-coder:3b',)` after, `None` when
+   unreachable.*
+3. **Tag-tolerant matching.** `qwen3-coder:30b` and
+   `qwen3-coder:30b-instruct-q4_K_M` are the same weights to an operator and
+   different strings to a registry; a bare name reports as `:latest`. An
+   over-strict comparison burns a cold load to load what is already loaded.
+4. **The swap runs OUTSIDE the failure classifier.** A slow cold load is not a
+   host fault, and counting it would open the breaker on a healthy machine that
+   was merely loading. Pinned structurally by AST test.
+
+It composes the EXISTING `LocalPrimeClient.warmup()` — which already forces
+weights into VRAM under a dedicated cold-start HTTP context — rather than
+adding a second cold-load path.
+
+#### 31.8.5 What was NOT built, and why
+
+Three of this arc's four requirements turned out to be satisfiable by existing
+machinery, and building them again would have created second authorities:
+
+| Requirement | Already existed |
+|---|---|
+| Streaming inter-token timeout | `LocalPrimeClient._complete_streaming` + `InterTokenStall` — the gateway only had to **arm** it (`stream=True`) on the remote path |
+| Model residency forcing | `LocalPrimeClient.warmup(timeout_s=)` |
+| Client-side keep-alive | `LocalConfig.keep_alive_seconds` → request body |
+| Local triage fallback | `InferenceGateway._local_target()`, one builder, DRY-pinned |
+
+The genuinely new surface is small: a bounded `/api/ps` probe, a tag-tolerant
+match, a TTL'd residency cache, and the decision to spend a swap budget
+outside the op clock.
+
+**Regression spine:** 26 tests in `tests/governance/test_local_tier_profile.py`,
+including a structural pin that **every `JARVIS_*` setting in the profile is
+read by code** — a profile documenting a knob nothing consults is the same
+defect class as a capability with no caller.
 
 ### 31.7 Invariants this section adds
 

--- a/scripts/live_fire_local_tier.py
+++ b/scripts/live_fire_local_tier.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Live-fire validation of the local sovereignty tier. No mocks, no fakes.
+
+Drives the REAL `InferenceGateway`, the REAL `LatencyProfiler` ledger and the
+REAL `ThroughputGovernor` against a REAL serving endpoint. There is no separate
+diagnostic channel: every number printed is read back out of the same objects
+the running system consults, because a diagnostic that observes a parallel copy
+of the state proves nothing about the state.
+
+    # against the Windows host over the LAN
+    python3 scripts/live_fire_local_tier.py --endpoint http://192.168.1.50:11434 \
+                                            --model qwen3-coder:30b
+
+    # against whatever this machine is serving (harness self-validation)
+    python3 scripts/live_fire_local_tier.py --endpoint http://127.0.0.1:11434 \
+                                            --model qwen2.5-coder:3b
+
+    # one phase at a time
+    python3 scripts/live_fire_local_tier.py --phase 3
+
+PHASE 1  residency probe + autonomous warm-swap handshake
+PHASE 2  closed-loop telemetry: ledger fills, governor re-sizes lanes
+PHASE 3  fault injection: a peer that accepts, emits, then goes SILENT
+
+Phase 3 does NOT stop your ollama. It stands up a deliberately wedged listener
+on loopback and points the gateway at it, so the failure is DETERMINISTIC and
+your serving host is never disturbed. Killing a real service would prove the
+same path less reliably and cost you a cold reload.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import json
+import os
+import sys
+import time
+from typing import Any, Optional, Tuple
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from backend.core.ouroboros.governance import hardware_signature as hs  # noqa: E402
+from backend.core.ouroboros.governance import inference_gateway as ig  # noqa: E402
+from backend.core.ouroboros.governance import local_inference_director as lid  # noqa: E402
+from backend.core.ouroboros.governance import throughput_governor as tg  # noqa: E402
+from backend.core.ouroboros.governance.route_budgets import (  # noqa: E402
+    route_generation_budget_s,
+)
+
+OK, BAD, WARN, DIM = "\033[32m", "\033[31m", "\033[33m", "\033[2m"
+END = "\033[0m"
+
+
+def _say(sym: str, colour: str, msg: str) -> None:
+    print(f"  {colour}{sym}{END} {msg}", flush=True)
+
+
+def ok(m): _say("PASS", OK, m)
+def bad(m): _say("FAIL", BAD, m)
+def warn(m): _say("WARN", WARN, m)
+def info(m): print(f"       {DIM}{m}{END}", flush=True)
+
+
+def banner(n: int, title: str) -> None:
+    print(f"\n{'=' * 72}\nPHASE {n} — {title}\n{'=' * 72}", flush=True)
+
+
+def _cfg_for(endpoint: str, model: str) -> Any:
+    return dataclasses.replace(
+        lid.LocalConfig.from_env(), base_url=endpoint, model_name=model)
+
+
+def _ledger_entry(cfg: Any, endpoint: str) -> Tuple[str, dict]:
+    """Read the DURABLE ledger the governor actually consults."""
+    key = lid.physics_key(cfg, endpoint=endpoint)
+    return key, (lid._physics_ledger_load().get(key) or {})
+
+
+# ---------------------------------------------------------------- PHASE 1
+async def phase1(gw: "ig.InferenceGateway", endpoint: str, model: str,
+                 swap_model: Optional[str]) -> bool:
+    banner(1, "LIVE LAN PROBE + RESIDENCY VERIFICATION")
+    passed = True
+
+    sig = hs.signature_for(endpoint)
+    info(f"endpoint      : {endpoint}")
+    info(f"hardware sig  : {sig.digest}  (provenance={sig.provenance})")
+    if sig.provenance == "endpoint":
+        ok("remote host has its OWN signature — its physics cannot land in "
+           "this machine's ledger")
+    elif sig.provenance == "probed":
+        warn("endpoint resolves as LOCAL — this is a loopback run, not a LAN run")
+
+    t0 = time.monotonic()
+    resident = await gw.resident_models(endpoint)
+    rtt = (time.monotonic() - t0) * 1000.0
+
+    if resident is None:
+        bad(f"/api/ps unreachable or unparseable after {rtt:.0f}ms")
+        info("the gateway treats this as UNKNOWABLE (not empty) and will "
+             "dispatch without a swap — verify the host is up and bound to "
+             "0.0.0.0, and that a firewall permits :11434 from this machine")
+        return False
+    ok(f"/api/ps answered in {rtt:.0f}ms — resident: {list(resident) or '<none>'}")
+
+    if ig.InferenceGateway._model_matches(model, resident):
+        ok(f"'{model}' is RESIDENT — no swap needed")
+    else:
+        warn(f"'{model}' is NOT resident (resident: {list(resident)})")
+
+    target = ig.GatewayTarget(base_url=endpoint, model_name=model,
+                              scope="remote", state=ig.HostState.HEALTHY,
+                              reason="live-fire")
+    t0 = time.monotonic()
+    rep = await gw.ensure_model_resident(target)
+    info(f"pre-flight    : {json.dumps(rep, default=str)[:200]}")
+    info(f"elapsed       : {(time.monotonic() - t0):.1f}s "
+         f"(budget {ig.warm_swap_budget_s():.0f}s, paid OUTSIDE any op clock)")
+    if rep.get("checked"):
+        ok("pre-flight ran and reported residency")
+    else:
+        bad("pre-flight did not run")
+        passed = False
+
+    if swap_model:
+        info(f"forcing a warm-swap handshake to '{swap_model}' …")
+        swap_target = dataclasses.replace(target, model_name=swap_model)
+        t0 = time.monotonic()
+        rep2 = await gw.ensure_model_resident(swap_target)
+        dt = time.monotonic() - t0
+        if rep2.get("swapped"):
+            ok(f"autonomous warm swap completed in {dt:.1f}s")
+        else:
+            warn(f"no swap performed: {rep2.get('reason')}")
+        after = await gw.resident_models(endpoint)
+        info(f"resident after: {list(after) if after is not None else 'unknown'}")
+    return passed
+
+
+# ---------------------------------------------------------------- PHASE 2
+async def phase2(gw: "ig.InferenceGateway", endpoint: str, model: str,
+                 rounds: int) -> bool:
+    banner(2, "CLOSED-LOOP TELEMETRY + GOVERNOR RE-SIZING")
+    cfg = _cfg_for(endpoint, model)
+    key, before = _ledger_entry(cfg, endpoint)
+    budget = route_generation_budget_s("background")
+    info(f"ledger key    : {key}")
+    info(f"samples before: {len(before.get('total') or [])}")
+
+    tg.reset_for_tests()
+    v0 = tg.get_default_governor().evaluate(budget_s=budget)
+    info(f"governor pre  : lanes={v0.lanes} per_op={v0.per_op_ms:.0f}ms "
+         f"via={v0.provenance}")
+
+    prompt = ("Reply with exactly one short sentence naming the single biggest "
+              "risk in reusing one timeout constant for two different waits.")
+    lat = []
+    for i in range(rounds):
+        t0 = time.monotonic()
+        try:
+            r = await gw.dispatch(system="You are terse.", user=prompt,
+                                  prompt_tokens=lid.estimate_tokens(prompt),
+                                  route="background", max_tokens=48)
+        except Exception as exc:  # noqa: BLE001
+            bad(f"round {i+1}: {type(exc).__name__}: {str(exc)[:110]}")
+            return False
+        dt = time.monotonic() - t0
+        lat.append(dt)
+        tps = (r.output_tokens / (r.total_ms / 1000.0)) if r.total_ms else 0.0
+        info(f"round {i+1}/{rounds}: ttft={r.ttft_ms:7.0f}ms "
+             f"total={r.total_ms:8.0f}ms out={r.output_tokens:4d}tok "
+             f"{tps:6.1f} tok/s  wall={dt:5.1f}s")
+
+    key2, after = _ledger_entry(cfg, endpoint)
+    n_before, n_after = len(before.get("total") or []), len(after.get("total") or [])
+    if n_after > n_before:
+        ok(f"ledger GREW {n_before} -> {n_after} samples at {key2}")
+    else:
+        bad(f"ledger did NOT grow ({n_before} -> {n_after}) — telemetry is not "
+            f"reaching the profiler the governor reads")
+        return False
+
+    tg.reset_for_tests()
+    v1 = tg.get_default_governor().evaluate(budget_s=budget)
+    info(f"governor post : lanes={v1.lanes} per_op={v1.per_op_ms:.0f}ms "
+         f"via={v1.provenance} measured={v1.measured}")
+    if v1.measured:
+        ok("governor is now sizing lanes from MEASURED remote physics")
+    else:
+        warn(f"governor still '{v1.provenance}' — needs "
+             f"{cfg.min_samples} samples to warm")
+
+    prof = lid.LatencyProfiler(cfg, ledger_key=key2)
+    first_s, steady_s = prof.inter_token_budget_s()
+    static = lid._inter_token_timeout_s()
+    info(f"inter-token   : first={first_s:.1f}s steady={steady_s:.1f}s "
+         f"(static legacy was {static:.0f}s for both)")
+    if steady_s <= static and first_s >= static:
+        ok("deadlines are directionally clamped: steady only tighter, first "
+           "only looser")
+    else:
+        bad("directional clamp violated")
+        return False
+    if lat and max(lat) < budget:
+        ok(f"every round finished inside the BACKGROUND budget "
+           f"(slowest {max(lat):.1f}s < {budget:.0f}s)")
+    return True
+
+
+# ---------------------------------------------------------------- PHASE 3
+class _WedgedPeer:
+    """A peer that accepts, emits ONE chunk, then goes permanently silent.
+
+    This is the exact shape the adaptive steady-state deadline exists to
+    catch, and the shape a total-duration timeout cannot distinguish from a
+    slow-but-healthy generation. Deterministic, loopback-only, and it never
+    touches your serving host.
+    """
+
+    def __init__(self) -> None:
+        self._server = None
+        self.port = 0
+
+    async def start(self) -> str:
+        async def handle(reader, writer):
+            try:
+                while True:                       # drain request headers
+                    line = await reader.readline()
+                    if line in (b"\r\n", b"", b"\n"):
+                        break
+                writer.write(b"HTTP/1.1 200 OK\r\n"
+                             b"Content-Type: text/event-stream\r\n"
+                             b"Cache-Control: no-cache\r\n"
+                             b"Connection: keep-alive\r\n\r\n")
+                chunk = {"choices": [{"delta": {"content": "the"}}]}
+                writer.write(b"data: " + json.dumps(chunk).encode() + b"\n\n")
+                await writer.drain()
+                await asyncio.sleep(3600)          # ... and then nothing. ever.
+            except Exception:                      # noqa: BLE001
+                pass
+
+        self._server = await asyncio.start_server(handle, "127.0.0.1", 0)
+        self.port = self._server.sockets[0].getsockname()[1]
+        return f"http://127.0.0.1:{self.port}"
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+
+async def phase3(local_model: str) -> bool:
+    banner(3, "FAULT INJECTION — MID-STREAM PARTITION")
+    peer = _WedgedPeer()
+    endpoint = await peer.start()
+    info(f"wedged peer   : {endpoint} (emits 1 chunk, then silence forever)")
+    passed = True
+    try:
+        cfg = _cfg_for(endpoint, "wedged-model:1b")
+        prof = lid.LatencyProfiler(cfg,
+                                   ledger_key=lid.physics_key(cfg, endpoint=endpoint))
+        for _ in range(cfg.min_samples + 2):       # warm it so the deadline adapts
+            prof.record(ttft_ms=60.0, total_ms=500.0, output_tokens=120)
+        first_s, steady_s = prof.inter_token_budget_s()
+        before_est = prof.adaptive_timeout_ms(prompt_tokens=4096)
+        info(f"armed with    : first={first_s:.1f}s steady={steady_s:.1f}s")
+        info(f"estimate pre  : {before_est:.0f}ms")
+
+        client = lid.LocalPrimeClient(cfg, profiler=prof)
+        t0 = time.monotonic()
+        try:
+            await client.complete(system="s", user="u", prompt_tokens=64,
+                                  max_tokens=64, stream=True)
+            bad("no stall raised — the wedged peer was not detected")
+            passed = False
+        except lid.InterTokenStall as exc:
+            dt = time.monotonic() - t0
+            ok(f"InterTokenStall raised after {dt:.1f}s — socket severed")
+            info(f"  {str(exc)[:150]}")
+            if dt < first_s + steady_s + 5:
+                ok(f"fired on the ADAPTIVE budget, not the static "
+                   f"{lid._inter_token_timeout_s():.0f}s")
+            else:
+                warn(f"took {dt:.1f}s — longer than the adaptive budget implies")
+        except Exception as exc:                   # noqa: BLE001
+            bad(f"wrong exception: {type(exc).__name__}: {str(exc)[:110]}")
+            passed = False
+        finally:
+            await client.aclose()
+
+        after_est = prof.adaptive_timeout_ms(prompt_tokens=4096)
+        if after_est > before_est:
+            ok(f"EWMA PENALISED {before_est:.0f} -> {after_est:.0f}ms — the "
+               f"ledger learned this host wedges")
+        else:
+            warn(f"estimate unchanged ({after_est:.0f}ms) — expected on the "
+                 f"survival/CPU branch (num_ctx unset), which deliberately "
+                 f"ignores the EWMA; the LAN bridge negotiates num_ctx")
+
+        info("classification:")
+        stall = lid.InterTokenStall("x")
+        if ig.is_infrastructure_fault(stall):
+            ok("InterTokenStall classifies as INFRASTRUCTURE -> counts against "
+               "host health, triggers fallback")
+        else:
+            bad("InterTokenStall not classified as infrastructure")
+            passed = False
+        if not ig.is_infrastructure_fault(ValueError("bad prompt")):
+            ok("a request fault does NOT count against host health")
+
+        gw = ig.InferenceGateway()
+        gw._publish_degraded(
+            ig.GatewayTarget(base_url=endpoint, model_name="wedged-model:1b",
+                             scope="remote", state=ig.HostState.DEGRADED,
+                             reason="fault-injection"), stall)
+        ok("provider_state_changed published (non-fatal, best-effort)")
+
+        health = ig._HostHealth()
+        for i in range(ig.failure_threshold()):
+            health.record_failure("InterTokenStall", now=100.0 + i)
+        if health.state(now=100.0) is ig.HostState.UNREACHABLE:
+            ok(f"after {ig.failure_threshold()} stalls the breaker OPENS — "
+               f"subsequent ops bypass the LAN")
+        else:
+            bad("breaker did not open")
+            passed = False
+        t_probe = 100.0 + ig.cooldown_s() + 1
+        if health.state(now=t_probe) is ig.HostState.PROBING:
+            ok(f"after {ig.cooldown_s():.0f}s cooldown ONE probe is offered")
+        info(f"fallback tgt  : {gw._local_target('fault-injection').to_dict()}")
+        ok(f"local triage fallback resolves to "
+           f"'{gw._local_target('x').model_name}'")
+    finally:
+        await peer.stop()
+    return passed
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--endpoint",
+                    default=os.environ.get("JARVIS_REMOTE_INFERENCE_ENDPOINT",
+                                           "http://127.0.0.1:11434"))
+    ap.add_argument("--model",
+                    default=os.environ.get("JARVIS_REMOTE_INFERENCE_MODEL",
+                                           "qwen3-coder:30b"))
+    ap.add_argument("--swap-model", default=None,
+                    help="force a warm-swap handshake to this model in phase 1")
+    ap.add_argument("--rounds", type=int, default=5)
+    ap.add_argument("--phase", default="1,2,3")
+    args = ap.parse_args()
+
+    phases = {int(x) for x in args.phase.split(",") if x.strip()}
+    print(f"\n{'#' * 72}\n# LIVE-FIRE — LOCAL SOVEREIGNTY TIER\n"
+          f"# endpoint {args.endpoint}   model {args.model}\n{'#' * 72}")
+
+    gw = ig.InferenceGateway()
+    results = {}
+    try:
+        if 1 in phases:
+            results[1] = await phase1(gw, args.endpoint, args.model,
+                                      args.swap_model)
+        if 2 in phases:
+            results[2] = await phase2(gw, args.endpoint, args.model, args.rounds)
+        if 3 in phases:
+            results[3] = await phase3(lid.LocalConfig.from_env().model_name)
+    finally:
+        await gw.aclose()
+
+    print(f"\n{'=' * 72}")
+    for n in sorted(results):
+        (ok if results[n] else bad)(f"PHASE {n}")
+    print(f"{'=' * 72}\n")
+    return 0 if all(results.values()) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/governance/test_adaptive_inter_token_sla.py
+++ b/tests/governance/test_adaptive_inter_token_sla.py
@@ -221,3 +221,38 @@ class TestTheDegradationEvent:
                              scope="remote", state=ig.HostState.DEGRADED,
                              reason="t")
         g._publish_degraded(t, RuntimeError("x"))   # must not raise
+
+    def test_the_payload_actually_reaches_the_channel(self, monkeypatch):
+        """`must not raise` is not `did publish`.
+
+        The blanket ``except`` that makes this method safe also makes it MUTE:
+        for one release it called an ``endpoint_host()`` that did not exist
+        anywhere in the tree, and the NameError was swallowed into a debug
+        line. Every test above still passed -- two read the SOURCE, and the
+        third asserted only that nothing propagated, which a swallow
+        guarantees. CI's undefined-name gate caught it; the suite did not.
+
+        So assert delivery, not survival.
+        """
+        from backend.core.ouroboros.governance import (
+            ide_observability_stream as s,
+        )
+        seen: list = []
+        monkeypatch.setattr(s, "publish_provider_state_changed",
+                            lambda payload: seen.append(payload))
+
+        g = ig.InferenceGateway()
+        t = ig.GatewayTarget(base_url="http://h:1", model_name="m",
+                             scope="remote", state=ig.HostState.DEGRADED,
+                             reason="t")
+        g._publish_degraded(t, RuntimeError("boom"))
+
+        assert seen, "the degradation was swallowed and never published"
+        payload = seen[0]
+        assert payload["fatal"] is False
+        assert payload["fallback"] == "local_triage"
+        assert payload["model"] == "m"
+        # The endpoint must be the SAME identity the breaker is keyed on, or
+        # the operator cannot correlate this event with `_health_for()`.
+        assert payload["endpoint"] == t.base_url
+        assert g._health_for(payload["endpoint"]) is g._health_for(t.base_url)

--- a/tests/governance/test_adaptive_inter_token_sla.py
+++ b/tests/governance/test_adaptive_inter_token_sla.py
@@ -1,0 +1,223 @@
+"""The stall deadline is derived, the stall is recorded, and the loop survives.
+
+Two defects this closes, both invisible until the LAN bridge forced the
+streaming path:
+
+  1. **One constant for two different physics.** `_complete_streaming` applied
+     a single 30s budget to BOTH the wait before the first chunk (which
+     measures PREFILL and grows with prompt size) and every wait after it
+     (which measures the inter-token gap and is roughly constant). At 220
+     tok/s that hides a wedged peer for ~6,600 normal gaps; on a 64K prompt it
+     can declare a healthy prefill "wedged".
+  2. **A stall taught the ledger nothing.** `record()` fires only on a clean
+     finish, so a host that wedges every op kept its optimistic EWMA forever
+     and the ThroughputGovernor kept sizing lanes for a machine that was
+     actively failing.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import os
+import tempfile
+import textwrap
+
+import pytest
+
+from backend.core.ouroboros.governance import inference_gateway as ig
+from backend.core.ouroboros.governance import local_inference_director as lid
+
+
+@pytest.fixture(autouse=True)
+def _ledger(monkeypatch):
+    monkeypatch.setenv("JARVIS_LATENCY_LEDGER_PATH",
+                       os.path.join(tempfile.mkdtemp(), "l.json"))
+    for k in ("JARVIS_LOCAL_INTER_TOKEN_ADAPTIVE_ENABLED",
+              "JARVIS_LOCAL_INTER_TOKEN_STALL_MULTIPLE",
+              "JARVIS_LOCAL_INTER_TOKEN_FLOOR_S",
+              "JARVIS_LOCAL_INTER_TOKEN_TIMEOUT_S"):
+        monkeypatch.delenv(k, raising=False)
+    yield
+
+
+def _profiler(**over):
+    return lid.LatencyProfiler(lid.LocalConfig.from_env())
+
+
+def _warm(p, *, ttft_ms, total_ms, out_tokens, n=8):
+    for _ in range(n):
+        p.record(ttft_ms=ttft_ms, total_ms=total_ms, output_tokens=out_tokens)
+    return p
+
+
+class TestTheBudgetIsDerived:
+    def test_a_cold_profiler_is_byte_identical_legacy(self):
+        """No measurement, no derivation. Guessing from an empty window would
+        be worse than the constant it replaces."""
+        static = lid._inter_token_timeout_s()
+        assert _profiler().inter_token_budget_s() == (static, static)
+
+    def test_a_fast_host_tightens_the_steady_deadline(self):
+        """The defect: at 220 tok/s the normal gap is ~4.5ms, so a 30s budget
+        gives a wedged peer thousands of normal gaps before anyone notices."""
+        p = _warm(_profiler(), ttft_ms=180.0, total_ms=1000.0, out_tokens=200)
+        first, steady = p.inter_token_budget_s()
+        assert steady < lid._inter_token_timeout_s()
+        assert steady >= lid._inter_token_floor_s()
+
+    def test_a_large_prefill_loosens_the_first_token_deadline(self):
+        """The mirror defect: the static budget was applied to the prefill
+        wait too, so a 64K prompt whose first byte legitimately takes 40s was
+        declared wedged while working normally."""
+        p = _warm(_profiler(), ttft_ms=9000.0, total_ms=40000.0, out_tokens=100)
+        first, _steady = p.inter_token_budget_s()
+        assert first > lid._inter_token_timeout_s()
+
+    def test_the_steady_deadline_can_only_tighten(self):
+        """Capped at the static value: this path may detect a wedge SOONER,
+        never later. Loosening it would weaken the guard it replaces."""
+        for ttft, total, out in ((50.0, 200.0, 100), (9000.0, 90000.0, 20)):
+            p = _warm(_profiler(), ttft_ms=ttft, total_ms=total, out_tokens=out)
+            assert p.inter_token_budget_s()[1] <= lid._inter_token_timeout_s()
+
+    def test_the_first_deadline_can_only_loosen(self):
+        for ttft, total, out in ((50.0, 200.0, 100), (9000.0, 90000.0, 20)):
+            p = _warm(_profiler(), ttft_ms=ttft, total_ms=total, out_tokens=out)
+            assert p.inter_token_budget_s()[0] >= lid._inter_token_timeout_s()
+
+    def test_a_floor_stops_jitter_being_read_as_a_wedge(self, monkeypatch):
+        """Below the floor, ordinary LAN jitter and server-side chunk batching
+        are indistinguishable from a stopped peer -- and a false positive
+        aborts a real generation."""
+        monkeypatch.setenv("JARVIS_LOCAL_INTER_TOKEN_FLOOR_S", "1.5")
+        p = _warm(_profiler(), ttft_ms=5.0, total_ms=50.0, out_tokens=500)
+        assert p.inter_token_budget_s()[1] >= 1.5
+
+    def test_the_master_flag_off_restores_one_constant(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_LOCAL_INTER_TOKEN_ADAPTIVE_ENABLED", "0")
+        p = _warm(_profiler(), ttft_ms=180.0, total_ms=1000.0, out_tokens=200)
+        static = lid._inter_token_timeout_s()
+        assert p.inter_token_budget_s() == (static, static)
+
+    def test_no_hardcoded_network_parameter_survives(self, monkeypatch):
+        """Every term is tunable; none is a literal in the decision path."""
+        monkeypatch.setenv("JARVIS_LOCAL_INTER_TOKEN_TIMEOUT_S", "45")
+        monkeypatch.setenv("JARVIS_LOCAL_INTER_TOKEN_STALL_MULTIPLE", "4")
+        monkeypatch.setenv("JARVIS_LOCAL_INTER_TOKEN_FLOOR_S", "0.5")
+        p = _warm(_profiler(), ttft_ms=100.0, total_ms=2000.0, out_tokens=100)
+        first, steady = p.inter_token_budget_s()
+        assert first >= 45.0 and 0.5 <= steady <= 45.0
+
+    def test_a_broken_profiler_still_arms_a_watchdog(self, monkeypatch):
+        """A watchdog that fails to arm is worse than a loose one."""
+        p = _profiler()
+        monkeypatch.setattr(type(p), "_mean",
+                            staticmethod(lambda _xs: (_ for _ in ()).throw(
+                                RuntimeError("boom"))))
+        static = lid._inter_token_timeout_s()
+        assert p.inter_token_budget_s() == (static, static)
+
+
+class TestTheStallTeachesTheLedger:
+    def test_the_streaming_path_penalises_before_it_raises(self):
+        """Structural: `record()` fires only on a clean finish, so without an
+        explicit penalty the EWMA never learns that this host wedges."""
+        src = textwrap.dedent(
+            inspect.getsource(lid.LocalPrimeClient._complete_streaming))
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call)):
+                continue
+            if getattr(node.exc.func, "id", "") != "InterTokenStall":
+                continue
+            enclosing = [
+                n for n in ast.walk(tree)
+                if isinstance(n, (ast.If, ast.Try))
+                and any(c is node for c in ast.walk(n))
+            ]
+            calls = {
+                c.func.attr for n in enclosing for c in ast.walk(n)
+                if isinstance(c, ast.Call) and isinstance(c.func, ast.Attribute)
+            }
+            assert "record_timeout_penalty" in calls
+            return
+        raise AssertionError("no InterTokenStall raise found")
+
+    def test_a_penalty_raises_the_estimate_on_the_path_the_bridge_uses(self):
+        """The behavioural half: a penalised profiler must ask for more time,
+        which is what makes the governor throttle lanes on a degraded host.
+
+        Exercised with `num_ctx` SET, because that is the branch a negotiated
+        remote endpoint takes -- and it is the branch that consults the EWMA.
+        """
+        import dataclasses
+        cfg = dataclasses.replace(lid.LocalConfig.from_env(), num_ctx=16384)
+        p = _warm(lid.LatencyProfiler(cfg), ttft_ms=180.0, total_ms=1000.0,
+                  out_tokens=200)
+        before = p.adaptive_timeout_ms(prompt_tokens=8000)
+        p.record_timeout_penalty(90_000.0)
+        assert p.adaptive_timeout_ms(prompt_tokens=8000) > before
+
+    def test_the_survival_path_is_deliberately_unmoved_by_a_penalty(self):
+        """Documents a PRE-EXISTING design choice rather than asserting a bug.
+
+        `adaptive_timeout_ms` has two branches, and the survival/CPU branch
+        (no negotiated `num_ctx`) is explicitly "BYTE-IDENTICAL legacy -- no
+        EWMA escalation". So the penalty is recorded there but not consulted.
+        That is fortunate rather than accidental for this work: the LAN bridge
+        negotiates `num_ctx`, so the host whose stalls must move the estimate
+        is exactly the host whose branch reads it. Pinned so a future change
+        to either branch has to confront the asymmetry deliberately.
+        """
+        import dataclasses
+        cfg = dataclasses.replace(lid.LocalConfig.from_env(), num_ctx=None)
+        p = _warm(lid.LatencyProfiler(cfg), ttft_ms=180.0, total_ms=1000.0,
+                  out_tokens=200)
+        before = p.adaptive_timeout_ms(prompt_tokens=8000)
+        p.record_timeout_penalty(90_000.0)
+        assert p.adaptive_timeout_ms(prompt_tokens=8000) == before
+
+    def test_the_penalty_is_fail_soft(self):
+        """Telemetry must never mask the stall it is describing.
+
+        AST rather than a character window: the call sits inside a long
+        explanatory comment block, and a substring search over a fixed slice
+        found the comment instead of the code.
+        """
+        src = textwrap.dedent(
+            inspect.getsource(lid.LocalPrimeClient._complete_streaming))
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try):
+                continue
+            calls = {
+                c.func.attr for c in ast.walk(node)
+                if isinstance(c, ast.Call) and isinstance(c.func, ast.Attribute)
+            }
+            if "record_timeout_penalty" in calls and node.handlers:
+                return
+        raise AssertionError("record_timeout_penalty is not inside a try/except")
+
+
+class TestTheDegradationEvent:
+    def test_it_reuses_an_existing_event_type(self):
+        """New SSE types must be in the canonical `_VALID_EVENT_TYPES` or they
+        are SILENTLY DROPPED -- a degradation signal that degrades silently."""
+        src = inspect.getsource(ig.InferenceGateway._publish_degraded)
+        assert "publish_provider_state_changed" in src
+        from backend.core.ouroboros.governance import (
+            ide_observability_stream as s,
+        )
+        assert "provider_state_changed" in s._VALID_EVENT_TYPES
+
+    def test_it_is_marked_non_fatal_and_names_the_fallback(self):
+        src = inspect.getsource(ig.InferenceGateway._publish_degraded)
+        assert '"fatal": False' in src and "local_triage" in src
+
+    def test_publishing_cannot_turn_a_handled_fault_into_an_unhandled_one(self):
+        """The op has already been re-routed by the time this runs."""
+        g = ig.InferenceGateway()
+        t = ig.GatewayTarget(base_url="http://h:1", model_name="m",
+                             scope="remote", state=ig.HostState.DEGRADED,
+                             reason="t")
+        g._publish_degraded(t, RuntimeError("x"))   # must not raise

--- a/tests/governance/test_boot_progress_and_unfunded.py
+++ b/tests/governance/test_boot_progress_and_unfunded.py
@@ -1,0 +1,140 @@
+"""A wait that says what it is doing, and a ceiling that stops posing as a balance."""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from backend.core.ouroboros.cli import boot_progress as bp
+from backend.core.ouroboros.governance import capability_state as cs
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_OV_BOOT_HISTORY_PATH", str(tmp_path / "h.json"))
+    for k in ("JARVIS_OV_BOOT_PROGRESS_ENABLED", "JARVIS_OV_BOOT_PROGRESS_CEILING"):
+        monkeypatch.delenv(k, raising=False)
+    cs.reset_for_tests()
+    yield
+    cs.reset_for_tests()
+
+
+class TestProgressNeverLies:
+    def test_no_history_and_no_markers_shows_no_percentage(self):
+        """The honest rendering of "I don't know how far along this is" is no
+        number, not a guess dressed as one."""
+        p = bp.Progress(expected_s=None)
+        out = p.render(4.0)
+        assert "%" not in out and "4s" in out
+
+    def test_it_never_regresses(self):
+        """A bar that goes backwards destroys the only thing it is for."""
+        p = bp.Progress(expected_s=30.0)
+        p.observe_log("[AegisPreflight] x\n[CredentialBootstrap] y\n"
+                      "[AegisDaemon] serving on x\nStatusLineBuilder registered",
+                      now=20.0)
+        high = p.fraction(25.0)
+        assert p.fraction(1.0) >= high
+        assert p.fraction(0.0) >= high
+
+    def test_it_never_reaches_100_before_the_socket_is_live(self):
+        """The last few percent belong to the event that actually matters."""
+        p = bp.Progress(expected_s=10.0)
+        for st in bp.DEFAULT_STAGES:
+            p.observe_log(st.marker, now=1.0)
+        assert p.fraction(9999.0) <= bp.progress_ceiling() < 1.0
+
+    def test_evidence_outranks_the_estimate(self):
+        """A confirmed stage sets a FLOOR the clock cannot argue below."""
+        p = bp.Progress(expected_s=600.0)      # estimate says ~0%
+        p.observe_log("[AegisPreflight] x\n[CredentialBootstrap] y\n"
+                      "[AegisDaemon] serving on x", now=1.0)
+        assert p.fraction(2.0) > 0.15
+
+    def test_the_estimate_cannot_claim_an_unconfirmed_stage(self):
+        """Interpolation may move the bar between milestones, never past the
+        next one that has not happened."""
+        p = bp.Progress(expected_s=10.0)
+        p.observe_log("[AegisPreflight] x", now=1.0)
+        total = sum(s.weight for s in bp.DEFAULT_STAGES)
+        nxt = sum(s.weight for s in bp.DEFAULT_STAGES[:2]) / total
+        assert p.fraction(9999.0) <= nxt + 1e-9
+
+    def test_unmatched_markers_degrade_to_elapsed_only(self):
+        """The marker table couples to log text. A format change must cost the
+        bar, never its correctness."""
+        p = bp.Progress(expected_s=None)
+        p.observe_log("nothing recognisable here", now=5.0)
+        assert "%" not in p.render(5.0)
+
+    def test_a_hostile_log_never_raises(self):
+        p = bp.Progress(expected_s=10.0)
+        for bad in ("", "\x00\x00", "x" * 100000):
+            p.observe_log(bad, now=1.0)
+            assert isinstance(p.render(1.0), str)
+
+
+class TestBootHistory:
+    def test_only_successful_boots_are_recorded(self):
+        """A failed boot has no duration; folding one in would teach the
+        estimator that boots take as long as the operator's patience."""
+        h = os.path.join(tempfile.mkdtemp(), "h.json")
+        for bad in (-1.0, 0.0, 99999.0):
+            bp.record_boot_duration(bad, path=h)
+        assert bp.observed_boot_durations(h) == []
+
+    def test_the_expectation_needs_evidence(self):
+        h = os.path.join(tempfile.mkdtemp(), "h.json")
+        bp.record_boot_duration(10.0, path=h)
+        bp.record_boot_duration(12.0, path=h)
+        assert bp.expected_boot_s(h) is None      # 2 samples is not a median
+        bp.record_boot_duration(11.0, path=h)
+        assert bp.expected_boot_s(h) == 11.0
+
+    def test_history_is_bounded(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OV_BOOT_HISTORY_MAX", "5")
+        h = os.path.join(tempfile.mkdtemp(), "h.json")
+        for i in range(30):
+            bp.record_boot_duration(float(i + 1), path=h)
+        assert len(bp.observed_boot_durations(h)) == 5
+
+    def test_a_corrupt_history_never_raises(self):
+        h = os.path.join(tempfile.mkdtemp(), "h.json")
+        open(h, "w").write("{not json")
+        assert bp.observed_boot_durations(h) == []
+        assert bp.expected_boot_s(h) is None
+
+
+class TestUnfundedNamesTheRemedy:
+    def _ev(self, monkeypatch, remote):
+        e = cs.CapabilityEvaluator()
+        monkeypatch.setattr(cs.CapabilityEvaluator, "_read_lanes",
+                            staticmethod(lambda: (True, "doubleword", True)))
+        monkeypatch.setattr(cs.CapabilityEvaluator, "_read_ops",
+                            staticmethod(lambda: (0, 0, 0, True)))
+        monkeypatch.setattr(cs.CapabilityEvaluator, "_read_remote",
+                            staticmethod(lambda: (remote, "http://h:1", True)))
+        return e.evaluate()
+
+    def test_out_of_credit_is_unfunded_not_merely_blocked(self):
+        """"blocked" sends the operator to a log to find out why. "unfunded"
+        names the remedy in the word itself — and money is the one blocker the
+        organism can never clear on its own."""
+        r = self._ev(pytest.MonkeyPatch(), "absent")
+        assert r.state is cs.Capability.UNFUNDED
+        assert r.badge == "unfunded"
+
+    def test_the_reason_states_what_to_do(self):
+        r = self._ev(pytest.MonkeyPatch(), "absent")
+        assert "add credits" in r.reason.lower()
+
+    def test_unfunded_still_stops_dispatch(self):
+        """A friendlier word must not become a lesser state."""
+        assert cs.Capability.UNFUNDED.is_blocking
+        assert not cs.Capability.UNFUNDED.can_work
+
+    def test_a_serving_local_lane_is_degraded_not_unfunded(self):
+        r = self._ev(pytest.MonkeyPatch(), "serving")
+        assert r.state is cs.Capability.DEGRADED
+        assert not r.is_funding_issue

--- a/tests/governance/test_boot_progress_and_unfunded.py
+++ b/tests/governance/test_boot_progress_and_unfunded.py
@@ -107,6 +107,13 @@ class TestBootHistory:
 
 
 class TestUnfundedNamesTheRemedy:
+    """NOTE on the fixture: these use the real `monkeypatch` FIXTURE, never a
+    bare `pytest.MonkeyPatch()`. A directly-constructed one is never undone,
+    so the class-level patches to `_read_lanes` / `_read_ops` / `_read_remote`
+    survived the test and leaked into every file that ran afterwards —
+    producing failures that appeared only when the suite ran together and
+    vanished when a file ran alone."""
+
     def _ev(self, monkeypatch, remote):
         e = cs.CapabilityEvaluator()
         monkeypatch.setattr(cs.CapabilityEvaluator, "_read_lanes",
@@ -117,24 +124,167 @@ class TestUnfundedNamesTheRemedy:
                             staticmethod(lambda: (remote, "http://h:1", True)))
         return e.evaluate()
 
-    def test_out_of_credit_is_unfunded_not_merely_blocked(self):
+    def test_out_of_credit_is_unfunded_not_merely_blocked(self, monkeypatch):
         """"blocked" sends the operator to a log to find out why. "unfunded"
         names the remedy in the word itself — and money is the one blocker the
         organism can never clear on its own."""
-        r = self._ev(pytest.MonkeyPatch(), "absent")
+        r = self._ev(monkeypatch, "absent")
         assert r.state is cs.Capability.UNFUNDED
         assert r.badge == "unfunded"
 
-    def test_the_reason_states_what_to_do(self):
-        r = self._ev(pytest.MonkeyPatch(), "absent")
+    def test_the_reason_states_what_to_do(self, monkeypatch):
+        r = self._ev(monkeypatch, "absent")
         assert "add credits" in r.reason.lower()
 
     def test_unfunded_still_stops_dispatch(self):
+        # no evaluator needed — this asks the enum directly
         """A friendlier word must not become a lesser state."""
         assert cs.Capability.UNFUNDED.is_blocking
         assert not cs.Capability.UNFUNDED.can_work
 
-    def test_a_serving_local_lane_is_degraded_not_unfunded(self):
-        r = self._ev(pytest.MonkeyPatch(), "serving")
+    def test_a_serving_local_lane_is_degraded_not_unfunded(self, monkeypatch):
+        r = self._ev(monkeypatch, "serving")
         assert r.state is cs.Capability.DEGRADED
         assert not r.is_funding_issue
+
+
+class TestOneLineNotMany:
+    """The indicator must REDRAW, not accumulate.
+
+    Observed: four identical rows appended during a single boot —
+
+        ⎿ [██████·······]  56%  session open   0s
+        ⎿ [██████·······]  56%  session open   5s
+        ⎿ [██████·······]  56%  session open  10s
+        ⎿ [██████·······]  56%  session open  16s
+
+    Two separate defects in one picture: it appended instead of redrawing,
+    and the percentage was frozen between stages.
+    """
+
+    def _tty_render(self, ticks):
+        import io as _io
+        import sys as _sys
+
+        class _FakeTTY(_io.StringIO):
+            def isatty(self):
+                return True
+
+        from backend.core.ouroboros.cli.thin_client import _mk_tick
+        real = _sys.__stdout__
+        _sys.__stdout__ = _FakeTTY()
+        try:
+            said = []
+            tick = _mk_tick(said.append)
+            for e in ticks:
+                tick(e)
+            return said, _sys.__stdout__.getvalue()
+        finally:
+            _sys.__stdout__ = real
+
+    def test_a_tty_redraws_one_line(self):
+        said, buf = self._tty_render([0.0, 0.3, 0.6, 0.9])
+        assert said == []                 # nothing appended
+        assert buf.count("\r") >= 3       # redrawn in place
+        assert "\n" not in buf            # exactly one line
+
+    def test_a_non_tty_keeps_appending(self):
+        """A carriage return in a pipe or a log file is an unreadable smear.
+        The wait must not become less legible in the transcript to become
+        prettier on screen."""
+        import sys as _sys
+        from backend.core.ouroboros.cli.thin_client import _mk_tick
+        real = _sys.__stdout__
+        _sys.__stdout__ = None            # no real stdout -> not interactive
+        try:
+            said = []
+            tick = _mk_tick(said.append)
+            for e in (0.0, 6.0, 12.0):
+                tick(e)
+        finally:
+            _sys.__stdout__ = real
+        assert len(said) >= 2
+        assert all("\r" not in s for s in said)
+
+    def test_the_tty_check_uses_the_unpatched_stream(self):
+        """`prompt_toolkit.patch_stdout` swaps sys.stdout for a non-TTY proxy,
+        so `sys.stdout.isatty()` returns False on a real terminal — which is
+        exactly why the indicator appended. The codebase already solved this
+        once for the live status line; a second TTY check would be the bug a
+        third time."""
+        import inspect
+        from backend.core.ouroboros.cli import thin_client
+        src = inspect.getsource(thin_client._mk_tick)
+        assert "real_stdout_isatty" in src
+
+
+class TestTheBarMovesOnAFirstBoot:
+    def test_progress_advances_between_stages_without_history(self):
+        """56% frozen across four ticks: with no cross-boot history there was
+        no horizon, so the bar could only move when a marker landed."""
+        p = bp.Progress(expected_s=None)
+        log = ""
+        for t, line in ((2.0, "[AegisPreflight] a"),
+                        (5.0, "[CredentialBootstrap] b"),
+                        (9.0, "[AegisDaemon] serving on x")):
+            log += line + "\n"
+            p.observe_log(log, now=t)
+        at_stage = p.fraction(9.0)
+        later = p.fraction(12.0)
+        assert later is not None and at_stage is not None
+        assert later > at_stage           # it MOVED with no new marker
+
+    def test_one_arrival_is_enough_because_the_start_is_known(self):
+        """An earlier version measured the rate BETWEEN arrivals and so
+        returned nothing when several markers landed in the same poll — the
+        common case on a fast boot, since the tail is read every quarter
+        second. Anchored on t=0, one arrival is a rate: two stages by second
+        four is two seconds a stage."""
+        p = bp.Progress(expected_s=None)
+        assert p._projected_total_s(1.0) is None      # nothing reached yet
+        p.observe_log("[AegisPreflight] a", now=2.0)
+        assert p._projected_total_s(3.0) is not None
+
+    def test_simultaneous_arrivals_still_project(self):
+        """Two markers in ONE observation share a timestamp; the interval
+        form produced zero span and gave up."""
+        p = bp.Progress(expected_s=None)
+        p.observe_log("[AegisPreflight] a\n[CredentialBootstrap] b", now=4.0)
+        assert p._projected_total_s(5.0) is not None
+
+    def test_an_overrunning_boot_never_promises_a_past_finish(self):
+        """An ETA of "0s left" that keeps not arriving is worse than none."""
+        p = bp.Progress(expected_s=None)
+        p.observe_log("[AegisPreflight] a", now=1.0)
+        assert p._projected_total_s(500.0) >= 500.0
+
+    def test_projection_still_cannot_claim_an_unconfirmed_stage(self):
+        """Interpolation earns motion, never milestones."""
+        p = bp.Progress(expected_s=None)
+        p.observe_log("[AegisPreflight] a\n[CredentialBootstrap] b", now=5.0)
+        total = sum(s.weight for s in bp.DEFAULT_STAGES)
+        nxt = sum(s.weight for s in bp.DEFAULT_STAGES[:3]) / total
+        assert p.fraction(9999.0) <= nxt + 1e-9
+
+    def test_cross_boot_history_still_wins_when_present(self):
+        """More samples, and it already knows how this machine behaves.
+
+        Asserts the INTENT — that the horizon lifted the bar above the pure
+        evidence floor — rather than a magic number. The first version
+        asserted >= 0.4 and failed at 0.375, which is the CORRECT value:
+        clamped at the next unconfirmed stage, exactly as designed. The test
+        was wrong, not the clamp.
+        """
+        p = bp.Progress(expected_s=20.0)
+        p.observe_log("[AegisPreflight] a\n[CredentialBootstrap] b", now=1.0)
+        assert p._projected_total_s(2.0) is not None   # both available
+        total = sum(s.weight for s in bp.DEFAULT_STAGES)
+        evidence_floor = sum(s.weight for s in bp.DEFAULT_STAGES[:2]) / total
+        next_bound = sum(s.weight for s in bp.DEFAULT_STAGES[:3]) / total
+        got = p.fraction(10.0)
+        assert evidence_floor < got <= next_bound
+
+    def test_an_eta_appears_without_any_history(self):
+        p = bp.Progress(expected_s=None)
+        p.observe_log("[AegisPreflight] a\n[CredentialBootstrap] b", now=4.0)
+        assert "left" in p.render(6.0)

--- a/tests/governance/test_boot_progress_and_unfunded.py
+++ b/tests/governance/test_boot_progress_and_unfunded.py
@@ -288,3 +288,129 @@ class TestTheBarMovesOnAFirstBoot:
         p = bp.Progress(expected_s=None)
         p.observe_log("[AegisPreflight] a\n[CredentialBootstrap] b", now=4.0)
         assert "left" in p.render(6.0)
+
+
+class TestTheScreenOwnerRendersTheGauge:
+    """Six screenshots across six seconds showed the bar absent from every
+    one. A Rich `Live` draws the animated crest and OWNS the terminal during
+    ignition; a carriage-return line written to stdout underneath it is erased
+    by the next frame. The gauge must live inside that Live's renderable.
+    """
+
+    def _anim(self):
+        from backend.core.ouroboros.ui.crest_animator import CrestAnimator
+        a = CrestAnimator(cols=40, rows=20)
+        a.add_log("⏺ no organism awake — igniting one in the background")
+        return a
+
+    def test_the_gauge_is_one_line_that_replaces_itself(self):
+        from backend.core.ouroboros.cli.thin_client import _mk_tick
+        a = self._anim()
+        base = len(a.logs_renderable().plain.split("\n"))
+        tick = _mk_tick(a.add_log, a.set_progress)
+        seen = []
+        # Elapsed values a whole second apart: with no new markers and no
+        # history the ONLY thing that can legitimately change is the clock, so
+        # sub-second ticks would rightly render an identical line. Asserting
+        # change there would demand motion the data does not support — the
+        # thing this whole indicator refuses to do.
+        for e in (0.0, 1.2, 2.4, 3.6):
+            tick(e)
+            lines = a.logs_renderable().plain.split("\n")
+            assert len(lines) == base + 1     # exactly ONE extra, always
+            seen.append(lines[-1])
+        assert len(set(seen)) > 1             # and it changes
+
+    def test_progress_is_not_appended_to_the_transcript(self):
+        """`add_log` is a TRANSCRIPT — entries are events that happened and
+        must stay. A gauge appended to it produced six stacked bars."""
+        from backend.core.ouroboros.cli.thin_client import _mk_tick
+        a = self._anim()
+        tick = _mk_tick(a.add_log, a.set_progress)
+        for e in (0.0, 0.3, 0.6, 0.9, 1.2):
+            tick(e)
+        a.clear_progress()
+        assert len(a.logs_renderable().plain.split("\n")) == 1
+
+    def test_clearing_the_gauge_leaves_the_transcript(self):
+        a = self._anim()
+        a.set_progress("⎿ [██····] 20% x")
+        assert "20%" in a.logs_renderable().plain
+        a.clear_progress()
+        assert "20%" not in a.logs_renderable().plain
+        assert "no organism awake" in a.logs_renderable().plain
+
+    def test_the_owner_takes_priority_over_raw_stdout(self):
+        """With an owner present the tick must NOT touch the terminal."""
+        import io as _io
+        import sys as _sys
+        from backend.core.ouroboros.cli.thin_client import _mk_tick
+
+        class _FakeTTY(_io.StringIO):
+            def isatty(self):
+                return True
+
+        a = self._anim()
+        real = _sys.__stdout__
+        _sys.__stdout__ = _FakeTTY()
+        try:
+            tick = _mk_tick(a.add_log, a.set_progress)
+            for e in (0.0, 0.3, 0.6):
+                tick(e)
+            wrote = _sys.__stdout__.getvalue()
+        finally:
+            _sys.__stdout__ = real
+        assert wrote == ""                    # nothing written under the Live
+
+
+class TestTheLogAnchor:
+    def test_a_previous_boots_markers_do_not_count(self):
+        """The daemon log is APPEND-ONLY ACROSS RUNS. Read unanchored, its
+        tail already contains every marker from every previous boot, so a
+        fresh wait matched all seven stages on its first poll and rendered
+        97% — complete before the work began."""
+        import os
+        import tempfile
+        d = tempfile.mkdtemp()
+        log = os.path.join(d, "ov.log")
+        with open(log, "w") as fh:
+            for st in bp.DEFAULT_STAGES:
+                fh.write(st.marker + " (previous boot)\n")
+        p = bp.make_progress(log)             # anchors at current size
+        p.observe_log(bp.read_log_tail(log, since=p.log_origin), now=1.0)
+        assert p._reached == 0
+        assert p.fraction(1.0) is None        # nothing known yet
+
+    def test_this_boots_markers_do_count(self):
+        import os
+        import tempfile
+        d = tempfile.mkdtemp()
+        log = os.path.join(d, "ov.log")
+        open(log, "w").write("old noise\n")
+        p = bp.make_progress(log)
+        with open(log, "a") as fh:
+            fh.write(bp.DEFAULT_STAGES[0].marker + " now\n")
+        p.observe_log(bp.read_log_tail(log, since=p.log_origin), now=1.0)
+        assert p._reached == 1
+
+    def test_a_missing_log_is_not_an_error(self):
+        assert bp.read_log_tail("/nonexistent/ov.log", since=0) == ""
+        assert bp.log_size("/nonexistent/ov.log") == 0
+
+
+class TestOnlyRealBootsAreRecorded:
+    def test_attach_latency_is_not_a_boot_duration(self):
+        """`await_socket` has four callers and three are "already up — confirm
+        and attach", ~0.1s. Recording those gave a median of 0.22s, so the bar
+        hit 97% on its first frame. Attach latency and boot duration are
+        different quantities."""
+        import inspect
+        from backend.core.ouroboros.cli import thin_client
+        sig = inspect.signature(thin_client._finish_tick)
+        assert sig.parameters["record"].default is False
+
+    def test_only_the_spawning_branch_asks_to_record(self):
+        import inspect
+        from backend.core.ouroboros.cli import thin_client
+        src = inspect.getsource(thin_client.ensure_daemon)
+        assert src.count("record_boot=True") == 1

--- a/tests/governance/test_budget_basis_surface.py
+++ b/tests/governance/test_budget_basis_surface.py
@@ -1,0 +1,111 @@
+"""A ceiling without its basis is an arbitrary constant.
+
+`$0.00/$0.71` prompted "where is the $0.71 coming from?" — a fair question,
+because 0.71 is DERIVED (p95 of the operator's own recorded sessions x a
+headroom multiple) and nothing on screen said so. `derived_cost_cap()` already
+returns `(usd, basis)` and its docstring is explicit:
+
+    "The basis is not decoration — it is the difference between 'this ceiling
+     reflects 143 sessions of real spend' and 'nobody has ever measured this',
+     and a surface that shows the number without it repeats the exact defect
+     this replaces."
+
+The basis was computed, returned, and dropped: the spawner sent it to
+`logger.debug` and the hydration payload had no field for it.
+"""
+from __future__ import annotations
+
+import inspect
+
+from rich.console import Console
+
+from backend.core.ouroboros.battle_test import status_line as sl
+from backend.core.ouroboros.cli import ov
+
+
+class TestTheNumberCarriesItsBasis:
+    def _render(self, payload) -> str:
+        buf = Console(force_terminal=False, width=120, record=True)
+        ov._render_hydration(buf, payload)
+        return buf.export_text()
+
+    def _payload(self, **status):
+        base = {"phase": "IDLE", "cost_spent_usd": 0.0,
+                "cost_budget_usd": 0.71,
+                "cost_budget_basis": "observed — 98 sessions, p95=$0.24 x3"}
+        base.update(status)
+        return {"status": base, "liquidity": {}, "ops": []}
+
+    def test_the_basis_is_rendered_beside_the_number(self):
+        out = self._render(self._payload())
+        assert "0.71" in out
+        assert "98 sessions" in out and "p95" in out
+
+    def test_no_basis_renders_no_line_rather_than_an_empty_one(self):
+        """Restraint: an unexplained number is better than a blank
+        explanation pretending to be one."""
+        out = self._render(self._payload(cost_budget_basis=""))
+        assert "budget $" not in out
+
+    def test_a_zero_budget_does_not_advertise_a_basis(self):
+        out = self._render(self._payload(cost_budget_usd=0.0))
+        assert "budget $0.00 (" not in out
+
+    def test_every_basis_shape_renders_readably(self):
+        """The string varies: derived, clamped, unmeasured, operator-set. The
+        surface must not parse it — only present it."""
+        for basis in ("observed — 98 sessions, p95=$0.24 x3",
+                      "clamped to the Aegis session cap $2.00",
+                      "unmeasured — no prior session recorded a cost",
+                      "operator"):
+            out = self._render(self._payload(cost_budget_basis=basis))
+            assert basis.split(" ")[0] in out
+
+    def test_the_render_survives_a_hostile_payload(self):
+        for bad in (None, {}, {"status": None}, {"status": {"cost_budget_basis": 12}}):
+            ov._render_hydration(Console(force_terminal=False), bad or {})
+
+
+class TestTheBasisTravelsWithTheNumber:
+    def test_the_snapshot_carries_a_basis_field(self):
+        assert "cost_budget_basis" in sl.StatusSnapshot.__dataclass_fields__
+
+    def test_the_basis_is_read_from_the_spawn_decision_not_re_derived(self):
+        """It belongs to the DECISION that set the ceiling. Re-deriving later
+        would sample a different set of sessions and could explain the number
+        with evidence that did not produce it."""
+        src = inspect.getsource(sl.StatusLineBuilder._sample_cost_basis)
+        assert "OUROBOROS_BATTLE_COST_CAP_BASIS" in src
+        assert "derived_cost_cap" not in src
+
+    def test_the_spawner_exports_the_basis_not_just_the_cap(self):
+        from backend.core.ouroboros.cli import thin_client
+        src = inspect.getsource(thin_client)
+        assert "OUROBOROS_BATTLE_COST_CAP_BASIS" in src
+
+    def test_the_hydration_payload_carries_it(self):
+        from backend.core.ouroboros.battle_test import harness
+        assert "cost_budget_basis" in inspect.getsource(harness)
+
+
+class TestTheRenderIsNotSilentlyTruncated:
+    def test_lines_below_the_budget_row_still_render(self):
+        """A fail-soft wrapper turns a typo into MISSING OUTPUT rather than a
+        crash. Using `_Text` where this function aliases `_T` raised
+        NameError, and every line below — including the liquidity rows —
+        silently stopped rendering. Verified by asserting the tail is present.
+        """
+        buf = Console(force_terminal=False, width=120, record=True)
+        ov._render_hydration(buf, {
+            "status": {"phase": "IDLE", "cost_spent_usd": 0.0,
+                       "cost_budget_usd": 0.71,
+                       "cost_budget_basis": "observed — 98 sessions"},
+            "liquidity": {"providers": {"doubleword": {"tokens_remaining": None}},
+                          "any_exhausted": True,
+                          "economic": {"doubleword": {"state": "economic",
+                                                      "reason": "status 402"}}},
+            "ops": []})
+        out = buf.export_text()
+        assert "budget $0.71" in out          # the new line
+        assert "liquidity doubleword" in out  # a line AFTER it
+        assert "OUT OF CREDIT" in out         # and the warning after that

--- a/tests/governance/test_capability_and_deferral.py
+++ b/tests/governance/test_capability_and_deferral.py
@@ -1,0 +1,260 @@
+"""A badge that cannot lie, and a blind spot that has a name.
+
+Two defects, both observed live on 2026-08-18:
+
+  1. The cockpit printed `● healthy` while both provider lanes were at zero
+     credit and every op was failing. The header read
+     `get_reactive_theme().state` — a PRESENTATION state answering "what
+     colour should the dot be" — and rendered it as a CAPABILITY claim, on
+     top of two optimistic defaults.
+  2. A 6.7 KB file was logged as a 10 s AST "timeout" after 14.1 s of
+     `parent_await_ms`. A 6.7 KB parse does not take 14 s; the file spent
+     that time queued behind a saturated pool and was blamed for it. It was
+     then dropped with no record of which files went unanalysed.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance import ast_compile_helper as ah
+from backend.core.ouroboros.governance import capability_state as cs
+from backend.core.ouroboros.governance import deferred_task_ledger as dl
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DEFERRED_LEDGER_PATH", str(tmp_path / "d.json"))
+    for k in ("JARVIS_CAPABILITY_STATE_ENABLED", "JARVIS_CAPABILITY_TTL_S",
+              "JARVIS_CAPABILITY_FAIL_STREAK", "JARVIS_AST_MAX_BYTES_PER_LINE",
+              "JARVIS_AST_DENSITY_FLOOR_BYTES", "JARVIS_AST_SHED_QUEUE_DEPTH"):
+        monkeypatch.delenv(k, raising=False)
+    cs.reset_for_tests()
+    dl.reset_for_tests()
+    yield
+    cs.reset_for_tests()
+    dl.reset_for_tests()
+
+
+def _ev(monkeypatch, *, dry=False, provider="", lanes_ok=True,
+        attempted=0, completed=0, failed=0, ops_ok=True):
+    e = cs.CapabilityEvaluator()
+    monkeypatch.setattr(cs.CapabilityEvaluator, "_read_lanes",
+                        staticmethod(lambda: (dry, provider, lanes_ok)))
+    monkeypatch.setattr(cs.CapabilityEvaluator, "_read_ops",
+                        staticmethod(lambda: (attempted, completed, failed, ops_ok)))
+    return e
+
+
+class TestTheBadgeCannotClaimHealthItDoesNotHave:
+    def test_a_dry_lane_blocks_immediately(self, monkeypatch):
+        """A dry runway is a BILLING state, not jitter. Waiting for a streak
+        would reproduce the original defect in slower motion."""
+        r = _ev(monkeypatch, dry=True, provider="doubleword").evaluate()
+        assert r.state is cs.Capability.BLOCKED
+        assert "doubleword" in r.reason
+
+    def test_unknown_renders_as_blocked_never_healthy(self, monkeypatch):
+        """The inverted default. If nothing is readable we do not know whether
+        the organism can work, and the honest rendering of 'I don't know' is
+        not a green dot."""
+        r = _ev(monkeypatch, lanes_ok=False, ops_ok=False).evaluate()
+        assert r.state is cs.Capability.UNKNOWN
+        assert r.badge == "blocked"
+
+    def test_a_broken_fusion_still_refuses_to_claim_health(self, monkeypatch):
+        monkeypatch.setattr(
+            cs.CapabilityEvaluator, "_read_lanes",
+            staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("boom"))))
+        r = cs.CapabilityEvaluator().evaluate()
+        assert r.badge == "blocked"
+
+    def test_all_ops_failing_blocks(self, monkeypatch):
+        r = _ev(monkeypatch, attempted=9, completed=0, failed=9).evaluate()
+        assert r.state is cs.Capability.BLOCKED
+        assert "9" in r.reason
+
+    def test_some_failures_is_degraded_not_blocked(self, monkeypatch):
+        r = _ev(monkeypatch, attempted=10, completed=7, failed=3).evaluate()
+        assert r.state is cs.Capability.DEGRADED
+
+    def test_clean_history_is_healthy(self, monkeypatch):
+        r = _ev(monkeypatch, attempted=5, completed=5, failed=0).evaluate()
+        assert r.state is cs.Capability.HEALTHY
+
+    def test_it_no_longer_reads_the_ui_theme(self):
+        """The category error. `UIState` answers 'what colour am I', and the
+        header rendered that as 'can I work'.
+
+        AST, not substring: this module's docstring NAMES `get_reactive_theme`
+        in order to explain the defect it replaces, so a text search finds the
+        prose and fails a module that is in fact clean. A test must be able to
+        tell an explanation from a use.
+        """
+        import ast
+        import inspect
+        tree = ast.parse(inspect.getsource(cs))
+        names = {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
+        names |= {n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)}
+        for n in ast.walk(tree):
+            if isinstance(n, (ast.Import, ast.ImportFrom)):
+                names |= {a.name.split(".")[-1] for a in n.names}
+                names |= set((getattr(n, "module", "") or "").split("."))
+        assert "get_reactive_theme" not in names
+        assert "UIState" not in names
+        assert "theme" not in names
+
+
+class TestAsymmetricHysteresis:
+    def test_recovery_requires_a_verified_success_not_a_timer(self, monkeypatch):
+        """A lane flickering back to 'not exhausted' has proved nothing. An op
+        that COMPLETED has."""
+        e = _ev(monkeypatch, dry=True, provider="dw", attempted=4,
+                completed=0, failed=4)
+        assert e.evaluate().state is cs.Capability.BLOCKED
+
+        # lane returns, but nothing has completed yet -> still blocked
+        monkeypatch.setattr(cs.CapabilityEvaluator, "_read_lanes",
+                            staticmethod(lambda: (False, "", True)))
+        e.invalidate()
+        held = e.evaluate()
+        assert held.state is cs.Capability.BLOCKED
+        assert held.held_by_hysteresis is True
+
+        # an op completes -> recovery
+        monkeypatch.setattr(cs.CapabilityEvaluator, "_read_ops",
+                            staticmethod(lambda: (5, 1, 4, True)))
+        e.invalidate()
+        assert e.evaluate().state is cs.Capability.HEALTHY
+
+    def test_degradation_does_not_wait_for_hysteresis(self, monkeypatch):
+        """Asymmetric on purpose: cheap to admit trouble, expensive to claim
+        health. Mirrors the profiler's asymmetric EWMA."""
+        e = _ev(monkeypatch, attempted=3, completed=3, failed=0)
+        assert e.evaluate().state is cs.Capability.HEALTHY
+        monkeypatch.setattr(cs.CapabilityEvaluator, "_read_lanes",
+                            staticmethod(lambda: (True, "dw", True)))
+        e.invalidate()
+        assert e.evaluate().state is cs.Capability.BLOCKED
+
+    def test_the_master_flag_off_restores_legacy(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CAPABILITY_STATE_ENABLED", "0")
+        assert cs.CapabilityEvaluator().evaluate().state is cs.Capability.HEALTHY
+
+
+class TestTheHighEntropyGuard:
+    def _run(self, source, name="f.py"):
+        return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
+            ah.analyze_python_source_for_opportunity_miner(
+                "test", source, filename=name))
+
+    def test_a_minified_bundle_is_refused_by_shape_not_size(self):
+        """60 KB on one line is under any byte cap and still pathological for
+        an AST walk. Size cannot express this; density can."""
+        r = self._run("x=1;" * 15000, "minified.py")
+        assert r.outcome is ah.AnalyzeOutcome.PATHOLOGICAL
+        assert "density" in (r.error_detail or "")
+
+    def test_binary_content_is_refused(self):
+        r = self._run("abc\x00def" * 2000, "blob.bin")
+        assert r.outcome is ah.AnalyzeOutcome.PATHOLOGICAL
+
+    def test_a_small_one_liner_is_not_punished(self):
+        """A legitimate 11-byte one-liner has a terrible bytes-per-line ratio
+        and costs nothing to parse. The density floor exists so the guard does
+        not reject healthy files to prevent a cost that does not exist."""
+        assert self._run("x=1;y=2;z=3", "tiny.py").outcome is ah.AnalyzeOutcome.OK
+
+    def test_the_guard_runs_before_the_execution_branch(self):
+        """Load-bearing placement: inline-tiny runs on the caller's thread and
+        the Oracle runs in-process with no pool, so NEITHER can be cancelled
+        by a timeout. Guarding after the branch would have protected only the
+        path that was already protected."""
+        import inspect
+        src = inspect.getsource(ah.analyze_python_source_for_opportunity_miner)
+        assert src.index("_pathological_shape") < src.index("source_bytes <= tiny_threshold")
+
+    def test_thresholds_are_tunable_not_literal(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_AST_MAX_BYTES_PER_LINE", "5000")
+        monkeypatch.setenv("JARVIS_AST_DENSITY_FLOOR_BYTES", "1000")
+        assert ah._resolve_max_bytes_per_line() == 5000.0
+        assert ah._resolve_density_floor_bytes() == 1000
+        assert ah._pathological_shape("x=1;" * 200, 800) is None
+
+    def test_the_guard_never_raises(self):
+        for bad in (None, 12345, object()):
+            try:
+                ah._pathological_shape(bad, 9999)   # type: ignore[arg-type]
+            except Exception as exc:  # noqa: BLE001
+                pytest.fail(f"guard raised {exc!r}")
+
+
+class TestTheDeferralLedger:
+    def test_a_shape_rejection_is_recorded_and_not_retried(self):
+        """Remembered, but re-running the same bytes through the same guard
+        yields the same refusal — so it must not be re-queued unchanged."""
+        led = dl.get_default_ledger()
+        led.defer(path="a.py", reason=dl.DeferReason.PATHOLOGICAL)
+        assert led.snapshot()["total"] == 1
+        assert led.retryable() == []
+
+    def test_pressure_and_timeout_are_retryable(self):
+        led = dl.get_default_ledger()
+        led.defer(path="b.py", reason=dl.DeferReason.SHED_PRESSURE)
+        led.defer(path="c.py", reason=dl.DeferReason.TIMEOUT)
+        assert {t.path for t in led.retryable()} == {"b.py", "c.py"}
+
+    def test_re_shedding_updates_rather_than_appends(self):
+        """A file shed on every scan is ONE persistent blind spot, not fifty
+        events. Counting it fifty times would drown the ledger in its own
+        worst case."""
+        led = dl.get_default_ledger()
+        for _ in range(50):
+            led.defer(path="hot.py", reason=dl.DeferReason.SHED_PRESSURE)
+        assert led.snapshot()["total"] == 1
+        assert led.retryable()[0].occurrences == 50
+
+    def test_success_resolves_the_blind_spot(self):
+        led = dl.get_default_ledger()
+        led.defer(path="d.py", reason=dl.DeferReason.SHED_PRESSURE)
+        led.resolve("d.py")
+        assert led.snapshot()["total"] == 0
+
+    def test_eviction_is_counted_not_silent(self, monkeypatch):
+        """A ledger that silently forgot entries would be a blind spot about
+        blind spots."""
+        monkeypatch.setenv("JARVIS_DEFERRED_LEDGER_MAX", "16")
+        led = dl.DeferredTaskLedger()
+        for i in range(40):
+            led.defer(path=f"f{i}.py", reason=dl.DeferReason.SHED_PRESSURE,
+                      now=float(i))
+        snap = led.snapshot()
+        assert snap["total"] == 16
+        assert snap["evicted"] == 24
+
+    def test_the_ledger_never_raises(self):
+        led = dl.get_default_ledger()
+        led.defer(path="", reason=dl.DeferReason.TIMEOUT)     # empty path
+        led.resolve("nonexistent.py")
+        assert isinstance(led.snapshot(), dict)
+
+
+class TestInflightAccounting:
+    def test_the_release_lives_in_the_analyze_function(self):
+        """Regression pin. This file mirrors its parse and analyze
+        implementations almost line-for-line; an anchored edit first landed
+        the release in the PARSE twin, so analyze incremented and never
+        released — the counter would climb until `_pool_saturated()` returned
+        True forever, converting a backpressure valve into a permanent
+        outage."""
+        import inspect
+        src = inspect.getsource(ah._process_pool_analyze)
+        assert "_inflight += 1" in src
+        assert "_inflight = max(0, _inflight - 1)" in src
+        assert "finally:" in src
+
+    def test_saturation_is_computed_not_read_from_a_private_field(self):
+        import inspect
+        src = inspect.getsource(ah._pool_saturated)
+        assert "_pending_work_items" not in src

--- a/tests/governance/test_capability_and_deferral.py
+++ b/tests/governance/test_capability_and_deferral.py
@@ -52,7 +52,8 @@ class TestTheBadgeCannotClaimHealthItDoesNotHave:
         """A dry runway is a BILLING state, not jitter. Waiting for a streak
         would reproduce the original defect in slower motion."""
         r = _ev(monkeypatch, dry=True, provider="doubleword").evaluate()
-        assert r.state is cs.Capability.BLOCKED
+        assert r.state.is_blocking and not r.state.can_work
+        assert r.state is cs.Capability.UNFUNDED   # money has its own word
         assert "doubleword" in r.reason
 
     def test_unknown_renders_as_blocked_never_healthy(self, monkeypatch):
@@ -112,7 +113,7 @@ class TestAsymmetricHysteresis:
         that COMPLETED has."""
         e = _ev(monkeypatch, dry=True, provider="dw", attempted=4,
                 completed=0, failed=4)
-        assert e.evaluate().state is cs.Capability.BLOCKED
+        assert e.evaluate().state.is_blocking
 
         # lane returns, but nothing has completed yet -> still blocked
         monkeypatch.setattr(cs.CapabilityEvaluator, "_read_lanes",
@@ -136,7 +137,7 @@ class TestAsymmetricHysteresis:
         monkeypatch.setattr(cs.CapabilityEvaluator, "_read_lanes",
                             staticmethod(lambda: (True, "dw", True)))
         e.invalidate()
-        assert e.evaluate().state is cs.Capability.BLOCKED
+        assert e.evaluate().state.is_blocking
 
     def test_the_master_flag_off_restores_legacy(self, monkeypatch):
         monkeypatch.setenv("JARVIS_CAPABILITY_STATE_ENABLED", "0")

--- a/tests/governance/test_cognitive_persistence.py
+++ b/tests/governance/test_cognitive_persistence.py
@@ -10,7 +10,15 @@ from backend.core.ouroboros.governance.cognitive_persistence import (
 )
 
 
-def test_footprint_matches_physics_key_shape():
+def test_footprint_is_model_scoped_and_deliberately_not_hardware_scoped():
+    """Mirrors the TAIL of `physics_key`, and stops there on purpose.
+
+    `physics_key` gained a hardware axis because LATENCY is a property of the
+    machine. A cognitive experience -- a hallucinated tool, a malformed call
+    -- is a property of the MODEL, and is equally true on every machine that
+    runs it. Adding hardware here would shard the experience ledger by
+    accident and make each host re-learn the same lesson.
+    """
     assert cognitive_footprint("qwen3:32b", 16384) == "qwen3:32b@16384"
     assert cognitive_footprint("qwen3:32b", None) == "qwen3:32b@cpu"
 

--- a/tests/governance/test_compute_topology_multi_device.py
+++ b/tests/governance/test_compute_topology_multi_device.py
@@ -1,0 +1,164 @@
+"""Two GPUs are two capacities, and only the serving stack knows which counts.
+
+The gap this closes is REPRESENTATIONAL, not a bug. `compute_topology`
+deliberately collapsed multi-GPU to the largest single device, with a sound
+rationale: a model must fit on one device unless the serving stack shards it,
+and summing would authorize a load that cannot physically land.
+
+That reasoning is correct and stays the default. What was missing is the
+ability to EXPRESS the other fact — that two devices exist and a sharding
+runtime could pool them — so a consumer that knows its stack can ask.
+
+Concretely: an RTX 5090 (32GiB) beside a 24GiB card is 32GiB to a stack that
+does not shard and 56GiB to one that does. Reporting only one of those numbers
+is wrong for somebody.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import compute_topology as ct
+from backend.core.ouroboros.governance import local_model_admission as lma
+
+_MIB = 1024 * 1024
+_GIB = 1024 * _MIB
+
+#: The dual-GPU host this work exists for.
+_SMI_DUAL = (
+    "32768, 31000, NVIDIA GeForce RTX 5090\n"
+    "24576, 23000, NVIDIA GeForce RTX 4090\n"
+)
+
+
+def _reading(devices, **kw):
+    base = dict(
+        topology=ct.MemoryTopology.DISCRETE,
+        total_bytes=max((d.total_bytes for d in devices), default=0),
+        free_bytes=max((d.free_bytes for d in devices), default=0),
+        device_name=devices[0].name if devices else "",
+        device_count=len(devices), source="test", resolved_class="test",
+        enabled=True, probed_at=0.0, free_probed_at=0.0, devices=tuple(devices),
+    )
+    base.update(kw)
+    return ct.ComputeReading(**base)
+
+
+class TestTheParserKeepsEveryDevice:
+    def test_both_cards_survive_the_parse(self):
+        devices = ct._parse_nvidia_smi_devices(_SMI_DUAL)
+        assert len(devices) == 2
+        assert devices[0].total_bytes == 32768 * _MIB
+        assert devices[1].total_bytes == 24576 * _MIB
+        assert [d.index for d in devices] == [0, 1]
+
+    def test_the_collapsed_view_is_unchanged(self):
+        """The existing contract: largest SINGLE device, not the sum."""
+        free, total, name, count = ct._parse_nvidia_smi(_SMI_DUAL)
+        assert total == 32768 * _MIB      # not 57344
+        assert count == 2
+        assert "5090" in name
+
+    def test_one_malformed_row_does_not_void_the_others(self):
+        text = "32768, 31000, RTX 5090\ngarbage\n24576, 23000, RTX 4090\n"
+        assert len(ct._parse_nvidia_smi_devices(text)) == 2
+
+    def test_unparseable_input_is_still_none(self):
+        assert ct._parse_nvidia_smi("garbage\n\n") is None
+        assert ct._parse_nvidia_smi_devices("garbage\n\n") == ()
+
+
+class TestBothCapacitiesAreExpressible:
+    def test_the_aggregate_is_the_sum_and_the_collapsed_view_is_not(self):
+        r = _reading(ct._parse_nvidia_smi_devices(_SMI_DUAL))
+        assert r.free_bytes == 31000 * _MIB              # largest single
+        assert r.aggregate_free_bytes == 54000 * _MIB    # pooled
+        assert r.aggregate_total_bytes == 57344 * _MIB
+        assert r.is_multi_device is True
+
+    def test_no_devices_enumerated_is_not_multi_device(self):
+        """Empty means 'could not enumerate', never 'one device' — and an
+        aggregate over devices never read would be a fabrication."""
+        r = _reading([], device_count=4)   # a count without an enumeration
+        assert r.is_multi_device is False
+        assert r.aggregate_free_bytes == 0
+
+    def test_a_single_device_aggregate_equals_itself(self):
+        d = ct.DeviceReading(index=0, name="one", total_bytes=32 * _GIB,
+                             free_bytes=30 * _GIB)
+        r = _reading([d])
+        assert r.is_multi_device is False
+        assert r.aggregate_free_bytes == r.free_bytes
+
+
+class TestPoolingRequiresADeclaration:
+    def test_the_default_stays_conservative(self):
+        """Undeclared, the answer is the single-device bound — the number
+        that holds no matter what the serving stack does."""
+        r = _reading(ct._parse_nvidia_smi_devices(_SMI_DUAL))
+        assert r.shardable_usable_bytes(sharding=False) == r.usable_bytes
+
+    def test_declaring_sharding_unlocks_the_pool(self):
+        r = _reading(ct._parse_nvidia_smi_devices(_SMI_DUAL))
+        pooled = r.shardable_usable_bytes(sharding=True)
+        assert pooled > r.usable_bytes
+        assert pooled <= r.aggregate_free_bytes   # headroom still reserved
+
+    def test_declaring_sharding_cannot_invent_a_second_card(self):
+        """The flag is not a capacity multiplier. On a single-device host it
+        must change nothing."""
+        d = ct.DeviceReading(index=0, name="one", total_bytes=32 * _GIB,
+                             free_bytes=30 * _GIB)
+        r = _reading([d])
+        assert r.shardable_usable_bytes(sharding=True) == r.usable_bytes
+
+    def test_headroom_is_still_reserved_when_pooled(self):
+        r = _reading(ct._parse_nvidia_smi_devices(_SMI_DUAL))
+        assert r.shardable_usable_bytes(sharding=True) < r.aggregate_free_bytes
+
+
+class TestTheAdmissionDeclaration:
+    def test_it_defaults_off(self, monkeypatch):
+        """Getting this wrong optimistically is the expensive direction: it
+        admits a model that then fails to load, having passed the gate whose
+        job was to prevent exactly that."""
+        monkeypatch.delenv("JARVIS_LOCAL_ACCEL_SHARDING", raising=False)
+        assert lma.accelerator_sharding_declared() is False
+
+    @pytest.mark.parametrize("raw,expected",
+                             [("1", True), ("true", True), ("ON", True),
+                              ("0", False), ("no", False), ("", False),
+                              ("garbage", False)])
+    def test_it_reads_the_flag(self, monkeypatch, raw, expected):
+        monkeypatch.setenv("JARVIS_LOCAL_ACCEL_SHARDING", raw)
+        assert lma.accelerator_sharding_declared() is expected
+
+    def test_the_admission_path_asks_the_reading_not_the_flag_alone(self):
+        """Regression pin: the consult must go through
+        `shardable_usable_bytes`, which re-checks `is_multi_device`. Reading
+        the flag and summing directly would let a declaration on a
+        single-GPU host fabricate capacity."""
+        import ast
+        import inspect
+        import textwrap
+        src = textwrap.dedent(inspect.getsource(lma))
+        tree = ast.parse(src)
+        # Both spellings: a direct `.attr` and the defensive
+        # `getattr(reading, "attr", ...)` the module actually uses, so the
+        # pin cannot be defeated by switching between them.
+        names = {n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)}
+        names |= {
+            n.value for n in ast.walk(tree)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)
+        }
+        assert "shardable_usable_bytes" in names
+        assert "aggregate_free_bytes" not in names, (
+            "admission must not sum device memory itself")
+
+
+class TestTheObservabilitySurface:
+    def test_the_dict_carries_both_numbers(self):
+        d = _reading(ct._parse_nvidia_smi_devices(_SMI_DUAL)).to_dict()
+        assert d["is_multi_device"] is True
+        assert d["free_bytes"] != d["aggregate_free_bytes"]
+        assert len(d["devices"]) == 2
+        assert d["devices"][0]["name"].endswith("5090")

--- a/tests/governance/test_device_affinity.py
+++ b/tests/governance/test_device_affinity.py
@@ -1,0 +1,221 @@
+"""Asymmetric GPUs are not interchangeable lanes.
+
+A 32GB RTX 5090 beside a 24GB card, each hosting its own model. A queue that
+treats them as equal is wrong in both directions: a long-context BACKGROUND op
+on the 24GB card OOMs or silently truncates its window (a QUALITY failure that
+looks like the model getting dumber), and a trivial SPECULATIVE op on the 32GB
+card occupies the only device that could have taken the next heavy one.
+
+The invariant these tests defend: **capacity is a constraint, affinity is a
+preference, and a preference may never override a constraint.**
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import device_affinity as da
+from backend.core.ouroboros.governance import local_model_admission as lma
+from backend.core.ouroboros.governance.compute_topology import DeviceReading
+
+GIB = 1024 ** 3
+
+
+@pytest.fixture(autouse=True)
+def _kv(monkeypatch):
+    # Qwen3.8-27B's measured rate, so the numbers below are realistic.
+    monkeypatch.setenv("JARVIS_KV_BYTES_PER_TOKEN", "64000")
+    monkeypatch.delenv("JARVIS_DEVICE_AFFINITY_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_KV_BYTES_PER_TOKEN_BY_MODEL", raising=False)
+    yield
+
+
+def _dev(i, name, total, free, uuid=""):
+    return DeviceReading(index=i, name=name, total_bytes=total,
+                         free_bytes=free, uuid=uuid or f"GPU-{i}")
+
+
+BIG = _dev(0, "RTX 5090", 32 * GIB, 30 * GIB)
+SMALL = _dev(1, "RTX 4090", 24 * GIB, 22 * GIB)
+PAIR = [BIG, SMALL]
+W = 18 * GIB          # ~a 27B model at Q4
+
+
+class TestAffinitySteersByRoute:
+    def test_light_triage_vacates_the_big_card(self):
+        """A SPECULATIVE op that fits anywhere should not occupy the only
+        device capable of taking the next heavy one."""
+        sel = da.select_device(PAIR, ctx_tokens=2000, weight_bytes=W,
+                               route="speculative")
+        assert sel.device.name == "RTX 4090"
+
+    @pytest.mark.parametrize("route", ["background", "complex", "standard",
+                                       "immediate"])
+    def test_heavy_routes_prefer_the_roomiest_device(self, route):
+        sel = da.select_device(PAIR, ctx_tokens=2000, weight_bytes=W,
+                               route=route)
+        assert sel.device.name == "RTX 5090"
+
+    def test_no_route_is_capacity_only(self):
+        sel = da.select_device(PAIR, ctx_tokens=2000, weight_bytes=W)
+        assert sel.reason == "most_free"
+
+    def test_the_master_flag_off_is_capacity_only(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_DEVICE_AFFINITY_ENABLED", "0")
+        sel = da.select_device(PAIR, ctx_tokens=2000, weight_bytes=W,
+                               route="speculative")
+        assert sel.reason == "most_free"
+        assert sel.device.name == "RTX 5090"
+
+
+class TestCapacityOverridesPreference:
+    def test_a_light_op_too_big_for_the_small_card_still_runs(self):
+        """Deferring work a present device could do would be policy defeating
+        the system it exists to tune."""
+        sel = da.select_device(PAIR, ctx_tokens=100_000, weight_bytes=W,
+                               route="speculative")
+        assert sel.device.name == "RTX 5090"
+        assert sel.fallback_from_preference is True
+
+    def test_the_displacement_is_visible_on_a_two_gpu_host(self):
+        """Regression pin. `fallback_from_preference` was originally computed
+        only in the multi-candidate path -- but with exactly two GPUs,
+        excluding one leaves one, so that branch was never reached and the
+        flag could never be True on the very configuration it was written
+        for. The one event an operator wants to see was invisible."""
+        sel = da.select_device(PAIR, ctx_tokens=100_000, weight_bytes=W,
+                               route="speculative")
+        assert sel.reason == "only_candidate"
+        assert sel.fallback_from_preference is True
+
+    def test_an_undisplaced_op_does_not_claim_it_was(self):
+        sel = da.select_device(PAIR, ctx_tokens=2000, weight_bytes=W,
+                               route="speculative")
+        assert sel.fallback_from_preference is False
+
+
+class TestTheDocumentedEdgeCases:
+    def test_1_no_devices_declines_rather_than_guessing(self):
+        """An empty list means "we could not see", never "there is nothing"."""
+        sel = da.select_device([], ctx_tokens=1000, weight_bytes=W)
+        assert sel.device is None and sel.reason == "not_enumerated"
+
+    def test_2_a_single_device_still_gets_the_capacity_check(self):
+        ok = da.select_device([SMALL], ctx_tokens=2000, weight_bytes=W,
+                              route="background")
+        assert ok.device is SMALL
+        too_big = da.select_device([SMALL], ctx_tokens=200_000,
+                                   weight_bytes=W, route="background")
+        assert too_big.device is None
+
+    def test_4_nothing_fits_returns_an_actionable_ceiling(self):
+        sel = da.select_device(PAIR, ctx_tokens=400_000, weight_bytes=W,
+                               route="background")
+        assert sel.device is None and sel.reason == "no_device_fits"
+        assert sel.max_ctx_tokens > 0
+        # and the ceiling must actually fit
+        assert da.select_device(PAIR, ctx_tokens=sel.max_ctx_tokens,
+                                weight_bytes=W,
+                                route="background").device is not None
+
+    def test_5_ties_are_broken_deterministically_by_index(self):
+        """Two identical cards must not flap between ops: a stable assignment
+        keeps each device's model resident instead of thrashing loads, and a
+        cold model load measured ~30s on this project's own hardware."""
+        twins = [_dev(0, "A", 24 * GIB, 20 * GIB),
+                 _dev(1, "B", 24 * GIB, 20 * GIB)]
+        picks = {da.select_device(twins, ctx_tokens=2000, weight_bytes=W,
+                                  route="background").device.index
+                 for _ in range(25)}
+        assert picks == {0}
+        assert {da.select_device(list(reversed(twins)), ctx_tokens=2000,
+                                 weight_bytes=W,
+                                 route="background").device.index
+                for _ in range(25)} == {0}
+
+    def test_6_zero_context_is_not_treated_as_zero_kv(self):
+        """A zero-KV assumption admits everything -- the optimistic direction,
+        and therefore the wrong one."""
+        assert da.estimate_kv_bytes(0) == 0
+        sel = da.select_device(PAIR, ctx_tokens=0, weight_bytes=W,
+                               route="background")
+        assert sel.kv_bytes == 0   # caller must pass its real window
+
+    def test_7_kv_is_sized_against_the_reachable_ceiling_not_the_prompt(self):
+        """Venom accumulates tool results into the same window until
+        compaction fires. An op sized against its FIRST prompt fits at round 1
+        and OOMs at round 7 -- after the exploration calls the Iron Gate
+        demanded have already been spent."""
+        grown = da.estimate_kv_bytes(10_000, grow=True)
+        raw = da.estimate_kv_bytes(10_000, grow=False)
+        assert grown > raw
+        assert grown == int(10_000 * da.context_growth_factor()) * 64000
+
+
+class TestKvEstimation:
+    def test_kv_is_linear_in_context(self):
+        a = da.estimate_kv_bytes(8_000, grow=False)
+        b = da.estimate_kv_bytes(32_000, grow=False)
+        assert b == a * 4
+
+    def test_a_per_model_rate_overrides_the_pessimistic_default(self,
+                                                                monkeypatch):
+        monkeypatch.setenv("JARVIS_KV_BYTES_PER_TOKEN_BY_MODEL",
+                           "qwen3.8-27b=64000,other=1000")
+        assert da.kv_bytes_per_token("qwen3.8-27b") == 64000
+        assert da.kv_bytes_per_token("other") == 1000
+        assert da.kv_bytes_per_token("unlisted") == 64000  # env default here
+
+    def test_a_malformed_override_does_not_take_the_gate_down(self,
+                                                              monkeypatch):
+        monkeypatch.setenv("JARVIS_KV_BYTES_PER_TOKEN_BY_MODEL", "garbage,,x=")
+        assert da.kv_bytes_per_token("anything") > 0
+
+    def test_the_growth_factor_is_clamped(self, monkeypatch):
+        for raw, lo, hi in (("0.1", 1.0, 4.0), ("99", 1.0, 4.0),
+                            ("nonsense", 1.0, 4.0)):
+            monkeypatch.setenv("JARVIS_DEVICE_AFFINITY_CTX_GROWTH", raw)
+            assert lo <= da.context_growth_factor() <= hi
+
+
+class TestAdmissionUsesTheSelectedDevice:
+    def _reading(self, devices):
+        from backend.core.ouroboros.governance import compute_topology as ct
+        return ct.ComputeReading(
+            topology=ct.MemoryTopology.DISCRETE,
+            total_bytes=max(d.total_bytes for d in devices),
+            free_bytes=max(d.free_bytes for d in devices),
+            device_name=devices[0].name, device_count=len(devices),
+            source="test", resolved_class="test", enabled=True,
+            probed_at=0.0, free_probed_at=0.0, devices=tuple(devices))
+
+    def test_a_context_no_device_can_hold_is_deferred_with_a_ceiling(
+            self, monkeypatch):
+        monkeypatch.setattr(lma, "_read_accelerator",
+                            lambda: self._reading(PAIR))
+        d = lma.assess(400_000, weight_bytes=W, model_id="m",
+                       route="background")
+        assert d.action == lma.Admission.DEFER.value
+        assert d.bound == "accelerator_device"
+        assert "largest context that fits" in d.reason
+
+    def test_a_context_that_fits_is_judged_against_that_device(self,
+                                                              monkeypatch):
+        monkeypatch.setattr(lma, "_read_accelerator",
+                            lambda: self._reading(PAIR))
+        d = lma.assess(4_000, weight_bytes=W, model_id="m", route="background")
+        assert d.action == lma.Admission.ADMIT.value
+
+    def test_pooled_readings_skip_per_device_selection(self, monkeypatch):
+        """One model spanning several devices has no per-device question to
+        ask -- the pooled bound is the right one."""
+        monkeypatch.setenv("JARVIS_LOCAL_ACCEL_SHARDING", "1")
+        monkeypatch.setattr(lma, "_read_accelerator",
+                            lambda: self._reading(PAIR))
+        d = lma.assess(4_000, weight_bytes=W, model_id="m", route="background")
+        assert d.bound != "accelerator_device"
+
+    def test_the_route_argument_is_optional(self, monkeypatch):
+        """Every existing caller passes no route and must keep working."""
+        monkeypatch.setattr(lma, "_read_accelerator",
+                            lambda: self._reading(PAIR))
+        assert lma.assess(4_000, weight_bytes=W, model_id="m") is not None

--- a/tests/governance/test_device_affinity.py
+++ b/tests/governance/test_device_affinity.py
@@ -198,12 +198,24 @@ class TestAdmissionUsesTheSelectedDevice:
         assert d.bound == "accelerator_device"
         assert "largest context that fits" in d.reason
 
-    def test_a_context_that_fits_is_judged_against_that_device(self,
-                                                              monkeypatch):
+    def test_a_context_that_fits_is_not_refused_by_the_device_bound(
+            self, monkeypatch):
+        """Asserts the ACCELERATOR verdict, not the global one.
+
+        An earlier version asserted `action == ADMIT`, which made the test
+        depend on the live system-memory level of whatever machine ran it:
+        the host gate can independently return PRUNE for reasons that have
+        nothing to do with the GPU, and it duly did once this laptop got
+        busier. A test whose result changes with what else is running is not
+        a test. The claim being made here is narrower and hermetic -- a
+        context that fits the selected device is not refused *by the device
+        bound*.
+        """
         monkeypatch.setattr(lma, "_read_accelerator",
                             lambda: self._reading(PAIR))
         d = lma.assess(4_000, weight_bytes=W, model_id="m", route="background")
-        assert d.action == lma.Admission.ADMIT.value
+        assert not (d.action == lma.Admission.DEFER.value
+                    and d.bound == "accelerator_device"), d.reason
 
     def test_pooled_readings_skip_per_device_selection(self, monkeypatch):
         """One model spanning several devices has no per-device question to

--- a/tests/governance/test_dlq_contract_and_provider_banner.py
+++ b/tests/governance/test_dlq_contract_and_provider_banner.py
@@ -1,0 +1,146 @@
+"""A dead-letter queue holds work, and a cockpit that knows must say.
+
+Two defects, both found by reading production state rather than code:
+
+  1. `.jarvis/intake_dlq.jsonl` held 156 rows of which 152 were DIAGNOSTICS.
+     `append_dlq(envelope: Any, ...)` typed its parameter `Any`, so the
+     contract was unenforced and callers filed error telemetry into a replay
+     queue. Not merely untidy: `replay_dlq` dedups by goal_id, every
+     diagnostic has an empty one, so a replay would collapse them to a single
+     entry and hand an error record to the intake router AS WORK.
+  2. The cockpit's economic-death banner filtered on
+     `consecutive_economic_failures` — a key `economic_view()` does not
+     return. The branch never rendered for any provider, ever, while
+     doubleword sat at `state='economic', hard_open=True, status 402`.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.cli.ov import _economic_evidence, _liquidity_lines
+from backend.core.ouroboros.governance import intake_dlq as dlq
+
+
+class TestTheQueueHoldsWork:
+    def test_a_pure_diagnostic_is_not_replayable(self):
+        """The shape that made up 55 of the 156 production rows: informative
+        to a human, meaningless to an intake router."""
+        assert not dlq.is_replayable(
+            {"action": "heartbeat_frozen", "error_class": "X",
+             "surface": "auth", "note": "n", "detail": "d", "event": "e"})
+
+    def test_node_coldstart_telemetry_is_not_replayable(self):
+        """91 of the 156."""
+        assert not dlq.is_replayable(
+            {"awakened_model": "m", "awakened_tier_heavy": True,
+             "classification": "c", "instance": "i", "k": 1})
+
+    def test_a_real_envelope_is_replayable(self):
+        assert dlq.is_replayable(
+            {"dedup_key": "abc", "description": "Fix the thing",
+             "confidence": 0.9})
+
+    def test_a_minimal_envelope_stays_replayable(self):
+        """Deliberately permissive. An earlier draft required actionable
+        content and would have DIVERTED REAL WORK carrying only an id — worse
+        than the misfiling being fixed, because misfiling never lost work."""
+        assert dlq.is_replayable({"goal_id": "g1"})
+
+    def test_dedup_key_counts_as_identity(self):
+        """Its absence was a live defect: real envelopes identify themselves
+        with `dedup_key` and often carry no goal_id, and `replay_dlq` dedups
+        first-wins — so every such envelope collapsed into ONE survivor."""
+        assert dlq._goal_id({"dedup_key": "k1"}) == "k1"
+        assert dlq._goal_id({"causal_id": "c1"}) == "c1"
+        assert dlq._goal_id({"goal_id": "g", "dedup_key": "k"}) == "g"
+
+    def test_a_diagnostic_is_rerouted_not_dropped(self, tmp_path):
+        """Enforcing the contract must not cost data — otherwise callers
+        would simply drop what the queue refuses."""
+        p = str(tmp_path / "dlq.jsonl")
+        dlq.append_dlq({"action": "x", "error_class": "y"}, reason="r", path=p)
+        assert dlq.read_dlq(p) == []
+        diag = dlq._diagnostics_path(p)
+        import os
+        assert os.path.exists(diag)
+        assert "action" in open(diag, encoding="utf-8").read()
+
+    def test_real_work_still_reaches_the_queue(self, tmp_path):
+        p = str(tmp_path / "dlq.jsonl")
+        dlq.append_dlq({"goal_id": "g9", "description": "real"},
+                       reason="no_router", path=p)
+        assert len(dlq.read_dlq(p)) == 1
+
+    @pytest.mark.asyncio
+    async def test_legacy_rows_are_skipped_on_replay(self, tmp_path):
+        """152 such rows exist today. Guarding only new writes would leave
+        them armed."""
+        import json
+        p = tmp_path / "dlq.jsonl"
+        p.write_text("\n".join(json.dumps(r) for r in [
+            {"ts": 1, "reason": "x", "goal_id": "",
+             "envelope": {"action": "a", "error_class": "b"}},
+            {"ts": 2, "reason": "y", "goal_id": "g1",
+             "envelope": {"goal_id": "g1", "description": "real work"}},
+        ]) + "\n", encoding="utf-8")
+        seen = []
+
+        async def _ingest(env):
+            seen.append(env)
+        drained = await dlq.replay_dlq(str(p), _ingest)
+        assert drained == 1
+        assert seen and seen[0].get("description") == "real work"
+
+
+class TestTheBannerSaysWhoIsOutOfMoney:
+    def _rows(self, econ):
+        return _liquidity_lines(
+            {"anthropic": {"tokens_remaining": 5_000_000},
+             "doubleword": {"tokens_remaining": None}},
+            any_exhausted=True, economic=econ)
+
+    def test_the_state_shape_is_read_not_a_nonexistent_counter(self):
+        """`economic_view()` returns {state, hard_open, reason, …}. The old
+        filter read `consecutive_economic_failures`, which is never present,
+        so the branch never fired for any provider."""
+        out = " ".join(self._rows({
+            "doubleword": {"state": "economic", "hard_open": True,
+                           "reason": "status 402"}}))
+        assert "doubleword: OUT OF CREDIT" in out
+        assert "status 402" in out
+
+    def test_the_legacy_counter_shape_still_works(self):
+        out = " ".join(self._rows({
+            "doubleword": {"consecutive_economic_failures": 3}}))
+        assert "OUT OF CREDIT" in out
+
+    def test_a_lapsed_verdict_is_reported_not_silenced(self):
+        """`economic_view` degrades a stale verdict to state='unknown' — it
+        must not assert knowledge it lacks. But dropping the row reports
+        "nothing known" when what IS known is "last time we looked this lane
+        was out of money"."""
+        out = " ".join(self._rows({
+            "anthropic": {"state": "unknown", "stale_clock": True,
+                          "unverified_since": 0.0,
+                          "reason": "Your credit balance is too low"}}))
+        assert "last known OUT OF CREDIT" in out
+        assert "lapsed on a timer" in out
+
+    def test_a_healthy_provider_produces_no_warning(self):
+        """Restraint: healthy is invisible."""
+        out = " ".join(self._rows({"claude": {"state": "healthy"}}))
+        assert "OUT OF CREDIT" not in out
+
+    def test_the_human_sentence_survives_truncation(self):
+        """Vendors wrap the one useful sentence in transport noise;
+        truncating the envelope yields JSON scaffolding and drops the remedy."""
+        raw = ("Error code: 400 - {'type': 'error', 'error': {'type': "
+               "'invalid_request_error', 'message': 'Your credit balance is "
+               "too low to access the Anthropic API. Please go to Plans'}}")
+        got = _economic_evidence(raw)
+        assert got.startswith("Your credit balance is too low")
+        assert "invalid_request_error" not in got
+
+    def test_evidence_extraction_never_raises(self):
+        for bad in ("", None, 12345, "{'message': "):
+            assert isinstance(_economic_evidence(bad), str)  # type: ignore[arg-type]

--- a/tests/governance/test_hardware_signature.py
+++ b/tests/governance/test_hardware_signature.py
@@ -1,0 +1,210 @@
+"""A ledger key must not conflate two machines.
+
+`physics_key` was `model@ctx`, with a docstring explaining that the endpoint
+is excluded because "node IPs change every run". That is right about IPs and
+wrong about machines: the same model name on a 16GB M1 and an RTX 5090 wrote
+ONE entry, so whichever measured last governed both. In the bridged
+configuration this project is building, the M1's ~95ms/token would size the
+5090's lane count -- the ThroughputGovernor computing a wrong answer from
+perfectly honest data.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from backend.core.ouroboros.governance import hardware_signature as hs
+from backend.core.ouroboros.governance import local_inference_director as lid
+
+LOCAL = "http://127.0.0.1:11434"
+WIN = "http://192.168.1.50:11434"
+OTHER = "http://192.168.1.77:11434"
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    monkeypatch.delenv("JARVIS_HARDWARE_SIGNATURE_ENABLED", raising=False)
+    hs.reset_for_tests()
+    yield
+    hs.reset_for_tests()
+
+
+class TestIsolation:
+    def test_local_and_remote_are_different_machines(self):
+        assert hs.signature_for(LOCAL).digest != hs.signature_for(WIN).digest
+
+    def test_two_remote_hosts_are_different_machines(self):
+        assert hs.signature_for(WIN).digest != hs.signature_for(OTHER).digest
+
+    @pytest.mark.parametrize("a,b", [
+        ("http://192.168.1.50:11434", "http://192.168.1.50:8080"),
+        ("http://192.168.1.50:11434", "https://192.168.1.50:443"),
+        ("192.168.1.50:11434", "http://192.168.1.50:11434"),
+    ])
+    def test_one_machine_is_one_signature_regardless_of_port_or_scheme(self, a, b):
+        """A port is not hardware. One box serving two models on two ports is
+        one machine, and splitting its ledger by port would re-introduce the
+        amnesia the physics ledger exists to cure."""
+        assert hs.signature_for(a).digest == hs.signature_for(b).digest
+
+    @pytest.mark.parametrize("url", ["http://localhost:11434", "http://[::1]:1",
+                                     "http://127.0.0.1:99", ""])
+    def test_loopback_spellings_all_resolve_to_this_machine(self, url):
+        assert hs.signature_for(url).provenance == "probed"
+
+
+class TestTheSpineDoesNotMove:
+    def test_the_signature_survives_a_topology_flag_flip(self, monkeypatch):
+        """A signature must change only when the MACHINE does.
+
+        Accelerator components were originally appended to the machine id, so
+        enabling `JARVIS_COMPUTE_TOPOLOGY_ENABLED` changed the digest and
+        orphaned every prior measurement on hardware that had not changed at
+        all. GPU identity is now a SUBSTITUTE for a missing spine, never an
+        addition to a present one.
+        """
+        monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_ENABLED", "0")
+        hs.reset_for_tests()
+        off = hs.signature_for(LOCAL).digest
+        monkeypatch.setenv("JARVIS_COMPUTE_TOPOLOGY_ENABLED", "1")
+        hs.reset_for_tests()
+        assert hs.signature_for(LOCAL).digest == off
+
+    def test_component_order_cannot_change_the_digest(self):
+        """nvidia-smi and torch may enumerate the same cards in different
+        orders; a signature that flipped with enumeration order would split
+        one machine's ledger in two."""
+        a = hs._digest(("gpu:B", "gpu:A", "machine:X"))
+        b = hs._digest(("machine:X", "gpu:A", "gpu:B"))
+        assert a == b
+
+    def test_the_digest_is_deterministic_across_calls(self):
+        assert hs._digest(("machine:X",)) == hs._digest(("machine:X",))
+
+
+class TestHonestProvenance:
+    def test_a_probed_identity_is_marked_strong(self):
+        assert hs.signature_for(LOCAL).is_strong is True
+
+    def test_a_remote_identity_is_not_claimed_as_probed(self):
+        """We cannot see that machine's hardware. Distinct is not the same as
+        verified, and the difference is recorded rather than smoothed over."""
+        sig = hs.signature_for(WIN)
+        assert sig.provenance == "endpoint"
+        assert sig.is_strong is False
+
+    def test_components_never_carry_the_port_or_a_full_url(self):
+        """A signature is an identity, not a connection string."""
+        joined = " ".join(hs.signature_for(WIN).components)
+        assert "11434" not in joined
+        assert "http" not in joined
+
+    def test_the_machine_id_is_not_the_hostname(self, monkeypatch):
+        """An operator renames a machine; a signature that moved when they did
+        would orphan every measurement taken before the rename."""
+        import platform
+        node = platform.node()
+        if node:
+            assert node not in (hs.machine_id() or "")
+
+
+class TestItNeverBreaksDispatch:
+    def test_a_broken_probe_still_yields_a_signature(self, monkeypatch):
+        monkeypatch.setattr(hs, "_probe_machine_id",
+                            lambda: (_ for _ in ()).throw(OSError("boom")))
+        monkeypatch.setattr(hs, "accelerator_components", lambda: ())
+        hs.reset_for_tests()
+        sig = hs.signature_for(LOCAL)
+        assert isinstance(sig.digest, str) and sig.digest
+
+    def test_a_random_node_id_is_declined_rather_than_trusted(self,
+                                                              monkeypatch):
+        """uuid.getnode() sets the multicast bit when it INVENTED a value. A
+        random per-process id is not an identity -- it would look distinct
+        every run and prevent the ledger from ever warm-starting."""
+        monkeypatch.setattr(hs, "_read_first_line", lambda _p: "")
+        monkeypatch.setattr(hs._uuid_mod, "getnode", lambda: 0x010000000000)
+        monkeypatch.setattr(hs.sys, "platform", "linux")
+        monkeypatch.setattr(hs.os, "name", "posix")
+        hs.reset_for_tests()
+        assert hs._probe_machine_id() == ""
+
+    def test_the_master_flag_off_is_an_empty_digest(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_HARDWARE_SIGNATURE_ENABLED", "0")
+        hs.reset_for_tests()
+        assert hs.signature_for(LOCAL).digest == ""
+
+
+class TestTheLedgerKey:
+    def _key(self, **over):
+        return lid.physics_key(
+            dataclasses.replace(lid.LocalConfig.from_env(), **over))
+
+    def test_the_same_model_on_two_hosts_gets_two_keys(self):
+        assert self._key(model_name="m", num_ctx=8192, base_url=LOCAL) != \
+            self._key(model_name="m", num_ctx=8192, base_url=WIN)
+
+    def test_the_model_and_ctx_tail_is_preserved(self):
+        assert self._key(model_name="m", num_ctx=8192).endswith("m@8192")
+        assert self._key(model_name="m", num_ctx=0).endswith("m@cpu")
+
+    def test_the_flag_off_restores_the_legacy_key_exactly(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_HARDWARE_SIGNATURE_ENABLED", "0")
+        hs.reset_for_tests()
+        assert self._key(model_name="m", num_ctx=8192) == "m@8192"
+
+    def test_an_unidentifiable_host_never_becomes_a_shared_bucket(
+            self, monkeypatch):
+        """A key containing a literal "unknown" segment would merge every
+        unidentifiable host into ONE entry -- the exact conflation being
+        removed, wearing a different name. Falling back to the legacy shape is
+        no worse than before; inventing a placeholder would be worse."""
+        monkeypatch.setattr(
+            hs, "signature_for",
+            lambda _u="": hs.HardwareSignature(digest="", provenance="unknown"))
+        assert self._key(model_name="m", num_ctx=8192) == "m@8192"
+
+
+class TestTheFailoverSeam:
+    """The store keyed by endpoint, the ledger keyed by cfg -- a mismatch.
+
+    `_failover_profiler_for(endpoint, cfg)` holds ONE profiler per endpoint
+    while carrying a SINGLE cfg. Deriving the machine from cfg there would
+    stamp every failover target with the base config's identity, re-creating
+    the host conflation at the one seam -- cross-node failover -- where it
+    matters most.
+    """
+
+    def test_an_explicit_endpoint_overrides_the_config(self):
+        cfg = dataclasses.replace(lid.LocalConfig.from_env(),
+                                  model_name="m", num_ctx=8192, base_url=LOCAL)
+        assert lid.physics_key(cfg) != lid.physics_key(cfg, endpoint=WIN)
+
+    def test_two_failover_targets_get_two_ledgers(self):
+        cfg = dataclasses.replace(lid.LocalConfig.from_env(),
+                                  model_name="m", num_ctx=8192, base_url=LOCAL)
+        assert lid.physics_key(cfg, endpoint=WIN) != \
+            lid.physics_key(cfg, endpoint=OTHER)
+
+    def test_the_generator_passes_the_endpoint_it_is_measuring(self):
+        """Wiring pin. Without the explicit argument the call compiles, runs,
+        and is silently wrong."""
+        import ast
+        import inspect
+        import textwrap
+        from backend.core.ouroboros.governance import candidate_generator as cg
+        src = textwrap.dedent(
+            inspect.getsource(cg.CandidateGenerator._failover_profiler_for))
+        for node in ast.walk(ast.parse(src)):
+            if (isinstance(node, ast.Call)
+                    and getattr(node.func, "id", "") == "physics_key"):
+                assert any(k.arg == "endpoint" for k in node.keywords), \
+                    "physics_key called without the endpoint being measured"
+                return
+        raise AssertionError("physics_key call not found in the failover seam")
+
+    def test_no_endpoint_falls_back_to_the_config(self):
+        cfg = dataclasses.replace(lid.LocalConfig.from_env(),
+                                  model_name="m", num_ctx=8192, base_url=WIN)
+        assert lid.physics_key(cfg, endpoint="") == lid.physics_key(cfg)

--- a/tests/governance/test_header_bounds_and_economic_lanes.py
+++ b/tests/governance/test_header_bounds_and_economic_lanes.py
@@ -1,0 +1,103 @@
+"""The nameplate must not collide with the artwork, and every lane must speak.
+
+Two defects from a live cockpit screenshot:
+
+  1. The capability reason is long enough to overflow the identity column, and
+     a wrapped continuation starts at COLUMN ZERO — on top of the crest. The
+     header read "…configure a local lane to keep" followed by "background work
+     moving" printed over the logo.
+  2. The banner rendered "a runway is reported dry but no provider row shows
+     it" — its own contradiction — because the daemon's economic payload
+     consulted the CLAUDE circuit breaker alone and never represented
+     Doubleword, the lane actually refusing with 402.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from rich.text import Text
+
+from backend.core.ouroboros.cli.ov import _liquidity_lines
+from backend.core.ouroboros.ui.crest_animator import render_cockpit_header
+
+LONG = ("● unfunded · ouroboros + venom · doubleword is out of credit — add "
+        "credits, or configure a local lane to keep background work moving")
+
+
+class TestTheNameplateStaysInItsColumn:
+    def _rows(self, width, lines=None):
+        lines = lines or [Text("O+V v0.1.0"), Text(LONG), Text("~/repo")]
+        return render_cockpit_header(None, lines, width).split("\n")
+
+    @pytest.mark.parametrize("width", [60, 80, 100, 120, 200])
+    def test_no_row_ever_exceeds_the_terminal_width(self, width):
+        """A row wider than the terminal wraps, and a wrapped continuation
+        starts at column zero — which is where the crest is."""
+        assert all(len(r) <= width for r in self._rows(width))
+
+    def test_the_row_count_is_stable_regardless_of_reason_length(self):
+        """The header is a NAMEPLATE — a fixed number of rows beside a
+        fixed-height crest. If it grew, the layout would shift every time a
+        provider changed state."""
+        short = [Text("O+V v0.1.0"), Text("● healthy"), Text("~/repo")]
+        long_ = [Text("O+V v0.1.0"), Text(LONG), Text("~/repo")]
+        assert len(self._rows(80, short)) == len(self._rows(80, long_))
+
+    def test_a_long_reason_is_ellipsised_not_wrapped(self):
+        rows = self._rows(80)
+        assert "…" in rows[1]
+        assert "background work moving" not in "\n".join(rows)
+
+    def test_the_callers_text_is_not_mutated(self):
+        """`lines` is rebuilt per frame but shared within one; truncating in
+        place would make the first narrow frame permanent."""
+        reason = Text(LONG)
+        before = len(reason)
+        render_cockpit_header(None, [Text("x"), reason, Text("y")], 60)
+        assert len(reason) == before
+
+    def test_a_tiny_terminal_still_renders(self):
+        for w in (20, 10, 1):
+            assert isinstance(render_cockpit_header(None, [Text(LONG)], w), str)
+
+
+class TestEveryLaneSpeaks:
+    def test_the_daemon_asks_the_classifier_not_one_breaker(self):
+        """`economic_view` handles Doubleword's 402 and Anthropic's 400 +
+        'credit balance' alike, and is the same function the banner's renderer
+        consumes. One source, every lane."""
+        from backend.core.ouroboros.battle_test import harness
+        src = inspect.getsource(harness)
+        assert "economic_view" in src
+
+    def test_a_populated_economic_map_removes_the_contradiction(self):
+        """With lanes represented, the banner names them instead of reporting
+        that it cannot."""
+        out = " ".join(_liquidity_lines(
+            {"anthropic": {"tokens_remaining": 5_000_000},
+             "doubleword": {"tokens_remaining": None}},
+            any_exhausted=True,
+            economic={"doubleword": {"state": "economic", "hard_open": True,
+                                     "reason": "status 402"}}))
+        assert "OUT OF CREDIT" in out
+        assert "no provider row shows it" not in out
+
+    def test_the_contradiction_warning_survives_a_genuinely_empty_map(self):
+        """It is still the honest thing to say when nothing can explain the
+        aggregate flag — the fix is to populate the map, not to silence the
+        warning."""
+        out = " ".join(_liquidity_lines(
+            {"anthropic": {"tokens_remaining": 5_000_000}},
+            any_exhausted=True, economic={}))
+        assert "no provider row shows it" in out
+
+    def test_a_lapsed_lane_is_still_represented(self):
+        out = " ".join(_liquidity_lines(
+            {"anthropic": {"tokens_remaining": 5_000_000}},
+            any_exhausted=True,
+            economic={"anthropic": {"state": "unknown", "stale_clock": True,
+                                    "unverified_since": 0.0,
+                                    "reason": "Your credit balance is too low"}}))
+        assert "last known OUT OF CREDIT" in out
+        assert "no provider row shows it" not in out

--- a/tests/governance/test_inference_gateway.py
+++ b/tests/governance/test_inference_gateway.py
@@ -1,0 +1,262 @@
+"""The LAN bridge: arm the watchdog, degrade instead of hanging, keep the books.
+
+Three properties, each guarding a specific way this could be wrong:
+
+  1. The Inter-Token Watchdog must be ARMED on the remote path. It already
+     exists inside `LocalPrimeClient._complete_streaming`, but `complete()`
+     only takes the streaming path when `num_ctx` is set -- so on an
+     un-negotiated remote it is present and DISARMED, and a wedged peer hangs
+     this process against a socket.
+  2. An unreachable host must become a ROUTING decision, not an error. Triage
+     work has somewhere else to run.
+  3. Remote measurements must land in the REMOTE host's physics ledger. Before
+     the hardware-signature work they would have poisoned this Mac's entry,
+     and the ThroughputGovernor would have sized the Mac's queue from LAN
+     numbers.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from backend.core.ouroboros.governance import inference_gateway as ig
+from backend.core.ouroboros.governance import local_inference_director as lid
+
+REMOTE = "http://192.168.1.50:11434"
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch, tmp_path):
+    for k in (ig.ENABLED_ENV, ig.REMOTE_ENDPOINT_ENV, ig.REMOTE_MODEL_ENV,
+              ig.LOCAL_TRIAGE_MODEL_ENV, ig.FAILURE_THRESHOLD_ENV,
+              ig.COOLDOWN_ENV):
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("JARVIS_LATENCY_LEDGER_PATH", str(tmp_path / "l.json"))
+    ig.reset_for_tests()
+    yield
+    ig.reset_for_tests()
+
+
+class _Completion:
+    """Mirrors `LocalCompletion` -- the fields the profiler actually records."""
+
+    def __init__(self, text="ok", output_tokens=10, ttft_ms=50.0,
+                 total_ms=900.0):
+        self.text = text
+        self.output_tokens = output_tokens
+        self.ttft_ms = ttft_ms
+        self.total_ms = total_ms
+
+
+class _FakeClient:
+    """Mirrors LocalPrimeClient's real contract: the same keyword-only
+    `complete` signature, an `aclose`, and a profiler it records into.
+
+    Mirroring matters -- a fake that accepts **kwargs would have hidden
+    whether `stream=True` was actually passed, which is the single most
+    important assertion in this file."""
+
+    def __init__(self, cfg, profiler, *, fail: Optional[BaseException] = None):
+        self.cfg = cfg
+        self.profiler = profiler
+        self.calls: List[Dict[str, Any]] = []
+        self.closed = False
+        self._fail = fail
+
+    async def complete(self, *, system: str, user: str, prompt_tokens: int,
+                       temperature: float = 0.2,
+                       max_tokens: Optional[int] = None,
+                       stream: Optional[bool] = None,
+                       prefill: str = "") -> Any:
+        self.calls.append({"stream": stream, "base_url": self.cfg.base_url,
+                           "prompt_tokens": prompt_tokens})
+        if self._fail is not None:
+            raise self._fail
+        c = _Completion()
+        self.profiler.record(ttft_ms=c.ttft_ms, total_ms=c.total_ms,
+                             output_tokens=c.output_tokens)
+        return c
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _gw(fail_for: Optional[Dict[str, BaseException]] = None):
+    made: Dict[str, _FakeClient] = {}
+
+    def factory(cfg, profiler):
+        exc = (fail_for or {}).get(cfg.base_url)
+        c = _FakeClient(cfg, profiler, fail=exc)
+        made[cfg.base_url] = c
+        return c
+
+    g = ig.InferenceGateway(client_factory=factory)
+    return g, made
+
+
+async def _run(g, **kw):
+    return await g.dispatch(system="s", user="u", prompt_tokens=100, **kw)
+
+
+class TestTheWatchdogIsArmed:
+    @pytest.mark.asyncio
+    async def test_streaming_is_forced_on_the_remote_path(self, monkeypatch):
+        """`complete()` chooses the non-streaming path whenever num_ctx is
+        unset, and the Inter-Token Watchdog lives INSIDE the streaming path.
+        Without this the guard is present and disarmed over the LAN."""
+        monkeypatch.setenv(ig.REMOTE_ENDPOINT_ENV, REMOTE)
+        g, made = _gw()
+        await _run(g, route="background")
+        assert made[REMOTE].calls[0]["stream"] is True
+
+    @pytest.mark.asyncio
+    async def test_the_local_path_keeps_the_clients_own_policy(self):
+        """Locally a stall is slowness, not a dead peer -- the client's own
+        num_ctx-based choice is correct and must not be overridden."""
+        g, made = _gw()
+        await _run(g, route="background")
+        assert list(made.values())[0].calls[0]["stream"] is None
+
+
+class TestDegradationIsARoutingDecision:
+    @pytest.mark.asyncio
+    async def test_an_inter_token_stall_falls_back_to_local(self, monkeypatch):
+        monkeypatch.setenv(ig.REMOTE_ENDPOINT_ENV, REMOTE)
+        g, made = _gw({REMOTE: lid.InterTokenStall("wedged")})
+        out = await _run(g, route="speculative")
+        assert out is not None                      # the op still completed
+        assert len(made) == 2                       # remote tried, local ran
+        assert made[REMOTE].calls and any(
+            k != REMOTE for k in made)
+
+    @pytest.mark.asyncio
+    async def test_the_breaker_opens_and_stops_trying_the_lan(self,
+                                                              monkeypatch):
+        monkeypatch.setenv(ig.REMOTE_ENDPOINT_ENV, REMOTE)
+        monkeypatch.setenv(ig.FAILURE_THRESHOLD_ENV, "2")
+        g, made = _gw({REMOTE: ConnectionRefusedError("down")})
+        for _ in range(2):
+            await _run(g, route="speculative")
+        assert g.target_for().scope == "local"
+        before = len(made[REMOTE].calls)
+        await _run(g, route="speculative")
+        assert len(made[REMOTE].calls) == before   # LAN not attempted again
+
+    @pytest.mark.asyncio
+    async def test_a_request_fault_does_not_take_a_healthy_host_down(
+            self, monkeypatch):
+        """A 400 for a malformed body says nothing about whether the machine
+        is up. Counting it would remove a working 5090 from service because a
+        prompt was wrong."""
+        monkeypatch.setenv(ig.REMOTE_ENDPOINT_ENV, REMOTE)
+        monkeypatch.setenv(ig.FAILURE_THRESHOLD_ENV, "1")
+        g, _made = _gw({REMOTE: ValueError("bad request body")})
+        with pytest.raises(ValueError):
+            await _run(g, route="background")
+        assert g.snapshot()["hosts"][REMOTE]["state"] != "unreachable"
+
+    def test_infrastructure_faults_are_classified_by_type(self):
+        assert ig.is_infrastructure_fault(lid.InterTokenStall("x"))
+        assert ig.is_infrastructure_fault(ConnectionRefusedError())
+        assert ig.is_infrastructure_fault(asyncio.TimeoutError())
+        assert not ig.is_infrastructure_fault(ValueError("bad prompt"))
+        assert not ig.is_infrastructure_fault(KeyError("k"))
+
+
+class TestRecovery:
+    def test_half_open_admits_exactly_one_probe(self, monkeypatch):
+        """Every queued op would otherwise stampede a recovering host the
+        instant the cooldown expired -- and the first thing it does on
+        recovery is load a model, so the stampede lands when it is least able
+        to absorb it."""
+        monkeypatch.setenv(ig.FAILURE_THRESHOLD_ENV, "1")
+        monkeypatch.setenv(ig.COOLDOWN_ENV, "10")
+        h = ig._HostHealth()
+        h.record_failure("boom", now=100.0)
+        assert h.state(now=105.0) is ig.HostState.UNREACHABLE
+        assert h.state(now=111.0) is ig.HostState.PROBING
+        assert h.claim_probe(now=111.0) is True
+        assert h.claim_probe(now=111.0) is False     # only one
+        assert h.state(now=111.0) is ig.HostState.UNREACHABLE
+
+    def test_a_failed_probe_re_arms_the_cooldown(self, monkeypatch):
+        """Its cooldown had already elapsed, so without re-stamping the open
+        time a host that fails its probe would be retried immediately -- a
+        breaker that stops breaking exactly when the host is worst."""
+        monkeypatch.setenv(ig.FAILURE_THRESHOLD_ENV, "1")
+        monkeypatch.setenv(ig.COOLDOWN_ENV, "10")
+        h = ig._HostHealth()
+        h.record_failure("boom", now=100.0)
+        h.claim_probe(now=111.0)
+        h.record_failure("still down", now=111.0)
+        assert h.state(now=112.0) is ig.HostState.UNREACHABLE
+        assert h.state(now=122.0) is ig.HostState.PROBING
+
+    def test_success_clears_the_streak(self, monkeypatch):
+        monkeypatch.setenv(ig.FAILURE_THRESHOLD_ENV, "3")
+        h = ig._HostHealth()
+        h.record_failure("a", now=1.0)
+        h.record_failure("b", now=2.0)
+        h.record_success()
+        assert h.state(now=3.0) is ig.HostState.HEALTHY
+        assert h.snapshot()["consecutive_failures"] == 0
+
+
+class TestTheTelemetryHandoff:
+    @pytest.mark.asyncio
+    async def test_remote_measurements_land_in_the_remote_ledger(
+            self, monkeypatch):
+        """The whole reason the hardware axis had to land first. Under the old
+        `model@ctx` key these LAN numbers would have written the Mac's entry
+        and the governor would have sized this queue from them."""
+        monkeypatch.setenv(ig.REMOTE_ENDPOINT_ENV, REMOTE)
+        g, made = _gw()
+        await _run(g, route="background")
+        key = made[REMOTE].profiler._ledger_key
+        local_cfg = lid.LocalConfig.from_env()
+        assert key != lid.physics_key(local_cfg)
+        assert lid._physics_ledger_load().get(key)      # it really persisted
+
+    @pytest.mark.asyncio
+    async def test_the_governor_sizes_against_the_active_host(self,
+                                                              monkeypatch):
+        """The serialisation happens on the REMOTE device, so this Mac's own
+        physics is irrelevant to how many lanes the queue may run."""
+        from backend.core.ouroboros.governance import throughput_governor as tg
+        monkeypatch.setenv(ig.REMOTE_ENDPOINT_ENV, REMOTE)
+        ig.reset_for_tests()
+        tg.reset_for_tests()
+        _prof, cfg = tg.ThroughputGovernor._profiler_and_config()
+        assert cfg is not None and cfg.base_url == REMOTE
+
+
+class TestLifecycleAndConfig:
+    def test_no_remote_configured_is_the_single_machine_case(self):
+        t = ig.InferenceGateway().target_for()
+        assert t.scope == "local"
+        assert "no remote endpoint" in t.reason
+
+    def test_the_endpoint_is_never_hardcoded(self, monkeypatch):
+        monkeypatch.setenv(ig.REMOTE_ENDPOINT_ENV, "http://10.0.0.9:1234")
+        assert ig.InferenceGateway().target_for().base_url == \
+            "http://10.0.0.9:1234"
+
+    def test_the_master_flag_off_is_local_only(self, monkeypatch):
+        monkeypatch.setenv(ig.REMOTE_ENDPOINT_ENV, REMOTE)
+        monkeypatch.setenv(ig.ENABLED_ENV, "0")
+        assert ig.InferenceGateway().target_for().scope == "local"
+
+    @pytest.mark.asyncio
+    async def test_aclose_closes_every_client_it_owns(self, monkeypatch):
+        """An un-closed aiohttp session is a leak this codebase already paid
+        for once, in the cognition-lanes provider."""
+        monkeypatch.setenv(ig.REMOTE_ENDPOINT_ENV, REMOTE)
+        g, made = _gw()
+        await _run(g, route="background")
+        await g.aclose()
+        assert all(c.closed for c in made.values())
+
+    def test_snapshot_never_raises(self):
+        assert isinstance(ig.InferenceGateway().snapshot(), dict)

--- a/tests/governance/test_inference_gateway.py
+++ b/tests/governance/test_inference_gateway.py
@@ -260,3 +260,63 @@ class TestLifecycleAndConfig:
 
     def test_snapshot_never_raises(self):
         assert isinstance(ig.InferenceGateway().snapshot(), dict)
+
+
+class TestClientCacheIdentity:
+    """A client is bound to (endpoint, MODEL) — not to the endpoint alone.
+
+    FOUND BY LIVE-FIRE, not by the tests above, because every one of them used
+    a single model per gateway. With an endpoint-only cache key, a warm swap
+    to a second model on the same host meant every subsequent dispatch got the
+    FIRST model's client back: the requested model was silently ignored, the
+    op ran on the wrong weights, and its telemetry landed under the wrong
+    physics key.
+
+    On the deployment this exists for, that reads as: one vision one-off swaps
+    to the 27B, and every BACKGROUND op afterwards quietly runs on it at a
+    third of the throughput, blowing route budgets with no error anywhere.
+    """
+
+    def _t(self, model, url="http://h:11434"):
+        return ig.GatewayTarget(base_url=url, model_name=model, scope="remote",
+                                state=ig.HostState.HEALTHY, reason="t")
+
+    def test_two_models_on_one_host_get_two_clients(self):
+        g, made = _gw()
+        a, _ = g._client_for(self._t("qwen3-coder:30b"))
+        b, _ = g._client_for(self._t("qwen3.8:27b"))
+        assert a is not b
+        assert a.cfg.model_name == "qwen3-coder:30b"
+        assert b.cfg.model_name == "qwen3.8:27b"
+
+    def test_the_same_model_is_still_cached(self):
+        """The fix must not turn the cache off — a new client per dispatch
+        would leak a session per op."""
+        g, _made = _gw()
+        a, _ = g._client_for(self._t("qwen3-coder:30b"))
+        b, _ = g._client_for(self._t("qwen3-coder:30b"))
+        assert a is b
+
+    def test_each_client_writes_its_own_physics_key(self):
+        """The observable symptom of the bug: telemetry under the wrong key.
+        Two models must never share one ledger entry."""
+        g, _made = _gw()
+        _a, pa = g._client_for(self._t("qwen3-coder:30b"))
+        _b, pb = g._client_for(self._t("qwen3.8:27b"))
+        assert pa._ledger_key != pb._ledger_key
+        assert "qwen3-coder:30b" in pa._ledger_key
+        assert "qwen3.8:27b" in pb._ledger_key
+
+    def test_the_same_model_on_two_hosts_gets_two_clients(self):
+        g, _made = _gw()
+        a, _ = g._client_for(self._t("m", "http://a:11434"))
+        b, _ = g._client_for(self._t("m", "http://b:11434"))
+        assert a is not b
+
+    @pytest.mark.asyncio
+    async def test_aclose_still_closes_every_cached_client(self):
+        g, _made = _gw()
+        clients = [g._client_for(self._t(m))[0]
+                   for m in ("m1", "m2", "m3")]
+        await g.aclose()
+        assert all(c.closed for c in clients)

--- a/tests/governance/test_latency_physics_ledger.py
+++ b/tests/governance/test_latency_physics_ledger.py
@@ -35,11 +35,58 @@ def ledger(tmp_path, monkeypatch):
 
 
 class TestLedgerBasics:
-    def test_physics_key_is_model_and_ctx_not_endpoint(self):
+    def test_physics_key_carries_model_and_ctx_but_never_the_address(self):
+        """The original contract, minus the exact-string assertion.
+
+        The key still ends in model@ctx and still must not contain a port or
+        an address -- node IPs change every run. What was added in front is a
+        HARDWARE axis; see the host-isolation tests below for why.
+        """
         cfg = _cfg(model_name="qwen2.5-coder:32b", num_ctx=16640)
-        assert lid.physics_key(cfg) == "qwen2.5-coder:32b@16640"
-        cfg2 = _cfg(model_name="qwen2.5-coder:3b", num_ctx=0)
-        assert lid.physics_key(cfg2) == "qwen2.5-coder:3b@cpu"
+        key = lid.physics_key(cfg)
+        assert key.endswith("qwen2.5-coder:32b@16640")
+        assert _cfg(model_name="qwen2.5-coder:3b", num_ctx=0) and \
+            lid.physics_key(_cfg(model_name="qwen2.5-coder:3b",
+                                 num_ctx=0)).endswith("qwen2.5-coder:3b@cpu")
+        # the address must not survive into the identity
+        assert "11434" not in key and "127.0.0.1" not in key
+
+    def test_two_machines_do_not_share_one_ledger_key(self):
+        """The defect this axis exists for.
+
+        Same model name, two hosts. Under the old key they wrote the SAME
+        entry, so a 16GB M1 that measured ~95ms/token would size an RTX
+        5090's lane count -- the ThroughputGovernor computing a wrong answer
+        from honest data.
+        """
+        from backend.core.ouroboros.governance import hardware_signature as hs
+        hs.reset_for_tests()
+        local = lid.physics_key(_cfg(model_name="m", num_ctx=8192,
+                                     base_url="http://127.0.0.1:11434"))
+        remote = lid.physics_key(_cfg(model_name="m", num_ctx=8192,
+                                      base_url="http://192.168.1.50:11434"))
+        assert local != remote
+        assert local.endswith("m@8192") and remote.endswith("m@8192")
+
+    def test_one_machine_serving_two_ports_is_one_machine(self):
+        """A port is not a piece of hardware. Splitting the ledger by port
+        would re-introduce the amnesia it exists to cure."""
+        from backend.core.ouroboros.governance import hardware_signature as hs
+        hs.reset_for_tests()
+        a = lid.physics_key(_cfg(model_name="m", num_ctx=8192,
+                                 base_url="http://192.168.1.50:11434"))
+        b = lid.physics_key(_cfg(model_name="m", num_ctx=8192,
+                                 base_url="http://192.168.1.50:8080"))
+        assert a == b
+
+    def test_the_flag_off_restores_the_legacy_shape_byte_for_byte(self,
+                                                                  monkeypatch):
+        from backend.core.ouroboros.governance import hardware_signature as hs
+        monkeypatch.setenv("JARVIS_HARDWARE_SIGNATURE_ENABLED", "0")
+        hs.reset_for_tests()
+        assert lid.physics_key(
+            _cfg(model_name="qwen2.5-coder:32b", num_ctx=16640)
+        ) == "qwen2.5-coder:32b@16640"
 
     def test_corrupt_ledger_failsoft(self, ledger):
         ledger.write_text("{not json")

--- a/tests/governance/test_local_tier_profile.py
+++ b/tests/governance/test_local_tier_profile.py
@@ -1,0 +1,264 @@
+"""The deployment profile, the warm swap, and the triage fallback.
+
+Three things are pinned here:
+
+  1. **No dead config.** Every `JARVIS_*` setting in the profile must be read
+     by code somewhere. A profile documenting a knob nothing consults is the
+     same defect class as a capability with no caller -- it looks configured
+     and does nothing.
+  2. **The warm swap is paid outside the op's clock.** Ollama loads on first
+     use; if that load happens inside a generation window calibrated for
+     generation, the op dies on a deadline that had nothing to do with the
+     model's speed.
+  3. **"Unknowable" is not "empty".** A server without `/api/ps` must not be
+     read as holding no models, or every op would trigger a needless swap.
+"""
+from __future__ import annotations
+
+import io
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import inference_gateway as ig
+
+PROFILE = Path("deploy/local_tier_windows.env")
+
+
+def _profile_settings():
+    out = {}
+    for line in io.open(PROFILE, encoding="utf-8"):
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        out[k.strip()] = v.strip()
+    return out
+
+
+class TestTheProfileIsReal:
+    def test_the_profile_exists_and_parses(self):
+        assert PROFILE.is_file()
+        assert _profile_settings()
+
+    def test_every_jarvis_setting_is_actually_read_by_code(self):
+        """No dead config. A knob nothing consults is documentation pretending
+        to be configuration."""
+        settings = [k for k in _profile_settings() if k.startswith("JARVIS_")]
+        assert settings, "profile declares no JARVIS_* settings"
+        src = ""
+        for path in Path("backend/core/ouroboros/governance").rglob("*.py"):
+            try:
+                src += io.open(path, encoding="utf-8").read()
+            except Exception:  # noqa: BLE001
+                continue
+        missing = [k for k in settings if k not in src]
+        assert not missing, f"profile sets knobs no code reads: {missing}"
+
+    def test_the_ollama_settings_are_marked_as_server_side(self):
+        """OLLAMA_* are read by `ollama serve` ON THE WINDOWS BOX. Sourcing
+        this file on the Mac does not apply them, and a profile that did not
+        say so would be actively misleading."""
+        text = io.open(PROFILE, encoding="utf-8").read()
+        assert "OLLAMA_KEEP_ALIVE=-1" in text
+        assert "OLLAMA_MAX_LOADED_MODELS=1" in text
+        assert "OLLAMA_KV_CACHE_TYPE=q8_0" in text
+        assert "WINDOWS" in text.upper()
+        head = text[:text.index("PART B")]
+        assert "cannot set them remotely" in head or "NOT apply them" in head
+
+    def test_the_endpoint_is_not_a_code_default(self):
+        """The LAN address lives in the profile, never in code -- an unset
+        endpoint is the single-machine case, not a misconfiguration."""
+        import inspect
+        assert "192.168." not in inspect.getsource(ig)
+
+    def test_sharding_is_explicitly_off_for_a_single_gpu_host(self):
+        assert _profile_settings().get("JARVIS_LOCAL_ACCEL_SHARDING") == "0"
+
+    def test_the_resident_model_is_the_moe_workhorse(self):
+        s = _profile_settings()
+        assert s["JARVIS_REMOTE_INFERENCE_MODEL"] == "qwen3-coder:30b"
+        assert s["JARVIS_LOCAL_TRIAGE_MODEL"]      # M1 fallback declared
+
+
+class TestKeepAliveReachesTheWire:
+    def test_minus_one_survives_parsing_and_is_sent_verbatim(self,
+                                                             monkeypatch):
+        """`-1` is ollama's "never unload". If parsing clamped it to 0 the
+        meaning would INVERT to "unload immediately" -- the exact opposite of
+        the profile's intent."""
+        from backend.core.ouroboros.governance import (
+            local_inference_director as lid,
+        )
+        monkeypatch.setenv("JARVIS_LOCAL_MODEL_KEEP_ALIVE_SECONDS", "-1")
+        cfg = lid.LocalConfig.from_env()
+        assert cfg.keep_alive_seconds == -1
+
+    def test_it_cannot_starve_the_http_connector(self):
+        """The same value feeds the aiohttp connector keepalive, which must
+        stay positive. The `max(30, ...)` guard is what keeps one env var
+        from meaning two incompatible things."""
+        import inspect
+        from backend.core.ouroboros.governance import (
+            local_inference_director as lid,
+        )
+        src = inspect.getsource(lid)
+        assert "max(30, self._cfg.keep_alive_seconds)" in src
+
+
+class TestResidencyProbe:
+    @pytest.mark.asyncio
+    async def test_an_unreachable_host_is_unknowable_not_empty(self):
+        """None and () mean different things: () would make every op warm-swap
+        against a server that simply does not implement /api/ps."""
+        g = ig.InferenceGateway()
+        assert await g.resident_models("http://127.0.0.1:9") is None
+
+    @pytest.mark.parametrize("wanted,resident,expect", [
+        ("qwen3-coder:30b", ("qwen3-coder:30b",), True),
+        ("qwen3-coder:30b", ("qwen3-coder:30b-instruct-q4_K_M",), True),
+        ("qwen3-coder", ("qwen3-coder:latest",), True),
+        ("qwen3-coder:30b", ("qwen3.8:27b",), False),
+        ("qwen3-coder:30b", (), False),
+        ("", ("anything",), True),
+    ])
+    def test_tag_variants_do_not_trigger_a_needless_swap(self, wanted,
+                                                         resident, expect):
+        """`qwen3-coder:30b` and `...:30b-instruct-q4_K_M` are the same weights
+        to an operator. An over-strict match burns a cold load to load what is
+        already loaded."""
+        assert ig.InferenceGateway._model_matches(wanted, resident) is expect
+
+
+class TestTheWarmSwap:
+    class _Client:
+        def __init__(self):
+            self.warmed_with = None
+
+        async def warmup(self, *, timeout_s):
+            self.warmed_with = timeout_s
+            return True
+
+    def _gw(self, resident):
+        g = ig.InferenceGateway()
+        client = self._Client()
+
+        async def _rm(_url):
+            return resident
+        g.resident_models = _rm                      # type: ignore[assignment]
+        g._client_for = lambda t: (client, None)     # type: ignore[assignment]
+        return g, client
+
+    def _target(self, model="qwen3.8:27b"):
+        return ig.GatewayTarget(base_url="http://h:11434", model_name=model,
+                                scope="remote", state=ig.HostState.HEALTHY,
+                                reason="t")
+
+    @pytest.mark.asyncio
+    async def test_a_resident_model_is_not_reloaded(self):
+        g, client = self._gw(("qwen3.8:27b",))
+        rep = await g.ensure_model_resident(self._target())
+        assert rep["swapped"] is False and client.warmed_with is None
+        assert rep["reason"] == "already resident"
+
+    @pytest.mark.asyncio
+    async def test_a_different_resident_model_triggers_a_swap(self):
+        g, client = self._gw(("qwen3-coder:30b",))
+        rep = await g.ensure_model_resident(self._target("qwen3.8:27b"))
+        assert rep["swapped"] is True
+        assert client.warmed_with == ig.warm_swap_budget_s()
+
+    @pytest.mark.asyncio
+    async def test_the_swap_uses_its_own_budget_not_a_route_budget(self,
+                                                                   monkeypatch):
+        """A cold load is PCIe transfer, not generation. Charging it to the
+        route budget would fail the op on a deadline that says nothing about
+        the model."""
+        monkeypatch.setenv("JARVIS_GATEWAY_WARM_SWAP_BUDGET_S", "240")
+        g, client = self._gw(("other:1b",))
+        await g.ensure_model_resident(self._target())
+        assert client.warmed_with == 240.0
+        from backend.core.ouroboros.governance.route_budgets import (
+            route_generation_budget_s,
+        )
+        assert client.warmed_with != route_generation_budget_s("background")
+
+    @pytest.mark.asyncio
+    async def test_unknowable_residency_dispatches_without_swapping(self):
+        g, client = self._gw(None)
+        rep = await g.ensure_model_resident(self._target())
+        assert rep["swapped"] is False and client.warmed_with is None
+        assert "unknown" in rep["reason"]
+
+    @pytest.mark.asyncio
+    async def test_preflight_off_is_a_clean_no_op(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_GATEWAY_PREFLIGHT_ENABLED", "0")
+        g, client = self._gw(("other:1b",))
+        rep = await g.ensure_model_resident(self._target())
+        assert rep["checked"] is False and client.warmed_with is None
+
+    @pytest.mark.asyncio
+    async def test_a_broken_preflight_never_blocks_dispatch(self):
+        g, _c = self._gw(("other:1b",))
+
+        async def _boom(_url):
+            raise OSError("probe exploded")
+        g.resident_models = _boom                    # type: ignore[assignment]
+        rep = await g.ensure_model_resident(self._target())
+        assert "degraded" in rep["reason"]
+
+    @pytest.mark.asyncio
+    async def test_residency_is_cached_within_its_ttl(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_GATEWAY_RESIDENCY_TTL_S", "300")
+        calls = {"n": 0}
+        g = ig.InferenceGateway()
+
+        async def _rm(_url):
+            calls["n"] += 1
+            return ("qwen3.8:27b",)
+        g.resident_models = _rm                      # type: ignore[assignment]
+        await g.ensure_model_resident(self._target())
+        await g.ensure_model_resident(self._target())
+        assert calls["n"] == 1
+
+    def test_the_swap_runs_outside_the_failure_classifier(self):
+        """A slow cold load must not be recorded as a host fault -- it would
+        open the breaker on a healthy machine that was merely loading."""
+        import ast
+        import inspect
+        import textwrap
+        src = textwrap.dedent(inspect.getsource(ig.InferenceGateway.dispatch))
+        tree = ast.parse(src)
+        tries = [n for n in ast.walk(tree) if isinstance(n, ast.Try)]
+        assert tries, "dispatch has no try block"
+        in_try = {
+            n.func.attr for t in tries for n in ast.walk(t)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        }
+        assert "ensure_model_resident" not in in_try
+
+
+class TestTheTriageFallback:
+    def test_the_fallback_names_the_configured_triage_model(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_LOCAL_TRIAGE_MODEL", "tiny:1b")
+        t = ig.InferenceGateway()._local_target("outage")
+        assert t.scope == "local" and t.model_name == "tiny:1b"
+
+    def test_it_falls_back_to_the_local_config_when_unset(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_LOCAL_TRIAGE_MODEL", raising=False)
+        assert ig.InferenceGateway()._local_target("x").model_name
+
+    def test_there_is_exactly_one_local_target_builder(self):
+        """DRY pin: the fallback must not be re-derived per call site, or two
+        outage paths will disagree about which model triage runs on."""
+        import ast
+        import inspect
+        import textwrap
+        tree = ast.parse(textwrap.dedent(inspect.getsource(ig)))
+        builders = [n for n in ast.walk(tree)
+                    if isinstance(n, ast.FunctionDef)
+                    and n.name == "_local_target"]
+        assert len(builders) == 1

--- a/tests/governance/test_slice11b_fix_analyze_helper.py
+++ b/tests/governance/test_slice11b_fix_analyze_helper.py
@@ -90,12 +90,33 @@ def _parse_module(path: pathlib.Path) -> _ast.Module:
 
 class TestClosedTaxonomies(unittest.TestCase):
 
-    def test_analyze_outcome_five_values(self) -> None:
-        self.assertEqual(len(list(AnalyzeOutcome)), 5)
+    def test_analyze_outcome_seven_values(self) -> None:
+        """Bumped 5 -> 7 deliberately, per the enum's own contract.
+
+        PATHOLOGICAL and SHED were added because the previous taxonomy could
+        not express two distinct facts the sensor needed to act on:
+
+        * PATHOLOGICAL — refused pre-flight by SHAPE (minified, binary,
+          absurd line density). Not TOO_LARGE, which is about bytes: a 40 KB
+          single-line bundle is under any byte cap and still explodes an AST
+          walk. Load-bearing, because the inline-tiny path runs on the
+          caller's thread and the Oracle's in-process path owns no pool, so
+          neither can be cancelled by a timeout — the pre-flight refusal is
+          their only protection.
+        * SHED — not attempted because the shared pool was saturated. The
+          file is fine; the queue was full. Collapsing this into TIMEOUT
+          blamed the file for the queue, which is exactly how a 6.7 KB source
+          came to be logged as a 10 s timeout after 14.1 s of waiting.
+
+        Both consumers (oracle.py, opportunity_miner_sensor) branch on
+        `!= OK`, so the new values degrade safely to "skip this file" while
+        the DeferredTaskLedger records WHY and whether it is worth revisiting.
+        """
+        self.assertEqual(len(list(AnalyzeOutcome)), 7)
         self.assertEqual(
             {m.name for m in AnalyzeOutcome},
             {"OK", "SYNTAX_ERROR", "TIMEOUT", "TOO_LARGE",
-             "INTERNAL_ERROR"},
+             "INTERNAL_ERROR", "PATHOLOGICAL", "SHED"},
         )
 
     def test_opportunity_analysis_payload_is_frozen(self) -> None:

--- a/tests/governance/test_sovereign_override.py
+++ b/tests/governance/test_sovereign_override.py
@@ -188,14 +188,40 @@ class TestTheQoSBreakerThatAlreadyExists:
     model, and that the breach is attributable.
     """
 
-    def test_the_orchestrator_caps_generation_per_lane(self):
+    def test_the_budgets_are_keyed_on_the_lane(self, monkeypatch):
         """The budgets are keyed on the LANE, so a slow model forced onto a
         fast lane inherits the fast lane's ceiling — which is exactly the
-        containment the brief asked for."""
+        containment the brief asked for.
+
+        Asserted against the resolver's OUTPUT rather than against the
+        spelling of an env var in some module's source. The table moved to
+        `route_budgets` (it had been written twice, byte-identical, in
+        orchestrator and generate_runner); a source-grep would have called
+        that a regression when nothing about the behaviour changed.
+        """
+        from backend.core.ouroboros.governance.route_budgets import (
+            route_generation_budget_s,
+        )
+        immediate = route_generation_budget_s("immediate")
+        background = route_generation_budget_s("background")
+        # The containment the brief asked for: the fast lane's ceiling is
+        # genuinely tighter, so a slow model pinned to it cannot inherit a
+        # background-sized window.
+        assert immediate < background
+
+        # ...and it is tunable, which is the property the env var existed for.
+        monkeypatch.setenv("JARVIS_GEN_TIMEOUT_IMMEDIATE_S", "7")
+        assert route_generation_budget_s("immediate") == 7.0
+
+    def test_the_orchestrator_enforces_that_budget(self):
+        """The ceiling is not advisory: the orchestrator reads the canonical
+        table and enforces it with a cancelling wait, plus the outer grace."""
         import inspect
         from backend.core.ouroboros.governance import orchestrator
         source = inspect.getsource(orchestrator)
-        assert "JARVIS_GEN_TIMEOUT_IMMEDIATE_S" in source
+        # Wiring pin: the orchestrator must read the ONE table. Without this,
+        # a future edit could re-inline a private copy and drift again.
+        assert "route_generation_budgets" in source
         assert "_gen_timeout + _OUTER_GATE_GRACE_S" in source
         assert "asyncio.wait_for(" in source
 

--- a/tests/governance/test_throughput_governor.py
+++ b/tests/governance/test_throughput_governor.py
@@ -1,0 +1,249 @@
+"""Measured throughput sizes the lane count — and says how it knows.
+
+The defect this guards: `BackgroundAgentPool` ran a CONSTANT number of lanes
+against one serving endpoint. A single local GPU serves concurrent requests
+SERIALLY, so N lanes multiply each op's wall-clock instead of its output, and
+the tail blows the route budget (`tool_loop_deadline_exceeded`).
+
+These tests pin the two things that make the fix a fix rather than a differently
+-spelled constant:
+
+  1. the lane count is DERIVED from measured latency and moves with it, and
+  2. every verdict states the PROVENANCE of the number it is derived from, so
+     a clamp is never read as a measurement.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from backend.core.ouroboros.governance import local_inference_director as lid
+from backend.core.ouroboros.governance import throughput_governor as tg
+from backend.core.ouroboros.governance import route_budgets as rb
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch):
+    """Every test gets its own physics ledger + a fresh governor.
+
+    Without this the tests would read `.jarvis/latency_physics.json` — the
+    real box's physics — and would pass or fail based on what the developer's
+    laptop happened to have measured that morning.
+    """
+    d = tempfile.mkdtemp()
+    monkeypatch.setenv("JARVIS_LATENCY_LEDGER_PATH", os.path.join(d, "l.json"))
+    monkeypatch.delenv("JARVIS_THROUGHPUT_GOVERNOR_ENABLED", raising=False)
+    tg.reset_for_tests()
+    yield
+    tg.reset_for_tests()
+
+
+def _seed_ledger(*, total_ms: float, ttft_ms: float = 50.0,
+                 out_tokens: int = 400, n: int = 8) -> None:
+    """Write n real-shaped samples into the isolated ledger."""
+    cfg = lid.LocalConfig.from_env()
+    p = lid.LatencyProfiler(cfg, ledger_key=lid.physics_key(cfg))
+    for _ in range(n):
+        p.record(ttft_ms=ttft_ms, total_ms=total_ms, output_tokens=out_tokens)
+
+
+class TestTheNumberIsDerived:
+    def test_faster_physics_buys_more_lanes(self):
+        """The whole point: lanes track measurement. If this can only ever
+        return one value it is a hardcode wearing a governor's clothes."""
+        _seed_ledger(total_ms=900.0)
+        fast = tg.ThroughputGovernor().evaluate(budget_s=180)
+
+        _seed_ledger(total_ms=40_000.0)
+        slow = tg.ThroughputGovernor().evaluate(budget_s=180)
+
+        assert fast.governed and slow.governed
+        assert fast.lanes > slow.lanes, (
+            f"lanes did not move with physics: fast={fast.lanes} "
+            f"slow={slow.lanes}")
+
+    def test_a_wider_budget_buys_more_lanes(self):
+        _seed_ledger(total_ms=900.0)
+        g = tg.ThroughputGovernor()
+        narrow = g.evaluate(budget_s=30)
+        g.invalidate()
+        wide = g.evaluate(budget_s=600)
+        assert wide.lanes >= narrow.lanes
+
+    def test_it_never_returns_zero_lanes(self):
+        """A zero-lane pool is a STALLED queue — a worse failure than a slow
+        one. When even one op cannot fit, the honest answer is 'run one and
+        let the existing deadline machinery record the breach'."""
+        _seed_ledger(total_ms=600_000.0)
+        v = tg.ThroughputGovernor().evaluate(budget_s=1)
+        assert v.lanes == 1
+        assert v.detail["raw_lanes"] < 1  # the math really did want zero
+
+
+class TestItSaysHowItKnows:
+    def test_no_samples_is_labelled_seeded_not_measured(self):
+        v = tg.ThroughputGovernor().evaluate(budget_s=180)
+        assert v.provenance == "seeded"
+        assert v.measured is False
+
+    def test_real_samples_are_labelled_measured(self):
+        _seed_ledger(total_ms=900.0)
+        v = tg.ThroughputGovernor().evaluate(budget_s=180)
+        assert v.provenance == "measured"
+        assert v.measured is True
+
+    def test_a_saturated_estimate_is_labelled_a_lower_bound(self):
+        """`adaptive_timeout_ms` CLAMPS to its ceiling. A clamp reported as a
+        measurement is a fabricated reading — the same class the Advisor's
+        blast-radius provenance work exists to prevent."""
+        _seed_ledger(total_ms=400_000.0)
+        v = tg.ThroughputGovernor().evaluate(budget_s=180)
+        assert v.provenance == "ceiling_clamped"
+        assert v.detail["saturated"] is True
+        assert "LOWER BOUND" in v.reason
+
+    def test_measured_provenance_survives_a_fresh_instance(self):
+        """`LatencyProfiler.is_calibrated()` is a per-instance scout flag the
+        ledger does NOT persist, so a fresh instance reports False while
+        serving genuinely measured numbers. The verdict must key off sample
+        count (`is_warm`), which does survive."""
+        _seed_ledger(total_ms=900.0)
+        cfg = lid.LocalConfig.from_env()
+        fresh = lid.LatencyProfiler(cfg, ledger_key=lid.physics_key(cfg))
+        assert fresh.is_calibrated() is False   # the trap
+        assert fresh.is_warm() is True          # the truth
+        assert tg.ThroughputGovernor().evaluate(budget_s=180).measured is True
+
+
+class TestItComposesRatherThanCompetes:
+    def test_the_memory_gate_can_only_lower_the_count(self, monkeypatch):
+        _seed_ledger(total_ms=200.0)          # very fast -> many raw lanes
+        ungated = tg.ThroughputGovernor().evaluate(budget_s=600)
+
+        class _Decision:
+            allowed, n_allowed, level = True, 2, "high"
+
+        class _Gate:
+            def can_fanout(self, n):
+                return _Decision()
+
+        from backend.core.ouroboros.governance import memory_pressure_gate as mpg
+        monkeypatch.setattr(mpg, "get_default_gate", lambda: _Gate())
+        monkeypatch.setattr(mpg, "is_enabled", lambda: True)
+        gated = tg.ThroughputGovernor().evaluate(budget_s=600)
+
+        assert gated.lanes == 2
+        assert gated.lanes <= ungated.lanes
+
+    def test_a_gate_answering_higher_than_asked_cannot_raise_lanes(
+            self, monkeypatch):
+        """Both are CEILING authorities. If the gate ever answered above what
+        it was asked, taking its number verbatim would let a memory gate
+        RAISE concurrency — the opposite of its job."""
+        _seed_ledger(total_ms=40_000.0)
+
+        class _Decision:
+            allowed, n_allowed, level = True, 99, "ok"
+
+        class _Gate:
+            def can_fanout(self, n):
+                return _Decision()
+
+        from backend.core.ouroboros.governance import memory_pressure_gate as mpg
+        monkeypatch.setattr(mpg, "get_default_gate", lambda: _Gate())
+        monkeypatch.setattr(mpg, "is_enabled", lambda: True)
+        v = tg.ThroughputGovernor().evaluate(budget_s=180)
+        assert v.lanes <= v.detail["raw_lanes"] or v.lanes == 1
+
+
+class TestItDegradesToTodaysBehaviour:
+    def test_master_off_is_ungoverned(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_THROUGHPUT_GOVERNOR_ENABLED", "0")
+        v = tg.ThroughputGovernor().evaluate(budget_s=180)
+        assert v.governed is False and v.lanes == 0
+
+    def test_ungoverned_is_distinguishable_from_one_lane(self):
+        """`lanes=1` and 'we could not measure' must never be the same value:
+        the first is a decision, the second is an absence of one."""
+        assert tg._ungoverned("x").governed is False
+        _seed_ledger(total_ms=600_000.0)
+        assert tg.ThroughputGovernor().evaluate(budget_s=1).governed is True
+
+    def test_a_broken_profiler_degrades_instead_of_raising(self, monkeypatch):
+        monkeypatch.setattr(
+            tg.ThroughputGovernor, "_profiler_and_config",
+            staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("boom"))))
+        v = tg.ThroughputGovernor().evaluate(budget_s=180)
+        assert v.governed is False
+
+    def test_a_nonsense_budget_is_ungoverned(self):
+        g = tg.ThroughputGovernor()
+        assert g.evaluate(budget_s=0).governed is False
+        g.invalidate()
+        assert g.evaluate(budget_s=-5).governed is False
+
+    def test_a_wedged_estimator_is_information_not_absence(self, monkeypatch):
+        """A runaway-latency refusal MEANS something: the model is wedged, so
+        the honest lane count is the minimum. Degrading to UNGOVERNED there
+        would tell the pool to keep whatever it had."""
+        class _Wedged:
+            def adaptive_timeout_ms(self, **_):
+                raise lid.UnrecoverableInferenceLatency("wedged")
+
+            def is_warm(self):
+                return True
+
+        monkeypatch.setattr(
+            tg.ThroughputGovernor, "_profiler_and_config",
+            staticmethod(lambda: (_Wedged(), lid.LocalConfig.from_env())))
+        v = tg.ThroughputGovernor().evaluate(budget_s=180)
+        assert v.governed is True and v.lanes == 1
+        assert v.provenance == "wedged"
+
+
+class TestCaching:
+    def test_the_verdict_is_cached_then_invalidatable(self):
+        _seed_ledger(total_ms=900.0)
+        g = tg.ThroughputGovernor()
+        first = g.evaluate(budget_s=180)
+        assert g.evaluate(budget_s=999999) is first     # served from cache
+        g.invalidate()
+        assert g.evaluate(budget_s=999999) is not first
+
+    def test_ttl_zero_disables_caching(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_THROUGHPUT_VERDICT_TTL_S", "0")
+        _seed_ledger(total_ms=900.0)
+        g = tg.ThroughputGovernor()
+        assert g.evaluate(budget_s=180) is not g.evaluate(budget_s=180)
+
+
+class TestRouteBudgets:
+    def test_the_table_has_exactly_one_home(self):
+        """It was written twice, byte-identical, in orchestrator and
+        generate_runner. Both must now READ the canonical resolver — a
+        re-inlined private copy is how the drift comes back."""
+        import inspect
+        from backend.core.ouroboros.governance import orchestrator
+        from backend.core.ouroboros.governance.phase_runners import generate_runner
+        for mod in (orchestrator, generate_runner):
+            src = inspect.getsource(mod)
+            assert "route_generation_budgets" in src, mod.__name__
+            assert "JARVIS_GEN_TIMEOUT_STANDARD_S" not in src, (
+                f"{mod.__name__} re-inlined its own copy of the route table")
+
+    def test_unknown_route_returns_the_callers_default(self):
+        """Callers already hold a meaningful fallback
+        (`config.generation_timeout_s`); inventing one here would silently
+        overrule it."""
+        assert rb.route_generation_budget_s("not-a-route", 42.0) == 42.0
+
+    def test_a_malformed_env_value_falls_back_to_its_own_default(
+            self, monkeypatch):
+        monkeypatch.setenv("JARVIS_GEN_TIMEOUT_BACKGROUND_S", "not-a-number")
+        assert rb.route_generation_budget_s("background") == 180.0
+
+    def test_the_fast_lane_ceiling_is_genuinely_tighter(self):
+        b = rb.route_generation_budgets()
+        assert b["immediate"] < b["background"]

--- a/tests/governance/test_throughput_governor_pool_wiring.py
+++ b/tests/governance/test_throughput_governor_pool_wiring.py
@@ -1,0 +1,156 @@
+"""The governor is CONSULTED by the pool — and composes with the lock.
+
+Two failure modes this guards, both of which have precedent in this codebase:
+
+  1. **Wired but inert.** A consult whose fallback touches something the class
+     does not own raises, gets swallowed by a broad `except`, and returns "no
+     opinion" forever. The capability ships, the tests pass, nothing happens.
+  2. **A second authority.** Routing a throughput number through
+     `set_target_pool_size` would either be silently rejected by the
+     Immutability Lock (a no-op exactly where a serving mesh exists) or would
+     have to outrank hardware truth. Lane COUNT and lane DRIVABILITY are
+     different axes and must compose, not compete.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import os
+import tempfile
+import textwrap
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from backend.core.ouroboros.governance import local_inference_director as lid
+from backend.core.ouroboros.governance import throughput_governor as tg
+from backend.core.ouroboros.governance.background_agent_pool import (
+    BackgroundAgentPool,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch):
+    d = tempfile.mkdtemp()
+    monkeypatch.setenv("JARVIS_LATENCY_LEDGER_PATH", os.path.join(d, "l.json"))
+    monkeypatch.delenv("JARVIS_THROUGHPUT_GOVERNOR_ENABLED", raising=False)
+    tg.reset_for_tests()
+    yield
+    tg.reset_for_tests()
+
+
+def _pool(**kw) -> BackgroundAgentPool:
+    return BackgroundAgentPool(
+        orchestrator=cast(Any, SimpleNamespace()), pool_size=3, queue_size=4, **kw)
+
+
+class TestTheConsultIsActuallyLive:
+    def test_it_returns_a_real_ceiling_not_none(self):
+        """The anti-inertness pin. `_throughput_lane_ceiling` reaches for a
+        route budget; an earlier draft reached it via `self._config`, which
+        this class does not own — every call raised, the broad `except`
+        swallowed it, and the consult was dead while looking wired."""
+        assert isinstance(_pool()._throughput_lane_ceiling(), int)
+
+    def test_it_returns_none_when_the_governor_is_off(self, monkeypatch):
+        """None means 'no opinion' — the caller must leave lanes untouched.
+        It must be distinguishable from a real ceiling of 1."""
+        monkeypatch.setenv("JARVIS_THROUGHPUT_GOVERNOR_ENABLED", "0")
+        tg.reset_for_tests()
+        assert _pool()._throughput_lane_ceiling() is None
+
+    def test_the_ceiling_tracks_measured_physics(self):
+        cfg = lid.LocalConfig.from_env()
+        prof = lid.LatencyProfiler(cfg, ledger_key=lid.physics_key(cfg))
+        for _ in range(8):
+            prof.record(ttft_ms=50.0, total_ms=900.0, output_tokens=400)
+        fast = _pool()._throughput_lane_ceiling()
+
+        tg.reset_for_tests()
+        prof2 = lid.LatencyProfiler(cfg, ledger_key=lid.physics_key(cfg))
+        for _ in range(8):
+            prof2.record(ttft_ms=50.0, total_ms=90_000.0, output_tokens=400)
+        slow = _pool()._throughput_lane_ceiling()
+
+        assert fast is not None and slow is not None
+        assert fast > slow
+
+
+class TestItComposesWithTheImmutabilityLock:
+    def test_the_consult_never_calls_the_locked_setter(self):
+        """Structural, via AST rather than substring: a comment mentioning the
+        setter must not be able to fail (or pass) this test."""
+        src = inspect.getsource(BackgroundAgentPool._throughput_lane_ceiling)
+        tree = ast.parse(textwrap.dedent(src))
+        called = {
+            n.func.attr for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        }
+        assert "set_target_pool_size" not in called
+
+    @pytest.mark.asyncio
+    async def test_the_ceiling_still_applies_under_a_held_lock(self):
+        """The whole reason this is a separate axis. Under a topology lock,
+        `set_target_pool_size` rejects every other source — so a throughput
+        number pushed through it would vanish. Consulted directly, it lives."""
+        pool = _pool()
+        assert pool.set_target_pool_size(3, source="fleet_topology", lock=True)
+        assert pool.set_target_pool_size(1, source="config") is False  # rejected
+        assert pool._throughput_lane_ceiling() is not None  # survives the lock
+
+
+class TestHoldIsReversibleAndRetireIsNot:
+    def _throughput_branch(self) -> ast.If:
+        """The `if` in `_worker_loop` guarding on the throughput ceiling."""
+        src = textwrap.dedent(
+            inspect.getsource(BackgroundAgentPool._worker_loop))
+        for node in ast.walk(ast.parse(src)):
+            if not isinstance(node, ast.If):
+                continue
+            names = {n.id for n in ast.walk(node.test) if isinstance(n, ast.Name)}
+            if "_thr" in names:
+                return node
+        raise AssertionError("throughput gate not found in _worker_loop")
+
+    def test_the_throughput_gate_continues_it_does_not_break(self):
+        """A topology retire is permanent and CORRECT — a node either exists
+        or it does not. A throughput ceiling comes from a reading with a ~30s
+        TTL, so breaking on it would make a transient measurement (a cold
+        model load, a memory spike) an irreversible decision."""
+        body = self._throughput_branch().body
+        kinds = {type(n) for n in ast.walk(ast.Module(body=body, type_ignores=[]))}
+        assert ast.Continue in kinds
+        assert ast.Break not in kinds
+
+    def test_the_gate_waits_so_stop_stays_responsive(self):
+        """A bare `continue` would spin the worker hot."""
+        node = self._throughput_branch()
+        assert any(isinstance(n, ast.Await) for n in ast.walk(node))
+
+    def test_worker_zero_can_never_be_held(self):
+        """The governor floors its verdict at 1 lane, so `worker_id >= ceiling`
+        is false for worker 0. A zero-lane pool is a STALLED queue."""
+        for total_ms in (900.0, 90_000.0, 600_000.0):
+            tg.reset_for_tests()
+            cfg = lid.LocalConfig.from_env()
+            p = lid.LatencyProfiler(cfg, ledger_key=lid.physics_key(cfg))
+            for _ in range(8):
+                p.record(ttft_ms=50.0, total_ms=total_ms, output_tokens=400)
+            ceiling = _pool()._throughput_lane_ceiling()
+            assert ceiling is not None and ceiling >= 1
+
+
+class TestNamingDoesNotCollide:
+    def test_the_hold_is_not_called_park(self):
+        """`ParkRequested` / `ParkedOpStore` already mean OP-level
+        suspend-and-resume in this module. Reusing the word for worker-level
+        lane throttling would make two mechanisms indistinguishable by name."""
+        src = inspect.getsource(BackgroundAgentPool._worker_loop)
+        tree = ast.parse(textwrap.dedent(src))
+        attrs = {
+            n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)
+        }
+        assert not any("park" in a.lower() for a in attrs
+                       if "throughput" in a.lower())

--- a/tests/governance/test_transport_and_fallback_fusion.py
+++ b/tests/governance/test_transport_and_fallback_fusion.py
@@ -55,14 +55,22 @@ class TestAWorkingFallbackIsNotAnOutage:
         assert r.state is cs.Capability.DEGRADED
         assert "running local" in r.reason
 
-    def test_dry_lane_with_no_remote_is_still_blocked(self, monkeypatch):
-        r = _ev(monkeypatch, dry=True, remote="absent").evaluate()
-        assert r.state is cs.Capability.BLOCKED
+    def test_dry_lane_with_no_remote_still_stops_dispatch(self, monkeypatch):
+        """Asserts the SEMANTIC, not the enum member.
 
-    def test_dry_lane_with_an_unreachable_remote_is_blocked(self, monkeypatch):
+        This read `is cs.Capability.BLOCKED` and broke the moment UNFUNDED was
+        added — a legitimate refinement, since money is the one blocker the
+        organism cannot clear itself. `is_blocking` is the property that
+        actually matters and survives the next refinement too.
+        """
+        r = _ev(monkeypatch, dry=True, remote="absent").evaluate()
+        assert r.state.is_blocking and not r.state.can_work
+        assert r.state is cs.Capability.UNFUNDED
+
+    def test_dry_lane_with_an_unreachable_remote_stops_dispatch(self, monkeypatch):
         r = _ev(monkeypatch, dry=True, remote="unreachable").evaluate()
-        assert r.state is cs.Capability.BLOCKED
-        assert "no lane left" in r.reason
+        assert r.state.is_blocking and not r.state.can_work
+        assert "unreachable" in r.reason
 
     def test_a_configured_but_untried_host_counts_as_a_lane(self, monkeypatch):
         """Never-contacted is UNVERIFIED, not broken. Reporting BLOCKED would

--- a/tests/governance/test_transport_and_fallback_fusion.py
+++ b/tests/governance/test_transport_and_fallback_fusion.py
@@ -1,0 +1,210 @@
+"""Network variance must not become inference telemetry, and a working
+fallback must not read as an outage.
+
+Two defects this closes, both introduced by the bridge itself:
+
+  1. A dry paid lane resolved to BLOCKED even when the sovereign host was
+     serving. Once BACKGROUND can run locally, an exhausted card is a COST
+     condition, not a capability one — and a badge that cries outage while the
+     organism works fine teaches the operator to stop reading it.
+  2. The steady-state stall deadline is derived from model physics and
+     computes to ~2.0s on a fast host. Over a Tailscale DERP relay a 2s gap
+     between chunks is legitimate — WireGuard over TCP bunches packets — so
+     the watchdog would sever healthy streams, write timeout penalties into
+     the ledger for a host that was fine, and fail over on hotel wifi.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from backend.core.ouroboros.governance import capability_state as cs
+from backend.core.ouroboros.governance import inference_gateway as ig
+from backend.core.ouroboros.governance import local_inference_director as lid
+from backend.core.ouroboros.governance import transport_profile as tp
+
+REMOTE = "http://100.64.1.20:11434"
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    for k in ("JARVIS_REMOTE_INFERENCE_ENDPOINT", "JARVIS_TRANSPORT_PROFILE_ENABLED",
+              "JARVIS_TRANSPORT_VARIANCE_K", "JARVIS_TRANSPORT_MIN_FLOOR_S",
+              "JARVIS_CAPABILITY_TTL_S"):
+        monkeypatch.delenv(k, raising=False)
+    cs.reset_for_tests(); ig.reset_for_tests(); tp.reset_for_tests()
+    yield
+    cs.reset_for_tests(); ig.reset_for_tests(); tp.reset_for_tests()
+
+
+def _ev(monkeypatch, *, dry, remote):
+    e = cs.CapabilityEvaluator()
+    monkeypatch.setattr(cs.CapabilityEvaluator, "_read_lanes",
+                        staticmethod(lambda: (dry, "doubleword", True)))
+    monkeypatch.setattr(cs.CapabilityEvaluator, "_read_ops",
+                        staticmethod(lambda: (0, 0, 0, True)))
+    monkeypatch.setattr(cs.CapabilityEvaluator, "_read_remote",
+                        staticmethod(lambda: (remote, REMOTE, True)))
+    return e
+
+
+class TestAWorkingFallbackIsNotAnOutage:
+    def test_dry_lane_with_a_serving_host_is_degraded(self, monkeypatch):
+        r = _ev(monkeypatch, dry=True, remote="serving").evaluate()
+        assert r.state is cs.Capability.DEGRADED
+        assert "running local" in r.reason
+
+    def test_dry_lane_with_no_remote_is_still_blocked(self, monkeypatch):
+        r = _ev(monkeypatch, dry=True, remote="absent").evaluate()
+        assert r.state is cs.Capability.BLOCKED
+
+    def test_dry_lane_with_an_unreachable_remote_is_blocked(self, monkeypatch):
+        r = _ev(monkeypatch, dry=True, remote="unreachable").evaluate()
+        assert r.state is cs.Capability.BLOCKED
+        assert "no lane left" in r.reason
+
+    def test_a_configured_but_untried_host_counts_as_a_lane(self, monkeypatch):
+        """Never-contacted is UNVERIFIED, not broken. Reporting BLOCKED would
+        send the operator to buy credits they do not need."""
+        monkeypatch.setenv("JARVIS_REMOTE_INFERENCE_ENDPOINT", REMOTE)
+        assert cs.CapabilityEvaluator._read_remote()[0] == "serving"
+
+    def test_the_capability_read_does_not_touch_the_network(self):
+        """It runs on the render path. A badge that blocked the UI thread on a
+        LAN round-trip would be a worse defect than the one it replaces.
+
+        AST, not substring — for the third time in this codebase. Good code
+        NAMES the thing it deliberately avoids, so `_read_remote`'s docstring
+        says "does NOT call resident_models()" and a text search finds the
+        explanation and fails a function that is in fact clean. A structural
+        test over source must parse it.
+        """
+        import ast
+        import inspect
+        import textwrap
+        tree = ast.parse(textwrap.dedent(
+            inspect.getsource(cs.CapabilityEvaluator._read_remote)))
+        called = {n.func.attr for n in ast.walk(tree)
+                  if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)}
+        assert "resident_models" not in called, "network call on the render path"
+        assert "snapshot" in called
+
+
+class TestBurstAwareTransportBudget:
+    def test_a_relay_switch_widens_the_budget_within_a_few_chunks(self):
+        """Mid-stream direct -> DERP. The budget must expand fast enough that
+        the NEXT chunk is not judged by a LAN-derived deadline."""
+        p = tp.profile_for("x")
+        for _ in range(20):
+            p.observe(0.4)
+        before = p.reading().budget_ms
+        for _ in range(6):
+            p.observe(90.0)
+        after = p.reading().budget_ms
+        assert after > before * 20
+
+    def test_recovery_contracts_slowly(self):
+        """Asymmetric on purpose. Too loose delays detection — recoverable.
+        Too tight severs a healthy stream and poisons the ledger for a host
+        that was fine."""
+        p = tp.profile_for("y")
+        for _ in range(10):
+            p.observe(90.0)
+        peak = p.reading().srtt_ms
+        for _ in range(10):
+            p.observe(0.4)
+        assert p.reading().srtt_ms > peak * 0.05   # still elevated
+
+    def test_bursting_inflates_variance_not_just_the_mean(self):
+        """Packet bunching is a VARIANCE event: 5 chunks instantly, then a
+        long pause. `rttvar` is the term that must absorb it."""
+        p = tp.profile_for("z")
+        for _ in range(12):
+            p.observe(5.0)
+        calm = p.reading()
+        for gap in (1.0, 1.0, 1.0, 1.0, 400.0) * 3:
+            p.observe(gap)
+        bursty = p.reading()
+        assert bursty.rttvar_ms > calm.rttvar_ms * 10
+        assert bursty.budget_ms > calm.budget_ms * 5
+
+    def test_an_unmeasured_transport_contributes_nothing(self):
+        assert tp.profile_for("never-seen").floor_s() == 0.0
+
+    def test_the_floor_never_drops_below_its_minimum(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_TRANSPORT_MIN_FLOOR_S", "0.75")
+        p = tp.profile_for("fast")
+        for _ in range(20):
+            p.observe(0.1)
+        assert p.floor_s() >= 0.75
+
+    def test_disabled_contributes_nothing(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_TRANSPORT_PROFILE_ENABLED", "0")
+        p = tp.profile_for("w")
+        for _ in range(20):
+            p.observe(50.0)
+        assert p.floor_s() == 0.0
+
+    def test_it_never_raises_on_hostile_samples(self):
+        p = tp.profile_for("hostile")
+        for bad in (-1.0, float("nan"), float("inf"), 0.0):
+            p.observe(bad)
+        assert isinstance(p.reading().budget_ms, float)
+
+
+class TestTransportClassKeyDimension:
+    def test_two_transports_do_not_share_a_ledger_key(self):
+        """Same silicon, two networks. Blending them would size lanes for a
+        hotel-wifi session from home-LAN measurements."""
+        cfg = dataclasses.replace(lid.LocalConfig.from_env(),
+                                  model_name="m", num_ctx=8192)
+        p = tp.profile_for(REMOTE)
+        for _ in range(10):
+            p.observe(0.4)
+        near = lid.physics_key(cfg, endpoint=REMOTE)
+        for _ in range(15):
+            p.observe(150.0)
+        far = lid.physics_key(cfg, endpoint=REMOTE)
+        assert near != far
+        assert near.endswith("m@8192") and far.endswith("m@8192")
+
+    def test_an_unmeasured_transport_omits_the_dimension(self):
+        """Empty rather than a guess: an unknown transport must not become a
+        bucket that later real measurements are mixed into."""
+        cfg = dataclasses.replace(lid.LocalConfig.from_env(),
+                                  model_name="m", num_ctx=8192)
+        tp.reset_for_tests()
+        assert lid.physics_key(cfg, endpoint=REMOTE).count("@") == 2
+
+    def test_the_class_has_hysteresis_at_boundaries(self):
+        """A boundary-hugging RTT that flipped the class would shred one
+        host's physics across two keys — the conflation the hardware axis
+        exists to prevent, one level down."""
+        p = tp.profile_for("edge")
+        for _ in range(20):
+            p.observe(14.0)          # just inside "lan" (bound 15.0)
+        first = p.reading().transport_class
+        for _ in range(3):
+            p.observe(16.0)          # just over the boundary
+        assert p.reading().transport_class == first
+
+
+class TestTailnetBinding:
+    def test_the_profile_binds_to_the_tailnet_not_the_world(self):
+        """Ollama has NO AUTHENTICATION. `0.0.0.0` exposes model execution to
+        whatever network the machine is on, including a café LAN."""
+        import io as _io
+        text = _io.open("deploy/local_tier_windows.env", encoding="utf-8").read()
+        active = [l.strip() for l in text.splitlines()
+                  if l.strip().startswith("OLLAMA_HOST=")]
+        assert active, "no OLLAMA_HOST setting"
+        assert not any(l.endswith("0.0.0.0:11434") for l in active)
+        assert any("100." in l for l in active)
+
+    def test_the_client_endpoint_is_a_tailnet_address(self):
+        import io as _io
+        text = _io.open("deploy/local_tier_windows.env", encoding="utf-8").read()
+        line = next(l for l in text.splitlines()
+                    if l.startswith("JARVIS_REMOTE_INFERENCE_ENDPOINT="))
+        assert "100." in line


### PR DESCRIPTION
## The local sovereignty tier, and a cockpit that only claims what it measured

19 commits. Two arcs that turned out to be the same arc: give O+V a lane it owns
outright, and stop the cockpit from asserting things nobody measured.

### 1 — Concurrency is a property of the hardware, not a constant

`JARVIS_BG_POOL_SIZE=3` is a claim about parallelism. On one local GPU it is
false: three lanes on one device are three lanes *queued*, and the pool reports
throughput it never had. `ThroughputGovernor` derives lanes from the physics
ledger instead — `floor((budget_ms x safety) / per_op_ms)` — and **composes with**
the Immutability Lock on `set_target_pool_size` rather than fighting it.

- `route_budgets.py` extracts the route table that was byte-identical in
  `orchestrator` and `generate_runner`.
- `hardware_signature.py` — **ONE SPINE**. `machine_id` alone keys the ledger;
  GPU identity is a *substitute* for a missing spine, never an addition.
  Otherwise flipping `JARVIS_COMPUTE_TOPOLOGY_ENABLED` silently re-keys the
  ledger and every learned latency is orphaned.
- Two GPUs are two capacities, and only the resident stack knows which one counts.

### 2 — Network jitter is not model physics

A slow response over a slow link was being written into the ledger as though the
*model* were slow. `transport_profile.py` separates them with Jacobson/Karels
(RFC 6298), asymmetric on purpose: `_ALPHA_EXPAND = 1/2` widens fast, `_ALPHA = 1/8`
narrows slowly. Measured: 6 samples to expand 0.4ms -> 88.6ms, 30+ to contract.
A working fallback is not an outage.

### 3 — InferenceGateway: a router, not a second transport

Host discovery, `/api/ps` residency, warm model swap, per-host breaker.
Live-fire found the bug the tests could not: the client cache was keyed on
endpoint alone, so a warm swap poisoned it. The key is `(base_url, model_name)`.

### 4 — The cockpit stops claiming what it did not measure

- **The $0.71 nobody could explain** was a *ceiling*, rendered as a *balance*.
  It now carries its basis and says which it is.
- A badge cannot claim health it does not have; `UNFUNDED` is a real state, and
  hysteresis arms on `state.is_blocking` — not on one enum member, which is how
  it stayed silent.
- The DLQ holds work, not identity-less fragments.
- One boot bar that redraws, rendered *through* the screen owner rather than
  underneath it (the flicker was Rich `Live` ownership, not a repaint rate).
- The nameplate is bounded to its column instead of wrapping over the crest, and
  the liquidity payload consults every lane rather than the Claude breaker alone.

### Testing

- New/updated regression spines across governor, topology, transport, gateway,
  capability state, DLQ, boot progress, header bounds: **green**.
- `tests/ui/` on this branch: 4 failed / 487 passed. **All 4 are pre-existing on
  clean `main`** (`938b477bbd`), reproduced in a detached worktree with identical
  assertion signatures — `test_geometry_scales_with_width`,
  `test_mid_trace_resize_regenerates_and_stays_monotonic`,
  `test_additions_and_removals_are_told_apart`,
  `test_ui_package_has_no_literal_styling`. This branch introduces none of them.

### Not yet proven

L1-L7 live-fire (PRD 31.6.1) needs the Windows host and has **not** run. The
local tier is wired and dry-run validated; it is not field-validated. Nothing
here claims otherwise.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives local concurrency from measured model physics and makes the cockpit report only what it observed. Also fixes a dropped gateway degradation signal so remote outages reach the cockpit.

- Replaces `JARVIS_BG_POOL_SIZE` with `ThroughputGovernor`: computes lanes from measured TTFT/tok cost and the real route budget; composes with the pool’s immutability lock; excess lanes hold instead of retire.
- Keys the latency ledger by hardware: `hardware_signature` + `physics_key(cfg, endpoint=...)` prevent cross-host conflation (old: `model@ctx` only).
- Separates network from model physics: `transport_profile` adapts inter-token stall budgets (burst-aware, asymmetric); the remote path is always streamed so the watchdog is armed.
- Adds `InferenceGateway`: routes to a remote host, warm-swaps models before the op clock, tracks per-host health, and binds profilers per `(base_url, model)`; publishes `provider_state_changed` with `base_url` (fixes a previously undefined helper that silently dropped degrade events).
- Makes multi-GPU explicit and non-interchangeable: `compute_topology` reports per-device readings; `device_affinity` prefers the smallest fitting device and never overrides capacity; admission checks weights+KV against the selected device.
- Unifies route timeouts in `route_budgets`; existing readers now consume the single table.
- Cockpit/UI: live boot progress from daemon logs + history; header derives capability from `capability_state`; budget shows its basis; adds “unfunded” state; fixes header bounds and liquidity banner.
- DLQ contract: `intake_dlq` only holds replayable work; diagnostics go to a sibling file; identity extraction includes `dedup_key`/`causal_id`.

**Rollout and review notes**
- Defaults on; disable with `JARVIS_THROUGHPUT_GOVERNOR_ENABLED`, `JARVIS_HARDWARE_SIGNATURE_ENABLED`, `JARVIS_DEVICE_AFFINITY_ENABLED`. Remote routing controlled by `JARVIS_GATEWAY_*`.
- Ledger keys change; old measurements are preserved but not consulted for new keys. Transport is a separate axis; unknown transport does not mix into measured buckets.
- DLQ now rejects legacy non-replayable rows during replay; no data loss (moved to diagnostics).
- Windows bridge profile lives in `deploy/local_tier_windows.env`; `OLLAMA_*` must be set on the Windows host. Live-fire harness: `scripts/live_fire_local_tier.py`.

<sup>Written for commit 5a6188f3007774b9d1d551a2706b1701886634d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

