### PR TITLE
fix(ov): Give the audio FSM a surface of its own

### DIFF
--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -1067,10 +1067,21 @@ class AttachUI:
     the app so prompt_toolkit repaints on its own schedule.
     """
 
+    #: The caret when no voice plane is in play — the base identity prompt.
+    #: Named once because FOUR things resolve to it: three FSM states, and the
+    #: unknown-state fallback, which must give the same answer as OFFLINE or an
+    #: unrecognised frame would look like a state change. Spelling it four
+    #: times made it four things to keep in step.
+    _BASE_CARET = "ov › "
+    #: The same identity in ASCII, for the append-only degradation. A terminal
+    #: that cannot report a cursor position may equally be one that cannot
+    #: render U+203A, so the degraded path does not borrow the glyph.
+    _ASCII_CARET = "ov > "
+
     _PROMPTS = {
-        "OFFLINE": "ov › ",
-        "UNAVAILABLE": "ov › ",
-        "HELD": "ov › ",
+        "OFFLINE": _BASE_CARET,
+        "UNAVAILABLE": _BASE_CARET,
+        "HELD": _BASE_CARET,
         "LISTENING": "🎙 Karen › ",
         "HEARING": "🎙 Karen (hearing you) › ",
         "THINKING": "💭 Karen (thinking) › ",
@@ -1426,16 +1437,43 @@ class AttachUI:
         the same redraw machinery — no second region, no manual cursor math.
         The bottom toolbar keeps only the static key hints, which genuinely
         do belong under the input."""
+        caret = self.caret()
         if self.append_only:
             # A bare caret. No live region, because there is no way to
             # repaint one without knowing where it is.
-            return "ov > "
-        caret = self._PROMPTS.get(self.audio_state, "ov › ")
+            return caret
         try:
             block = self._live_region()
             return f"{block}\n{caret}" if block else caret
         except Exception:  # noqa: BLE001 — a caret always renders
             return caret
+
+    def caret(self) -> str:
+        """The input caret ALONE — the audio FSM's own observable surface.
+
+        The FSM had no surface of its own: the caret was resolved inline
+        inside :meth:`prompt`, so the only way to ask "what did the state
+        change do?" was to read the whole composed block — pulse, flash,
+        ignition skeleton, deck rows and all. Those move for reasons that have
+        nothing to do with audio, so an FSM assertion written against
+        ``prompt()`` fails whenever the DECK changes, which is exactly what
+        happened when the live region moved above the input line: three
+        ``TestFooterMorphing`` cases had been asserting ``prompt() == "ov › "``
+        and went red for a layout decision they were not testing.
+
+        This is the ONE resolution of state -> caret, and :meth:`prompt`
+        composes it rather than repeating the lookup. That direction matters:
+        a caret re-derived here in parallel with the one ``prompt`` renders
+        would be a second authority, and the operator sees the one downstream.
+
+        Always answers — an unknown state falls back to the base caret, which
+        is deliberately the SAME string ``OFFLINE`` resolves to, so a garbled
+        frame is indistinguishable from idle rather than looking like a new
+        mode nobody can name.
+        """
+        if self.append_only:
+            return self._ASCII_CARET
+        return self._PROMPTS.get(self.audio_state, self._BASE_CARET)
 
     def _live_region(self) -> str:
         """Pulse + (deck | lanes | focused pane) — the block above the caret.

--- a/tests/battle_test/test_ambient_deck.py
+++ b/tests/battle_test/test_ambient_deck.py
@@ -224,18 +224,45 @@ def test_addressed_goes_to_scrollback_ambient_goes_to_the_deck(
 
 def test_live_region_grows_above_the_caret() -> None:
     """The pulse and deck render ABOVE the input line (operator layout), so
-    the block is part of the prompt, not the bottom toolbar."""
+    the block is part of the prompt, not the bottom toolbar.
+
+    The contract is POSITION. This asserted line COUNT as a proxy for "the
+    deck row appeared" -- ``len(splitlines()) > base_lines`` -- and the proxy
+    is wrong at exactly one point: the FIRST row does not grow the block, it
+    SUPERSEDES the cold-boot ignition skeleton (``⏺ awaiting daemon
+    telemetry…``), which occupies that slot precisely so the gap before
+    hydration does not read as an empty screen. Cold 3 lines -> one post 3
+    lines -> two posts 4. The row was there and named in the output the whole
+    time; only the counter disagreed.
+
+    So assert the property directly -- the row is present and ABOVE the caret
+    -- and keep the growth check where growth genuinely happens, on the post
+    that has no placeholder left to consume.
+    """
     from backend.core.ouroboros.cli import ov
 
     ui = ov.AttachUI()
-    base_lines = len(ui.prompt().splitlines())
+    cold = ui.prompt().splitlines()
     ui.on_ambient("DW provider failover")
-    out = ui.prompt()
-    assert "failover" in out
-    assert len(out.splitlines()) > base_lines, "the deck row did not appear"
-    assert out.splitlines()[-1].strip().endswith("›"), (
+    out = ui.prompt().splitlines()
+
+    assert any("failover" in ln for ln in out), "the deck row did not appear"
+    assert out[-1].strip().endswith("›"), (
         "the caret must be the LAST line — the live region sits above it"
     )
+    # ...and it is genuinely IN the region, not merely somewhere in the block.
+    assert any("failover" in ln for ln in out[:-1])
+    # The skeleton was replaced, not accumulated beside the real row.
+    assert not any("awaiting daemon" in ln for ln in out), (
+        "the ignition skeleton outlived the first real row"
+    )
+    assert len(out) == len(cold)
+
+    # A second post has no placeholder to consume, so NOW the block grows.
+    ui.on_ambient("second ambient post")
+    grown = ui.prompt().splitlines()
+    assert len(grown) > len(out), "a second deck row did not extend the region"
+    assert grown[-1] == out[-1], "the caret moved when the region grew"
 
 
 def test_deck_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/battle_test/test_audio_visual_synapse.py
+++ b/tests/battle_test/test_audio_visual_synapse.py
@@ -252,6 +252,23 @@ class TestFooterMorphing:
         ui.bind_app(session.app)
         return ui, session
 
+    # These three assert `caret()`, not `prompt()`.
+    #
+    # `prompt()` is a COMPOSITION: a live region (pulse, flash, ignition
+    # skeleton, deck rows) above the input line, with the caret last. That
+    # layout is deliberate and has its own tests —
+    # `test_ambient_deck.test_live_region_grows_above_the_caret` ("the caret
+    # must be the LAST line") and
+    # `test_append_only_degradation.test_the_degraded_client_emits_a_bare_caret`
+    # ("the normal prompt is a multi-line block"). Asserting
+    # `prompt() == "ov › "` here contradicted both, and went red the moment the
+    # region moved above the caret — for a layout decision the audio FSM is not
+    # party to.
+    #
+    # The fix is a seam, not a looser assertion: `caret()` is the FSM's own
+    # surface. `test_the_caret_the_fsm_resolves_is_the_one_the_prompt_renders`
+    # below keeps the two from drifting into separate authorities.
+
     async def test_listening_frame_morphs_prompt_without_touching_buffer(self):
         """Mock an incoming ``AUDIO_STATE: LISTENING`` IPC frame; the
         Footer prompt repaints while the active keystroke buffer is
@@ -259,18 +276,21 @@ class TestFooterMorphing:
         from prompt_toolkit.application import create_app_session
         from prompt_toolkit.input.defaults import create_pipe_input
         from prompt_toolkit.output import DummyOutput
+        from backend.core.ouroboros.cli.ov import AttachUI
 
         with create_pipe_input() as pipe:
             with create_app_session(input=pipe, output=DummyOutput()):
                 ui, session = self._session()
                 # Operator mid-keystroke:
                 session.default_buffer.insert_text("deploy the fix")
-                assert ui.prompt() == "ov › "
+                assert ui.caret() == AttachUI._BASE_CARET
                 # The mocked IPC frame lands (exactly what
                 # CockpitAttachClient's read loop dispatches):
                 ui.on_audio_state("LISTENING")
-                assert ui.prompt() == "🎙 Karen › "
+                assert ui.caret() == AttachUI._PROMPTS["LISTENING"]
                 assert "listening" in ui.toolbar()
+                # ...and the morph reached the rendered prompt.
+                assert ui.prompt().splitlines()[-1] == ui.caret()
                 # Keystroke integrity: the buffer was never interrupted.
                 assert session.default_buffer.text == "deploy the fix"
 
@@ -280,16 +300,39 @@ class TestFooterMorphing:
         seen = []
         for state in ("LISTENING", "HEARING", "THINKING", "SPEAKING"):
             ui.on_audio_state(state)
-            seen.append(ui.prompt())
+            seen.append(ui.caret())
         assert len(set(seen)) == 4              # every state is distinct
         ui.on_audio_state("OFFLINE")
-        assert ui.prompt() == "ov › "
+        assert ui.caret() == AttachUI._BASE_CARET
 
     def test_unknown_state_is_inert(self):
+        """An unrecognised frame must be INDISTINGUISHABLE from idle.
+
+        Not merely "some default": the same string OFFLINE resolves to. A
+        distinct fallback caret would render a mode the operator cannot name
+        and no state machine can leave.
+        """
         from backend.core.ouroboros.cli.ov import AttachUI
         ui = AttachUI()
         ui.on_audio_state("QUANTUM")
-        assert ui.prompt() == "ov › "           # graceful: default prompt
+        assert ui.caret() == AttachUI._BASE_CARET
+        assert ui.caret() == AttachUI._PROMPTS["OFFLINE"]
+
+    def test_the_caret_the_fsm_resolves_is_the_one_the_prompt_renders(self):
+        """One authority. `caret()` would be worthless as a surface if
+        `prompt()` re-derived the caret alongside it — the operator sees the
+        downstream one, so a test passing against the upstream one would prove
+        nothing. Holds across every state, and across the append-only
+        degradation where the live region is suppressed entirely.
+        """
+        from backend.core.ouroboros.cli.ov import AttachUI
+        ui = AttachUI()
+        for state in list(AttachUI._PROMPTS) + ["QUANTUM", ""]:
+            ui.on_audio_state(state)
+            assert ui.prompt().splitlines()[-1] == ui.caret(), state
+        ui.degrade_to_append_only()
+        assert ui.prompt() == ui.caret() == AttachUI._ASCII_CARET
+        assert "\n" not in ui.prompt()
 
     def test_invalidate_called_on_morph(self):
         from backend.core.ouroboros.cli.ov import AttachUI

--- a/tests/governance/test_audio_lease_broker.py
+++ b/tests/governance/test_audio_lease_broker.py
@@ -559,7 +559,12 @@ class TestFlush:
             assert ui.should_flush_on_input() is ducks
         ui.on_audio_state("HELD")
         assert "held by another terminal" in ui.toolbar()
-        assert ui.prompt() == "ov › "
+        # HELD is a TOOLBAR state, not a caret state: another terminal owns the
+        # voice plane, so this one shows the base caret. Asserted on `caret()`,
+        # the FSM's own surface -- `prompt()` composes the live region (pulse,
+        # deck, ignition skeleton) ABOVE it, so `prompt() == "ov › "` was the
+        # pre-live-region contract and had been red since that layout landed.
+        assert ui.caret() == AttachUI._BASE_CARET
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Give the audio FSM a surface of its own

Five tests asserted `AttachUI.prompt() == "ov › "`. `prompt()` has not returned
that since the live region moved above the input line — it composes a block
(pulse, flash, cold-boot ignition skeleton, deck rows) with the **caret last**.

The stale ones didn't merely disagree with the code, they **contradicted two live
tests**: `test_live_region_grows_above_the_caret` ("the caret must be the LAST
line — the live region sits above it") and
`test_the_degraded_client_emits_a_bare_caret` ("the normal prompt is a multi-line
block"). When two tests disagree, one is stale — that pair settled which, without
guessing.

### The real defect: the FSM had no observable surface

Why was an audio-FSM test reading a layout at all? The caret was resolved **inline
inside `prompt()`**, so the only way to ask "what did this state change do?" was to
read the whole composed block — including a deck that moves for reasons audio is
not party to. That's why a layout decision turned three FSM assertions red, and it
would have recurred on the next deck change.

`AttachUI.caret()` is now the **one** resolution of state → caret, and `prompt()`
**composes** it. The direction is load-bearing: a caret re-derived inside
`prompt()` alongside `caret()` would be a second authority, and the operator sees
the downstream one — a test passing against the upstream copy would prove nothing.
`test_the_caret_the_fsm_resolves_is_the_one_the_prompt_renders` pins them together
across every state and the append-only degradation, and **fails when the parallel
derivation is reintroduced** (verified).

That also collapsed the caret's **four** spellings (three `_PROMPTS` entries + the
`.get` default) into `_BASE_CARET`, with `_ASCII_CARET` for the degraded path that
cannot assume U+203A. The unknown-state fallback is now explicitly the *same*
string `OFFLINE` resolves to: an unrecognised frame must be indistinguishable from
idle, not "some default", or it renders a mode nobody can name and no state machine
can leave.

### Two more of the same class, found in the sweep

`test_audio_lease_broker` carried a **fourth** copy (HELD is a toolbar state, not a
caret state).

The **fifth** was different and worth naming. `test_live_region_grows_above_the_caret`
asserted line **count** as a proxy for "the deck row appeared" — but the first row
doesn't grow the block, it **supersedes** the ignition skeleton
(`⏺ awaiting daemon telemetry…`), which holds that slot so the pre-hydration gap
doesn't read as an empty screen. Measured: cold 3 lines → one post 3 → two posts 4.
The row was present and named in the output the whole time; only the counter
disagreed. It now asserts the property the test is named for — the row is *above*
the caret — and keeps the growth check on the post with no placeholder left to
consume. Both new assertions are mutation-tested against the skeleton accumulating
and against the region rendering below the caret.

### Testing

- **560 passed / 0 failed** across all 25 `AttachUI` consumer suites. Clean `main`
  under the identical command **and identical sandbox setting**: 5 failed / 554
  passed.
- `tests/cli/test_ov_demo.py`: 56 passed.
- `pyflakes` clean on every changed file.

**No production behaviour change**: `caret()` returns exactly what `prompt()`
already resolved, and `prompt()`'s output is byte-identical.

### Note for the reviewer

`tests/cli/test_ov_demo.py` takes ~3.5 min because pygments re-scans entry points
via `guess_lexer_for_filename` on every `deck.diff` call. Pre-existing and
unrelated to this change, but it will blow a 180s per-test timeout under load.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives the audio FSM its own observable surface by adding `AttachUI.caret()` and having `prompt()` compose it with the live region above the input line. This prevents layout changes from breaking FSM tests; production output is unchanged.

- Introduces `caret()` as the single authority for state → caret; `prompt()` now renders the live region (pulse/flash/ignition/deck) above it.
- Deduplicates caret strings into `_BASE_CARET` (U+203A) and `_ASCII_CARET` (degraded path). Unknown/invalid states fall back to `_BASE_CARET` (same as `OFFLINE`).
- Updates tests to assert `caret()` instead of `prompt()` for FSM behavior, adds a pin ensuring `prompt()` renders the same caret, and fixes the deck test to assert position (row above caret) and real growth on the second post. Clarifies `HELD` is a toolbar state; caret remains base.

Bold areas to review
- Verify no prompt diffs in normal and append-only modes; unknown/empty states yield the base caret; append-only emits a bare caret (no newline).
- Note: `tests/cli/test_ov_demo.py` is slow (~3.5 min) due to `pygments` rescans; pre-existing. No migrations required.

<sup>Written for commit d466174cc6a04edc664ef22c71cf6e9238c3e968. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

