### PR TITLE
perf(deck): The hunk highlighter re-read every installed package, per line

### DIFF
--- a/backend/core/ouroboros/ui/deck_grammar.py
+++ b/backend/core/ouroboros/ui/deck_grammar.py
@@ -39,7 +39,9 @@ is escaped: a diff hunk containing ``[foo]`` is content, never a tag.
 """
 from __future__ import annotations
 
+import functools
 import logging
+import os
 from typing import Any, Optional
 
 logger = logging.getLogger("Ouroboros.DeckGrammar")
@@ -293,6 +295,125 @@ def _legible_over_band(style: str, banded: bool) -> str:
         return style
 
 
+#: How many distinct paths keep a resolved lexer. A diff session touches the
+#: files in its hunks and no more, so this is a memory bound rather than a
+#: behaviour knob — it is read once, and every value produces identical output,
+#: only a different number of re-resolutions. Tunable because "how many files
+#: can one session touch" has no defensible constant.
+try:
+    _LEXER_CACHE_ENTRIES = max(
+        1, int(os.environ.get("JARVIS_DECK_LEXER_CACHE_ENTRIES", "512")))
+except (TypeError, ValueError):
+    _LEXER_CACHE_ENTRIES = 512
+
+
+def _filename_candidates(path: str) -> int:
+    """How many lexers claim ``path`` BY NAME. ``-1`` means "could not tell".
+
+    This is the loop-invariant half of pygments' own algorithm.
+    ``guess_lexer_for_filename`` first collects every lexer whose ``filenames``
+    globs match — a function of the PATH ALONE — and only then, if more than
+    one matched, consults the content to break the tie. Collecting that set is
+    where the whole cost lives: it walks ``_iter_lexerclasses()``, which calls
+    ``find_plugin_lexers()`` -> ``importlib.metadata.entry_points()``, which
+    re-reads the ``entry_points.txt`` of every installed distribution. Profiled
+    at 1125 file reads and ~88% of a 19ms call — repeated for every line of
+    every hunk, always returning the same answer.
+
+    So the count is cached per path, and it is the only thing this function
+    reports: the identity of the winner still comes from pygments.
+
+    Uses pygments' private helpers, which is a coupling worth naming: they are
+    guarded by ``hasattr`` and any failure returns ``-1``, which routes the
+    caller to the ordinary uncached call. A pygments that reorganises these
+    costs us the optimisation, never the answer.
+    """
+    try:
+        from pygments import lexers as _lx
+        iter_classes = getattr(_lx, "_iter_lexerclasses", None)
+        fn_matches = getattr(_lx, "_fn_matches", None)
+        if iter_classes is None or fn_matches is None:
+            return -1
+        matched = 0
+        for lexer in iter_classes():
+            names = tuple(getattr(lexer, "filenames", ()) or ())
+            aliases = tuple(getattr(lexer, "alias_filenames", ()) or ())
+            if any(fn_matches(path, f) for f in names) or \
+                    any(fn_matches(path, f) for f in aliases):
+                matched += 1
+                if matched > 1:
+                    return matched          # ambiguous is all the caller needs
+        return matched
+    except Exception:  # noqa: BLE001
+        return -1
+
+
+def _sole_lexer_alias(path: str) -> Optional[str]:
+    """The alias for a path exactly ONE lexer claims, else ``None``.
+
+    When a single lexer matches the filename, pygments returns it WITHOUT
+    reading the content at all, so caching by path is not an approximation —
+    the content provably cannot change the answer. That covers ``.py``,
+    ``.md``, ``.toml`` and very nearly every file a hunk contains.
+    """
+    if _filename_candidates(path) != 1:
+        return None
+    try:
+        from pygments.lexers import get_lexer_for_filename
+        lexer = get_lexer_for_filename(path)
+        return lexer.aliases[0] if lexer.aliases else lexer.name
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _guess_with_content(path: str, code: str) -> str:
+    """Pygments' answer for an AMBIGUOUS filename, memoized on (path, code).
+
+    ``index.html`` is claimed by nine lexers — html, html+django, html+php and
+    friends — and only the content separates them. That per-line choice is the
+    RIGHT behaviour for a line-oriented renderer: a hunk line showing
+    ``{% block %}`` should be highlighted as the template tag it is, and
+    resolving one lexer for the whole file would flatten it back to plain html.
+
+    So the ambiguous case still asks pygments, through Rich, unchanged. It is
+    memoized rather than avoided: a deck repaints the same hunk on every frame,
+    so the same (path, code) is asked over and over.
+    """
+    try:
+        from rich.syntax import Syntax
+        return Syntax.guess_lexer(path, code)
+    except Exception:  # noqa: BLE001
+        return "default"
+
+
+#: Cached in its own right, not merely through `_sole_lexer_alias`: the
+#: candidate COUNT is the loop-invariant this whole change exists to hoist, and
+#: leaving it reachable only via its caller would make that dependence
+#: incidental — a later caller could re-pay the scan without anything noticing.
+_filename_candidates = functools.lru_cache(  # type: ignore[assignment]
+    maxsize=_LEXER_CACHE_ENTRIES)(_filename_candidates)
+_sole_lexer_alias = functools.lru_cache(  # type: ignore[assignment]
+    maxsize=_LEXER_CACHE_ENTRIES)(_sole_lexer_alias)
+_guess_with_content = functools.lru_cache(  # type: ignore[assignment]
+    maxsize=_LEXER_CACHE_ENTRIES)(_guess_with_content)
+
+
+def _lexer_for(path: str, code: str) -> str:
+    """Path (+ content, only when the path is ambiguous) -> lexer alias.
+
+    Byte-identical to the previous ``Syntax.guess_lexer(path, code)`` by
+    construction: the single-candidate branch returns what pygments returns
+    without consulting content, and every other path defers to pygments.
+    `functools.lru_cache` is the memo idiom this package already uses
+    (`crest._generate_cached`) and is thread-safe, which matters — the deck
+    renders from the TUI's repaint path.
+    """
+    sole = _sole_lexer_alias(path)
+    if sole is not None:
+        return sole
+    return _guess_with_content(path, code)
+
+
 def _highlight_to_markup(code: str, path: Optional[str], bg: str) -> str:
     """Syntax-highlight ``code`` and return DECK MARKUP. NEVER raises.
 
@@ -311,11 +432,19 @@ def _highlight_to_markup(code: str, path: Optional[str], bg: str) -> str:
     the escapes. Returning markup keeps every existing consumer working, so the
     highlighting is additive rather than a migration.
 
-    The lexer is INFERRED by Rich from the path (`Syntax.guess_lexer`), never from
-    a table here. A hardcoded extension map is wrong the first time someone edits
-    a `.toml`, and Rich already owns that knowledge — it resolves `.py` to python,
-    `.md` to markdown, and a bare `Makefile` to make, none of which this module
-    should be in the business of knowing.
+    The lexer is INFERRED from the path, never from a table here. A hardcoded
+    extension map is wrong the first time someone edits a `.toml`, and Rich and
+    pygments already own that knowledge — `.py` is python, `.md` is markdown, a
+    bare `Makefile` is make, none of which this module should be in the business
+    of knowing.
+
+    Resolution goes through `_lexer_for`, which is byte-for-byte what
+    `Syntax.guess_lexer(path, code)` returned but without re-deriving the part
+    that never changes. The call cost 19.4ms PER LINE — 7.7s on a 400-line hunk
+    — and profiling put ~88% of it in `find_plugin_lexers()` ->
+    `importlib.metadata.entry_points()`, re-reading 1125 installed
+    `entry_points.txt` files on every single line to reach the same answer.
+    That is the defect: a loop-invariant filesystem scan inside a per-line call.
     """
     try:
         from rich.console import Console
@@ -328,7 +457,7 @@ def _highlight_to_markup(code: str, path: Optional[str], bg: str) -> str:
         lexer = None
         if path:
             try:
-                lexer = Syntax.guess_lexer(str(path), code)
+                lexer = _lexer_for(str(path), code)
             except Exception:  # noqa: BLE001
                 lexer = None
         if not lexer:

--- a/tests/ui/test_deck_lexer_resolution.py
+++ b/tests/ui/test_deck_lexer_resolution.py
@@ -1,0 +1,124 @@
+"""The hunk highlighter resolves a lexer without re-reading the world.
+
+`deck.diff` called `Syntax.guess_lexer(path, code)` once PER LINE. Profiled at
+19.4ms a call — 7.7s on a 400-line hunk — with ~88% inside
+`find_plugin_lexers()` -> `importlib.metadata.entry_points()`, which re-reads
+the `entry_points.txt` of all 1125 installed distributions to reach an answer
+that cannot change. A loop-invariant filesystem scan inside a per-line call.
+
+The fix hoists the invariant and keeps the variant, so these tests pin BOTH
+halves. The first attempt cached by path alone and was measurably faster — and
+silently dropped `html+django`, rendering `{% block %}` as plain text. Speed
+that loses a feature is not a fix, so the dialect case below is the important
+one.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.ui import deck_grammar as dg
+
+
+@pytest.fixture(autouse=True)
+def _cold_caches():
+    """Every test starts on a cold cache — a hit from a neighbour would let a
+    broken resolver pass on someone else's answer."""
+    dg._sole_lexer_alias.cache_clear()
+    dg._guess_with_content.cache_clear()
+    dg._filename_candidates.cache_clear()
+    yield
+
+
+class TestTheInvariantIsHoisted:
+    def test_a_path_only_one_lexer_claims_ignores_content_entirely(self):
+        """Pygments returns a sole match WITHOUT reading the content, so
+        caching by path is not an approximation — the content provably cannot
+        change the answer."""
+        assert dg._filename_candidates("x.py") == 1
+        first = dg._lexer_for("x.py", "    return rows[0]")
+        assert first == dg._lexer_for("x.py", "<div>{% not python %}</div>")
+        assert first == "python"
+
+    def test_the_expensive_scan_happens_once_per_path(self):
+        for i in range(200):
+            dg._lexer_for("backend/x/ov.py", f"    return rows[{i}]")
+        info = dg._sole_lexer_alias.cache_info()
+        assert info.misses == 1, "the per-path scan repeated"
+        assert info.hits == 199
+
+    def test_repeated_lines_do_not_re_ask_even_when_ambiguous(self):
+        """A deck repaints the same hunk every frame, so the ambiguous path
+        must memoise too — it just cannot memoise on the path alone."""
+        for _ in range(50):
+            dg._lexer_for("index.html", "{% block content %}")
+        info = dg._guess_with_content.cache_info()
+        assert info.misses == 1 and info.hits == 49
+
+
+class TestTheVariantSurvives:
+    """The half a path-only cache destroys."""
+
+    def test_an_ambiguous_filename_still_consults_the_content(self):
+        assert dg._filename_candidates("index.html") > 1
+        plain = dg._lexer_for("index.html", "<div>")
+        django = dg._lexer_for("index.html", "{% block content %}")
+        assert plain != django, (
+            "the dialect was resolved from the path alone — `{% %}` will "
+            "render as plain text"
+        )
+        assert "django" in django
+
+    def test_a_template_tag_is_still_highlighted_in_a_rendered_hunk(self):
+        """The end-to-end statement of the same thing, through `diff`."""
+        out = dg.diff(7, "+", "{% block content %}", path="index.html",
+                      width=80)
+        assert "bright_cyan" in out, "the template tag lost its colour"
+
+    def test_a_python_hunk_is_still_highlighted(self):
+        out = dg.diff(7, "+", "    return rows[0]", path="x.py", width=80)
+        assert "bright_blue" in out
+
+
+class TestItDegradesRatherThanGuessing:
+    def test_an_unclaimed_path_resolves_to_the_default_sentinel(self):
+        assert dg._lexer_for("data.unknownext", "zzz") == "default"
+        assert dg._lexer_for("", "zzz") == "default"
+
+    def test_a_whole_name_match_still_resolves(self):
+        """`Makefile` has no extension; only filename globbing finds it. An
+        extension-only shortcut would silently stop highlighting these."""
+        assert dg._lexer_for("Makefile", "all:\n\tgcc") == "make"
+        assert dg._lexer_for("Dockerfile", "FROM python") == "docker"
+
+    def test_the_private_pygments_coupling_is_guarded(self, monkeypatch):
+        """`_filename_candidates` reads pygments' private helpers. If a future
+        pygments reorganises them the optimisation must be lost, never the
+        answer: `-1` means "could not tell", which routes to the ordinary
+        uncached call.
+        """
+        import pygments.lexers as pl
+        monkeypatch.delattr(pl, "_iter_lexerclasses", raising=False)
+        dg._filename_candidates.cache_clear()
+        assert dg._filename_candidates("x.py") == -1
+        assert dg._lexer_for("x.py", "    return 1") == "python"
+        assert dg.diff(1, "+", "    return 1", path="x.py", width=80)
+
+    def test_a_broken_pygments_never_takes_the_deck_down(self, monkeypatch):
+        """A deck line is chrome; chrome must not be what fails."""
+        import pygments.lexers as pl
+
+        def _boom(*a, **k):
+            raise RuntimeError("pygments is unwell")
+
+        monkeypatch.setattr(pl, "_iter_lexerclasses", _boom, raising=False)
+        monkeypatch.setattr(pl, "get_lexer_for_filename", _boom, raising=False)
+        dg._filename_candidates.cache_clear()
+        dg._sole_lexer_alias.cache_clear()
+        assert dg._filename_candidates("x.py") == -1
+        out = dg.diff(1, "+", "    return 1", path="x.py", width=80)
+        # Assert the rendered TEXT, not the markup string: a highlighter splits
+        # `return 1` across style tags, so a substring check on the markup
+        # tests whether highlighting happened to be off rather than whether the
+        # operator can read the line.
+        from rich.text import Text
+        assert "return 1" in Text.from_markup(out).plain, "the line was lost"


### PR DESCRIPTION
## The hunk highlighter re-read every installed package, per line

`_highlight_to_markup` resolved a lexer with `Syntax.guess_lexer(path, code)`
**once per line** of a hunk — 19.4 ms a call, 294× the extension lookup, **7.7 s on
a 400-line hunk**.

Profiling says almost none of that is lexing. **~88% is inside
`find_plugin_lexers()` → `importlib.metadata.entry_points()`**, which re-reads the
`entry_points.txt` of all 1125 installed distributions (1125 `read_text` calls per
invocation) to compute a set that cannot change while the process lives. A
loop-invariant filesystem scan inside a per-line call.

### What is, and is not, invariant

Pygments' own algorithm already separates them: `guess_lexer_for_filename` first
collects every lexer whose filename globs match — **a function of the path alone** —
and only consults content if *more than one* matched. Collecting that set is the
expensive half; disambiguating is nearly free.

So the count is cached per path. When exactly one lexer claims the path (`.py`,
`.md`, `.toml` — very nearly every file in a hunk) pygments returns it **without
reading content at all**, so answering from a path-keyed cache is not an
approximation. When several claim it, the call still goes to pygments unchanged,
memoized on `(path, code)` because a deck repaints the same hunk every frame.

| case | before | after | |
|---|---|---|---|
| 400 unique lines, `ov.py` | 4.777 s | 0.126 s | **37.9×** |
| 400 repainted lines, `ov.py` | 5.189 s | 0.171 s | 30.4× |
| 400 repainted lines, `.html` | 4.380 s | 0.079 s | 55.8× |
| 400 unique lines, `.html` | 5.223 s | 5.248 s | **1.0×** |

The last row is the honest one. An ambiguous filename with unique content still
pays pygments per line, because that is the only place the answer can come from.
Making it fast would mean reimplementing pygments' ranking here, and a duplicated
ranking that drifts is worse than a slow one that cannot.

### The first attempt was faster and wrong

Caching by path alone — dropping content entirely — was faster still and silently
destroyed `html+django`: `{% block content %}` rendered as plain text because
`index.html` resolved to `html` for the whole file. Per-line selection is *not* the
bug it looked like; for a line-oriented renderer it is the desired behaviour. Only
the byte-identity check caught it, and `TestTheVariantSurvives` now pins it.

The pygments coupling (`_iter_lexerclasses`, `_fn_matches`) is private, so it is read
through `getattr` and any failure returns `-1` — "could not tell" — routing to the
ordinary uncached call. A pygments that reorganises these costs the optimisation,
never the answer. Both degradations are tested, including one where pygments raises.

### Testing

- **663 renders byte-identical** to `main` — suffixed, whole-name, extension-less,
  unknown, empty and ambiguous paths × 3 diff signs × 13 code shapes. Includes the
  pre-existing `go.mod` → modula2 quirk, preserved rather than quietly corrected.
- 10 new tests; 576 passed across `tests/ui` + deck consumers. The single failure
  (`test_compose_diff_body_uses_diff_colors`) **fails identically on `main`**.
- `pyflakes` clean.

### What this does NOT fix

**Not `tests/cli/test_ov_demo.py`.** I previously said this bug was why that test
takes 3.5 minutes; that was an inference from one stack sample and it was wrong.
Back-to-back: main 156.99 s, this branch 161.07 s. The profile puts **324.8 s of
373.6 s in `progress_board.build_import_graph`**, which parses 3556 files 8961 times
then walks each tree once per analyser (49.7 M `ast.walk` calls). Separate defect,
untouched here, addressed next.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates per-line lexer resolution in the deck hunk highlighter by caching filename-based candidates and memoizing ambiguous cases. Previously we called `rich.Syntax.guess_lexer(path, code)` for every line, which repeatedly triggered `importlib.metadata.entry_points()` scans; now we cache the path-only invariant and only consult content when needed, preserving behavior and improving render time dramatically (common cases 30–55x faster; ambiguous-unique content unchanged).

- Adds LRU caches in `backend/core/ouroboros/ui/deck_grammar.py`: `_filename_candidates`, `_sole_lexer_alias`, `_guess_with_content`; size tunable via `JARVIS_DECK_LEXER_CACHE_ENTRIES` (default 512). Thread-safe via `functools.lru_cache`.
- Keeps per-line dialect selection (e.g., `html+django` in `index.html`), preventing the earlier regression where path-only caching flattened template tags.
- Graceful degradation: if `pygments` private helpers are unavailable or error, fall back to the uncached path; unknown paths resolve to `"default"`. Output is byte-identical to `main` for non-ambiguous files.
- Tests: adds `tests/ui/test_deck_lexer_resolution.py` to pin invariant hoisting, ambiguous-case memoization, degradation paths, and end-to-end highlighting.

<sup>Written for commit a32644b873bdd638128aae9c2482b31e5aeb4bea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

