### PR TITLE
fix(ui): Four contracts moved, four tests stayed, and nothing was watching

### DIFF
--- a/.github/workflows/ui-gate.yml
+++ b/.github/workflows/ui-gate.yml
@@ -1,0 +1,73 @@
+# presentation gate — the cockpit's own suite has to actually run somewhere
+#
+# The root problem this closes: nothing ran `tests/ui/`. `test.yml` and
+# `ci-cd-pipeline.yml` between them run `tests/unit/` and `tests/integration/`,
+# and both append `|| true` so the result is discarded anyway. `tests/ui/` —
+# 496 tests over the crest, the theme guard, the deck grammar, the awakening
+# ceremony and the alt-screen — was named by no workflow at all.
+#
+# So four failures sat on `main` for six weeks each, and every one of them was
+# a contract that had MOVED while its test stayed still:
+#
+#   * 2026-07-18 the crest took a one-column right margin; two tests still
+#     asserted `frame.cols == terminal_cols` (the pre-margin contract).
+#   * 2026-07-27 `ui/alt_screen.py` arrived owning smcup/rmcup, and the theme
+#     guard banned every `\x1b[` — flagging terminal CONTROL as styling.
+#   * 2026-07-30 diff hunks moved from foreground tones to background bands;
+#     the test still asserted the retired foreground hex.
+#
+# None of that is exotic. All of it is what a test suite is for, and it was
+# invisible because the suite had no runner.
+#
+# Design invariants:
+#   * HARD FAIL. No `|| true`. A gate whose result is discarded is not a gate
+#     — that is the exact defect `lint-gate.yml` was written to answer, and
+#     repeating it here would buy nothing.
+#   * NARROW + KEYLESS. rich, prompt_toolkit, pytest. `tests/ui/` is a leaf
+#     suite over the presentation layer; it needs no models, no API keys, no
+#     services. Installing the full requirements set would make this slow and
+#     flaky for no coverage.
+#   * Runs from the REPO ROOT. `pytest.ini` lives there and sets
+#     `pythonpath = . backend`; running from `backend/` (as the older
+#     workflows do) would not import `backend.core.*` at all.
+#   * pty-backed tests self-skip via `tests/pty_gate.py` when no pty can be
+#     allocated. Ubuntu runners have them, so they are expected to RUN here —
+#     which is the point, since a sandboxed laptop is where they skip.
+
+name: ui gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ui-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  presentation-suite:
+    name: ui suite (tests/ui)
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install the presentation layer's dependencies
+        run: |
+          python -m pip install -q --upgrade pip
+          python -m pip install -q \
+            "pytest>=8" "pytest-asyncio>=0.23" "pytest-timeout>=2.2" \
+            "rich>=13" "prompt_toolkit>=3.0"
+
+      - name: Run the presentation suite
+        run: python -m pytest tests/ui/ -p no:randomly --timeout=180

--- a/backend/core/ouroboros/ui/crest.py
+++ b/backend/core/ouroboros/ui/crest.py
@@ -3,7 +3,8 @@
 Ports docs/superpowers/specs/assets/2026-07-07-ov-crest-v5-generator.py into
 a reactive generator: every metric scales from the measured terminal width
 (Mandate 2 -- zero absolute canvas dimensions), clamped to
-[JARVIS_OV_CREST_MIN_COLS, JARVIS_OV_CREST_MAX_COLS]. Rendering is
+[JARVIS_OV_CREST_MIN_COLS, JARVIS_OV_CREST_MAX_COLS] and held back from the
+terminal's last column by JARVIS_OV_CREST_RIGHT_MARGIN. Rendering is
 hard-threshold quadrant rasterization -- solid fill, no anti-aliasing.
 
 The asset is the geometry source of truth; this module reproduces its math
@@ -151,35 +152,71 @@ def _fit_cols(measured_cols: int, measured_rows: int) -> Tuple[int, int, int]:
     exactly where a crest either overflows or vanishes. The range is at most
     a few hundred integers and this runs once per resize."""
     # The cap is now a SAFETY rail, not the working limit: a crest wider than
-    # it stops reading as an emblem and starts reading as wallpaper. The
-    # bounds and the one-column margin come from _clamp_cols so there is a
-    # single definition of each (DRY).
+    # it stops reading as an emblem and starts reading as wallpaper. Every
+    # bound — floor, cap and right margin — comes from _crest_bounds via
+    # _clamp_cols, so each has exactly one definition (DRY).
     lo, hi, width_budget = _clamp_cols(measured_cols)
     # Reserve rows for the header the ceremony prints beneath the crest.
     # CREST_HEADER_ROWS is the single definition of that number — awakening
     # independently reserved 6 rows before deciding whether the animated path
     # would fit, so a reserve chosen separately here would be a second copy
     # free to drift out of step with it.
-    try:
-        reserve = max(0, int(os.environ.get(
-            "JARVIS_OV_CREST_ROW_RESERVE", str(CREST_HEADER_ROWS))))
-    except (TypeError, ValueError):
-        reserve = CREST_HEADER_ROWS
+    reserve = _env_int("JARVIS_OV_CREST_ROW_RESERVE", CREST_HEADER_ROWS)
     row_budget = max(0, int(measured_rows) - reserve)
 
+    # The shrink floor is the minimum CREST width, which is not the ``lo``
+    # returned above — that one is the minimum MEASURED width and includes the
+    # margin. Shrinking to it would stop one column early and, at the
+    # boundary, hand back a crest wider than the width budget it was given.
+    min_crest, _hi, _margin = _crest_bounds()
     fitted = width_budget
-    while fitted > lo and _Geometry.rows_needed(fitted) > row_budget:
+    while fitted > min_crest and _Geometry.rows_needed(fitted) > row_budget:
         fitted -= 1
     return lo, hi, fitted
+
+
+def _env_int(name: str, default: int, *, floor: int = 0) -> int:
+    """One tunable read, defended once.
+
+    Every column bound is operator-tunable, and a malformed value must not be
+    the thing that takes the crest down: this module's contract is that it
+    NEVER raises. ``int("")`` and ``int("wide")`` both raise, so an unparseable
+    override silently became a crash inside a render path that callers trust
+    to degrade instead.
+    """
+    try:
+        return max(floor, int(os.environ.get(name, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+def _crest_bounds() -> Tuple[int, int, int]:
+    """``(min_crest, max_crest, right_margin)`` -- THE definition of every
+    column bound, each independently tunable.
+
+    The margin is a bound in its own right, not a literal buried in an
+    expression. It was written as a bare ``- 1`` inside the clamp, which is
+    how it came to be silently cancelled at the low boundary (see
+    :func:`_clamp_cols`): a number with no name is a number no caller can
+    reason about, and the floor that defeated it looked correct precisely
+    because the thing it was defeating was invisible.
+    """
+    return (
+        _env_int("JARVIS_OV_CREST_MIN_COLS", 46, floor=1),
+        _env_int("JARVIS_OV_CREST_MAX_COLS", 140, floor=1),
+        _env_int("JARVIS_OV_CREST_RIGHT_MARGIN", 1),
+    )
 
 
 def _clamp_cols(measured: int) -> Tuple[int, int, int]:
     """Return (lo, hi, clamped) column bounds for a measured width.
 
-    ``clamped`` is only meaningful when ``measured >= lo`` -- callers must
-    check the low bound against ``measured`` directly (not ``clamped``,
-    which is floored at ``lo`` by construction and so can never itself
-    read as "below minimum").
+    ``lo`` is the minimum MEASURED width -- the narrowest terminal that can
+    hold a crest -- not the minimum crest width. Those differ by the margin,
+    and conflating them is the bug documented below. ``clamped`` is only
+    meaningful when ``measured >= lo``; callers must check the low bound
+    against ``measured`` directly (not ``clamped``, which is floored by
+    construction and so can never itself read as "below minimum").
 
     Width-only. Since 2026-07-25 this is the WIDTH HALF of
     :func:`_fit_cols`, which additionally solves for height — callers that
@@ -190,10 +227,26 @@ def _clamp_cols(measured: int) -> Tuple[int, int, int]:
     as wide as the terminal auto-wraps its last cell onto the next line, and
     every row sheds one detached artifact block. One column of right margin
     kills the whole off-by-one wrap class.
+
+    ...except at the boundary, where it did not (fixed 2026-08-19). The clamp
+    read ``max(min_crest, min(measured - margin, hi))``, and that outer floor
+    is reached exactly when ``measured <= min_crest`` -- at which point it
+    hands back a crest as wide as the terminal and reinstates the wrap class
+    the margin exists to kill. At the default bounds a 46-column terminal
+    emitted 46-column rows: measured and reproducible, not theoretical.
+
+    The floor is not the defect -- a crest narrower than ``min_crest`` stops
+    reading as an emblem, so refusing to shrink past it is right. The defect
+    was asking ONE number to answer two questions. A terminal must afford
+    ``min_crest`` columns for the emblem PLUS ``margin`` for the margin, so
+    the minimum measured width is their SUM, and below it the honest answer
+    is "unavailable" rather than a crest that wraps. Returning that sum as
+    ``lo`` makes the availability guard callers already run
+    (``measured_cols < lo``) correct without a second check to forget.
     """
-    lo = int(os.environ.get("JARVIS_OV_CREST_MIN_COLS", "46"))
-    hi = int(os.environ.get("JARVIS_OV_CREST_MAX_COLS", "140"))
-    return lo, hi, max(lo, min(measured - 1, hi))
+    min_crest, hi, margin = _crest_bounds()
+    return (min_crest + margin, hi,
+            max(min_crest, min(measured - margin, hi)))
 
 
 # ===========================================================================

--- a/tests/ui/test_awakening_resize.py
+++ b/tests/ui/test_awakening_resize.py
@@ -17,6 +17,7 @@ from rich.console import Console
 
 from backend.core.ouroboros.ui.awakening import AwakeningConductor
 from backend.core.ouroboros.ui import theme
+from backend.core.ouroboros.ui import crest as crest_mod
 from tests.ui.test_awakening import FakeClock, FakeTimer
 
 
@@ -69,7 +70,14 @@ async def test_mid_trace_resize_regenerates_and_stays_monotonic():
 
     assert c.regenerations >= 1
     cols_seen = {cols for cols, _ in revealed_counts}
-    assert 50 in cols_seen                            # regenerated at new width
+    # The crest's width is DERIVED from the terminal's, not equal to it:
+    # `_fit_cols` solves both dimensions and holds back the right margin. This
+    # asserted the raw terminal width (`50 in cols_seen`), which was the
+    # pre-margin contract and has been red since 14a2a47ef5 (2026-07-18).
+    # Read the mapping from the sizing function -- the margin and the bounds
+    # are tunables, "it regenerated at the new measurement" is the invariant.
+    assert crest_mod._fit_cols(80, 30)[2] in cols_seen     # before SIGWINCH
+    assert crest_mod._fit_cols(50, 30)[2] in cols_seen     # after  SIGWINCH
     # monotonic reveal FRACTION across the resize boundary (no flash-back)
     fracs = [f for _, f in revealed_counts]
     assert all(b >= a - 1e-9 for a, b in zip(fracs, fracs[1:]))

--- a/tests/ui/test_crest.py
+++ b/tests/ui/test_crest.py
@@ -84,9 +84,76 @@ def test_delays_monotonic_tail_to_head_and_bounded():
 # ---- reactivity + clamping (Mandate 2) --------------------------------------
 
 def test_geometry_scales_with_width():
-    small, large = gen(cols=46), gen(cols=72)
-    assert small.cols == 46 and large.cols == 72
+    """Wider terminal -> wider, denser crest.
+
+    The crest's width is DERIVED from the terminal's, never equal to it:
+    ``_clamp_cols`` holds back ``JARVIS_OV_CREST_RIGHT_MARGIN`` columns so the
+    last cell cannot auto-wrap. This asserted ``cols == 46 and cols == 72``,
+    which was the PRE-margin contract and has been red since 14a2a47ef5
+    (2026-07-18) -- unseen because CI runs tests/unit and tests/integration,
+    never tests/ui.
+
+    The bounds are tunables; the scaling is the invariant. So the expected
+    width is READ from the sizing function rather than restated -- the idiom
+    ``test_hard_clamp_at_default_max`` below already uses.
+    """
+    lo, _hi, _c = crest_mod._clamp_cols(0)     # lo does not depend on measured
+    small_term, large_term = lo, lo + 26
+    rows = 60                                   # ample: isolate WIDTH scaling
+    small, large = gen(cols=small_term, rows=rows), gen(cols=large_term,
+                                                        rows=rows)
+    assert small.unavailable_reason is None and large.unavailable_reason is None
+    assert small.cols == crest_mod._fit_cols(small_term, rows)[2]
+    assert large.cols == crest_mod._fit_cols(large_term, rows)[2]
+    assert large.cols > small.cols
     assert len(large.cells) > len(small.cells) * 1.5
+
+
+def test_the_crest_never_occupies_the_terminals_last_column():
+    """The margin is the whole point of the clamp, and it was cancelled at the
+    boundary for a month.
+
+    ``max(min_crest, min(measured - margin, hi))`` reaches its outer floor
+    exactly when ``measured <= min_crest``, handing back a crest as wide as
+    the terminal -- the auto-wrap / detached-artifact class the margin exists
+    to kill. At default bounds a 46-column terminal emitted 46-column rows.
+
+    A single-width check (``_clamp_cols(80) == 79``) could not see it. Sweep
+    the boundary, and assert the PROPERTY rather than any one number.
+    """
+    lo, hi, _c = crest_mod._clamp_cols(0)
+    _min_crest, _hi, margin = crest_mod._crest_bounds()
+    widths = list(range(lo - 2, lo + 6)) + [60, 72, 80, hi, hi + 1, hi + 60]
+    for term in widths:
+        _lo, _h, clamped = crest_mod._clamp_cols(term)
+        if term < lo:
+            continue                            # correctly unavailable
+        assert clamped <= term - margin, (
+            f"terminal {term}: crest {clamped} leaves no margin")
+
+
+def test_a_terminal_too_narrow_for_crest_plus_margin_is_unavailable():
+    """Availability must account for the margin, or the narrowest accepted
+    terminal is precisely the one that wraps. ``lo`` is the minimum MEASURED
+    width (crest + margin), not the minimum crest width."""
+    lo, _hi, _c = crest_mod._clamp_cols(0)
+    assert generate_crest(lo - 1, 60, tier=T,
+                          unicode_ok=True).unavailable_reason is not None
+    f = generate_crest(lo, 60, tier=T, unicode_ok=True)
+    assert f.unavailable_reason is None
+    assert f.cols < lo                          # the margin survived
+
+
+def test_column_bounds_are_tunable_and_survive_a_malformed_override(
+        monkeypatch):
+    """Every bound is operator-tunable, and this module NEVER raises -- so an
+    unparseable override must degrade to the default, not crash a render."""
+    monkeypatch.setenv("JARVIS_OV_CREST_RIGHT_MARGIN", "3")
+    assert crest_mod._clamp_cols(80)[2] == 77
+    monkeypatch.setenv("JARVIS_OV_CREST_RIGHT_MARGIN", "not-a-number")
+    assert crest_mod._clamp_cols(80)[2] == 79   # back to the default margin
+    monkeypatch.setenv("JARVIS_OV_CREST_MAX_COLS", "")
+    assert crest_mod._clamp_cols(400)[2] == crest_mod._crest_bounds()[1]
 
 
 def test_hard_clamp_at_default_max():

--- a/tests/ui/test_deck_grammar.py
+++ b/tests/ui/test_deck_grammar.py
@@ -92,8 +92,31 @@ class TestHierarchy:
         assert theme.semantic("ok") in deck.action("Validate")
 
     def test_additions_and_removals_are_told_apart(self):
-        assert theme.semantic("ok") in deck.diff(1, "+", "x")
-        assert theme.semantic("crit") in deck.diff(1, "-", "x")
+        """The band belongs to the SIGN -- and it is a BACKGROUND role.
+
+        This asserted the FOREGROUND `ok`/`crit` tones, which `diff` stopped
+        using in eaa1d1468e (2026-07-30): `on <foreground green>` is a
+        saturated slab that renders syntax-highlighted code illegible over it,
+        so the hunk body moved to the dedicated `code_add_bg` / `code_del_bg`
+        background roles. Red ever since, unseen because CI runs tests/unit
+        and tests/integration and never tests/ui.
+
+        The roles are read from `role_palette`, their declared owner, rather
+        than restated as two hexes: the exact tint is a palette decision, and
+        "an addition does not look like a removal" is the invariant this test
+        is named for.
+        """
+        from backend.core.ouroboros.ui.semantic_tokens import role_palette
+        palette = role_palette()
+        add_band, del_band = palette["code_add_bg"], palette["code_del_bg"]
+        assert add_band != del_band, "one tint cannot tell two signs apart"
+
+        added, removed = deck.diff(1, "+", "x"), deck.diff(1, "-", "x")
+        assert f"on {add_band}" in added
+        assert f"on {del_band}" in removed
+        # ...and neither sign wears the other's band.
+        assert f"on {del_band}" not in added
+        assert f"on {add_band}" not in removed
 
 
 class TestContentIsNeverMarkup:

--- a/tests/ui/test_theme_guard.py
+++ b/tests/ui/test_theme_guard.py
@@ -5,8 +5,23 @@ This is the enforcement mechanism for the Restrained Mono migration (spec
 presentation consumer for banned patterns:
 
   * legacy Rich color markup  -- ``[bold cyan]`` / ``[bright_green]`` / ``[dim]``
-  * raw ANSI CSI escapes       -- ``\\x1b[`` (OSC title ``\\x1b]`` is allowed)
+  * raw ANSI SGR escapes       -- ``\\x1b[1;32m`` and every spelling of it
   * hardcoded frames           -- ``"─" * 52`` and friends
+
+The ANSI pattern matches by FUNCTION, not by introducer. What is banned is
+*styling*, so the pattern is SGR -- a CSI run terminated by ``m``. Cursor and
+mode control (``\\x1b[?1049h`` smcup, ``\\x1b[H`` home) carries no appearance
+decision, has no theme-token spelling to migrate to, and is the entire purpose
+of ``ui/alt_screen.py``. Matching every ``\\x1b[`` flagged that module for
+doing its job, while the OSC carve-out below shows the line was always meant
+to be drawn by function.
+
+It matches every SPELLING, too: ``\\x1b``, ``\\033`` and ``\\e`` are one byte
+with three source forms, and a guard that knows only the first is blind to the
+other two -- which is exactly what happened. ``battle_test/diff_display.py``
+sat on the enforced list below for six weeks holding eighteen raw SGR colour
+constants (``_GRN = "\\033[32m"``), invisible because it spelt the escape in
+octal.
 
 ``theme.py`` is the single exempt source of truth -- it legitimately defines
 the concrete color values and box glyphs the tokens resolve to. Consumers must
@@ -43,9 +58,28 @@ _MIGRATED_CONSUMERS = [
     _BATTLE / "status_line.py",
     _BATTLE / "live_status_line.py",
     _BATTLE / "diff_preview.py",
-    _BATTLE / "diff_display.py",
     _BATTLE / "tool_render_view.py",
     _BATTLE / "boot_timing.py",
+]
+
+#: ANSI-native modules: exempt from the STYLING ban because emitting raw SGR
+#: is what they are for, and there is no token spelling available to them.
+#:
+#: ``diff_display.py`` was listed as a migrated consumer on 2026-07-06 and is
+#: not migrated -- it holds eighteen raw colour constants and imports neither
+#: ``rich`` nor ``ui.theme``. It is the fallback the cockpit falls through to
+#: when Rich cannot own the screen, so it writes SGR to a plain stream by
+#: construction; "migrate it to semantic tokens" would mean giving it the
+#: dependency whose absence is its whole reason to exist.
+#:
+#: The claim was never contradicted because the guard matched only ``\x1b``
+#: and the file spells its escapes ``\033``. That is the part worth fixing:
+#: an exemption should be a decision on the record, not a spelling accident.
+#: ``test_the_ansi_native_exemption_still_earns_itself`` pins the premise, so
+#: the day anything here gains a Rich/theme dependency the exemption fails
+#: rather than quietly widening.
+_ANSI_NATIVE = [
+    _BATTLE / "diff_display.py",
 ]
 
 _BANNED = {
@@ -60,7 +94,9 @@ _BANNED = {
         r"""(?:bright_)?(?:black|red|green|yellow|blue|magenta|cyan|white|gr[ae]y\d*)\b"""
     ),
     "style_kw_dim": re.compile(r"""(?:border_)?style\s*=\s*["']dim\b"""),
-    "raw_ansi_csi": re.compile(r"\\x1b\["),
+    # SGR only -- a CSI run terminated by `m`. Cursor/mode control is not
+    # styling (see module docstring). All three source spellings of ESC.
+    "raw_ansi_sgr": re.compile(r"\\(?:x1[bB]|033|e)\[[0-9;]*m"),
     "hardcoded_frame": re.compile(
         r"""["'][─═]["']\s*\*|["'][=\-]["']\s*\*\s*\d{2,}"""
     ),
@@ -104,6 +140,55 @@ def test_migrated_consumers_have_no_literal_styling() -> None:
         if hits:
             offenders[str(path.relative_to(_REPO))] = hits
     assert not offenders, f"literal styling regressed: {offenders}"
+
+
+def test_the_ansi_pattern_bans_styling_and_permits_terminal_control() -> None:
+    """The line is drawn by FUNCTION, so pin both sides of it.
+
+    Banning every ``\\x1b[`` made ``ui/alt_screen.py`` an offender for owning
+    smcup/rmcup -- sequences with no colour in them and no token to migrate
+    to. Banning only the ``\\x1b`` spelling made eighteen ``\\033[3Xm`` colour
+    constants invisible. A pattern this load-bearing gets its own test rather
+    than being inferred from whichever files happen to exist today.
+    """
+    rx = _BANNED["raw_ansi_sgr"]
+    for styling in (r'"\x1b[0m"', r'"\x1b[1;32m"', r'"\033[32m"',
+                    r'"\033[38;2;255;0;0m"', r'"\e[0m"', r'"\x1B[7m"',
+                    r'"\x1b[m"'):
+        assert rx.search(styling), f"styling not caught: {styling}"
+    for control in (r'"\x1b[?1049h"', r'"\x1b[?1049l"', r'"\x1b[H"',
+                    r'"\x1b[2J"', r'"\x1b[?25h"', r'"\033[?25l"',
+                    r'"\x1b]0;title\x07"'):
+        assert not rx.search(control), f"terminal control flagged: {control}"
+
+
+def test_the_ansi_native_exemption_still_earns_itself() -> None:
+    """An exemption is a claim, and this one is checkable.
+
+    ``diff_display.py`` is exempt because it has no Rich/theme dependency and
+    therefore no token spelling to migrate to. If that ever stops being true
+    the exemption has to be re-argued -- so assert the PREMISE, not the
+    conclusion. Import edges are read from the AST: a substring search would
+    be satisfied by the word ``rich`` in a comment, which tests spelling
+    rather than structure.
+    """
+    import ast
+    for path in _ANSI_NATIVE:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        imported = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(a.name for a in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+        offenders = {m for m in imported
+                     if m == "rich" or m.startswith("rich.")
+                     or m.endswith("ui.theme")}
+        assert not offenders, (
+            f"{path.name} now depends on {sorted(offenders)} -- it has a token "
+            f"vocabulary available, so its ANSI-native exemption no longer "
+            f"holds. Migrate it and move it to _MIGRATED_CONSUMERS."
+        )
 
 
 def test_boot_banner_active_path_log_line_migrated() -> None:


### PR DESCRIPTION
## Four contracts moved, four tests stayed, and nothing was watching

`tests/ui/` is named by **no workflow**. `test.yml` and `ci-cd-pipeline.yml`
between them run `tests/unit/` and `tests/integration/`, and both append
`|| true` so the result is discarded anyway. 496 tests over the crest, the theme
guard, the deck grammar and the awakening ceremony had no runner — and four went
red, for six weeks each, silently.

Every one was the same shape: **a contract moved and its test kept asserting the
retired one.** None was a live bug in shipped behaviour. One neighbouring bug
was, and only surfaced because the boundary finally got looked at.

### 1 — The crest took a right margin (14a2a47ef5, 07-18)

`_clamp_cols` holds back a column so the crest cannot fill the terminal: a row
exactly as wide as the screen wraps its last cell and every line sheds a
detached artifact. Two tests still asserted `frame.cols == terminal_cols`. They
now **read** the width from the sizing function — the idiom the tests beside
them already use.

**...and the margin was cancelled at the boundary.** The clamp was
`max(min_crest, min(measured - 1, hi))`, and that outer floor is reached exactly
when `measured <= min_crest` — handing back a crest as wide as the terminal,
reinstating the very wrap class the margin exists to kill. At default bounds a
46-column terminal emitted 46-column rows. Measured, not theorised:

```
measured= 46 -> clamped= 46  widest_emitted_row= 46   >>> fills the terminal
measured= 47 -> clamped= 46  widest_emitted_row= 46
```

The single-width guard (`_clamp_cols(80) == 79`) could not see it. The floor
isn't the defect — a crest below `min_crest` stops reading as an emblem. The
defect was **one number answering two questions**: a terminal must afford the
emblem *plus* the margin, so the minimum measured width is their sum, and below
it the honest answer is "unavailable". Returning that sum as `lo` makes the
guard callers already run (`measured_cols < lo`) correct with no second check to
forget.

The margin was a bare `- 1` inside an expression — which is *how* it came to be
cancelled; a number with no name is one no caller can reason about. Now
`_crest_bounds()`: three named, independently tunable bounds behind one
`_env_int` that degrades a malformed override instead of raising inside a module
whose contract is that it never does.

### 2 — The theme guard was too broad *and* too narrow (alt_screen, 07-27)

It banned every `\x1b[`. `ui/alt_screen.py` exists to emit smcup/rmcup and
cursor-home — terminal **control**, no appearance decision, no token to migrate
to — so the guard flagged a module for doing its job. The contract is "no
literal **styling**", and the existing OSC carve-out already showed the line was
meant to be drawn by function. The pattern is now SGR: a CSI run terminated by
`m`.

Narrowing it exposed the opposite hole. The pattern knew only the `\x1b`
spelling, and `battle_test/diff_display.py` — on the "migrated, held to the
contract forever" list since 2026-07-06 — carries **eighteen raw colour
constants spelt `\033[32m`**. It has passed for six weeks by spelling alone. The
pattern now matches `\x1b`, `\033` and `\e`, mutation-tested in all three plus
the control sequences it must *not* flag.

That makes the diff_display claim false rather than unverified. It imports
neither `rich` nor `ui.theme` — it's the fallback for when Rich cannot own the
screen, so it writes SGR to a plain stream by construction, and migrating it
would mean giving it the dependency whose absence is its reason to exist. It
moves to an explicit `_ANSI_NATIVE` exemption whose **premise is asserted from
the AST**: the day it gains a Rich/theme import, the exemption fails rather than
quietly widening.

### 3 — The hunk band moved to the background (eaa1d1468e, 07-30)

`deck.diff` stopped using foreground `ok`/`crit` (`on <foreground green>` makes
syntax-highlighted code illegible) and moved to `code_add_bg`/`code_del_bg`. The
test still asserted the retired hex. It now reads both bands from
`role_palette`, asserts they **differ**, and asserts neither sign wears the
other's band — the invariant it is named for.

### 4 — The runner

`.github/workflows/ui-gate.yml` runs `tests/ui/` and **hard fails**. No
`|| true` — a gate whose result is discarded is not a gate, which is the defect
`lint-gate.yml` was written to answer. Keyless and narrow: rich,
prompt_toolkit, pytest.

**Verified in a clean venv with exactly those five dependencies: 496 passed, 0
skipped** — so the pty-backed tests genuinely run there rather than self-skipping
as they do in a sandbox.

### Testing

- `tests/ui/`: **496 passed** (was 487 passed / 4 failed). 5 new tests.
- Consumer suites (`test_audio_visual_synapse`, `test_canvas_allotment`,
  `test_cockpit_console_hygiene`, `test_alt_screen_boot`, `test_split_plane_mux`,
  `test_bipartite_attach`) **byte-identical to main**: 3 failed / 117 passed
  before and after. Those three `TestFooterMorphing` failures are pre-existing on
  `main` and untouched here.
- Narrowed theme-guard mutation-tested: hex SGR, octal SGR and Rich markup all
  still CAUGHT when injected.
- `python -m pyflakes` clean on every changed file.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores UI test coverage by adding a dedicated workflow and aligns four stale tests to moved contracts. Fixes a crest width boundary bug where the crest could fill the terminal’s last column and wrap.

- Old vs new: `_clamp_cols` previously allowed `crest == terminal width` at the minimum; now `lo = min_crest + margin`, so the crest never occupies the last column. Tunables are read via a safe `_env_int`, and malformed env values degrade to defaults.

**Review notes**
- Adds `.github/workflows/ui-gate.yml` that runs `tests/ui/` only, hard-fails (no `|| true`), installs `pytest`, `pytest-asyncio`, `pytest-timeout`, `rich`, `prompt_toolkit`, runs from repo root, and uses a concurrency group.
- Crest sizing: introduces `_crest_bounds()` and `_env_int()`. `_clamp_cols(measured)` now returns `(lo= min_crest + margin, hi, clamped)`. `_fit_cols` shrinks down to the crest floor, not the measured floor. Tests now read expected widths from the sizing functions instead of asserting raw terminal width.
- Theme guard: narrows the ban to ANSI SGR only and matches all ESC spellings (`\x1b`, `\033`, `\e`). Allows terminal control sequences (smcup/rmcup, cursor-home). Moves `battle_test/diff_display.py` to an explicit `_ANSI_NATIVE` exemption and asserts its “no `rich`/theme import” premise via AST.
- Diff hunk coloring: tests assert background roles (`code_add_bg`/`code_del_bg`) instead of foreground `ok`/`crit`, and verify the signs are distinct.

**Rollout**
- CI impact: new “ui gate” job must be green; expect ~496 tests to run with pty on Ubuntu runners.
- No product API or migration required. If any tooling referenced the old guard name, use `raw_ansi_sgr`.

<sup>Written for commit fd36fd9657950a3fe8ab3c14cc652dc12c8a69ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

