### PR TITLE
fix(cockpit): A ceiling is a policy cap, a balance is money — and an overrun you cannot see

### DIFF
--- a/backend/core/ouroboros/battle_test/presentation_restraint.py
+++ b/backend/core/ouroboros/battle_test/presentation_restraint.py
@@ -1227,6 +1227,8 @@ def format_idle_breadcrumb(
     posture: str = "",
     op_id: str = "",
     detail: str = "",
+    funding: str = "",
+    funding_label: str = "",
 ) -> str:
     """One-line breadcrumb for the IDLE phase — replaces the silent
     empty status line that today leaves operators wondering whether
@@ -1257,8 +1259,35 @@ def format_idle_breadcrumb(
         parts[0] = f"IDLE · {detail}"
     if isinstance(branch, str) and branch:
         parts.append(branch)
+    # The ceiling is a POLICY cap derived from spend HISTORY (p95 of prior
+    # sessions x3), not a balance. Rendered bare it reads as headroom, and an
+    # operator watching `$0.00/$0.71` over two empty accounts is reading a
+    # number nothing can spend. `funding` says which kind of number it is;
+    # the cap is QUALIFIED, never deleted, because it is still what stops a
+    # runaway session the moment a lane is funded again.
     if cost_budget > 0.0:
-        parts.append(f"${cost_spent:.2f}/${cost_budget:.2f}")
+        chip = f"${cost_spent:.2f}/${cost_budget:.2f}"
+        if funding == "local":
+            # Every paid lane is dry, but a sovereign tier is serving. This is
+            # the case a flat "unfunded" gets exactly backwards: the organism
+            # is WORKING, at zero marginal cost, and a dollar ceiling is no
+            # longer the binding constraint. Show what is actually true — what
+            # has been spent — and name the tier carrying the work.
+            chip = f"${cost_spent:.2f} · local tier"
+            if funding_label:
+                chip += f" ({funding_label})"
+        elif funding == "unfunded":
+            # Nothing can spend against it and nothing else can serve.
+            chip += " unfunded"
+        elif funding == "partial":
+            # FRACTIONAL — and the reason this is not folded into "unfunded".
+            # One lane out does NOT make the ceiling inert: the funded lane can
+            # still spend the whole of it, so the denominator stays honest and
+            # only gains the name of the lane that is out. Collapsing this to a
+            # blanket verdict would tell an operator with a working Anthropic
+            # key that their organism is broke.
+            chip += f" · ⚠ {funding_label} dry" if funding_label else " · ⚠ dry"
+        parts.append(chip)
     elif cost_spent > 0.0:
         parts.append(f"${cost_spent:.2f}")
     if isinstance(posture, str) and posture:

--- a/backend/core/ouroboros/battle_test/status_line.py
+++ b/backend/core/ouroboros/battle_test/status_line.py
@@ -115,6 +115,12 @@ class StatusSnapshot:
     #: an arbitrary constant, which is how an operator ends up asking where
     #: their own number came from.
     cost_budget_basis: str = ""
+    #: How the cost chip should READ — "" | partial | unfunded | local.
+    #: The ceiling is a policy cap; this says whether anything can spend
+    #: against it, and is lane-specific rather than a blanket verdict.
+    funding_mode: str = ""
+    #: The lanes that are out (partial), or the serving endpoint (local).
+    funding_label: str = ""
     # Idle window
     idle_elapsed_s: float = 0.0
     idle_timeout_s: float = 0.0
@@ -348,6 +354,7 @@ class StatusLineBuilder:
         primary_op, extra_ops = self._sample_ops()
         route, provider, model = self._sample_route_and_provider(primary_op)
         liq_exhausted, liq_provider, liq_reset = self._sample_liquidity()
+        funding_mode, funding_label = self._sample_funding()
 
         # §37 Slice 5 — feed cost-band-crossing observer.
         # Chatter-suppression is structural in the observer; this call
@@ -380,6 +387,8 @@ class StatusLineBuilder:
             liquidity_exhausted=liq_exhausted,
             liquidity_provider=liq_provider,
             liquidity_reset_s=liq_reset,
+            funding_mode=funding_mode,
+            funding_label=funding_label,
         )
 
     def render_plain(self) -> str:
@@ -676,30 +685,128 @@ class StatusLineBuilder:
         return (primary_phase, detail)
 
     def _sample_liquidity(self) -> tuple:
-        """Circadian liquidity sample (item #5) — reads the file-backed
-        ProviderLiquidityLedger the Aegis proxy hydrates on every
-        upstream response. Restraint contract: returns the exhausted
-        triple ONLY when some provider's declared runway is dry; the
-        healthy state samples as (False, "", None) and renders nothing.
+        """Which lane is dry, for the ``⚠ … dry`` token. NEVER raises.
+
+        Asks :func:`economic_state.display_liquidity`, NOT
+        `provider_liquidity_ledger.runway_exhausted`. That swap is the whole
+        fix: `runway_exhausted` is a ROUTING predicate and fail-opens by
+        design — it folds in `quota_exhausted`, which is `t < until`, a WINDOW
+        test that lapses on a TTL so a topped-up wallet resumes routing without
+        manual clearing. Correct for routing; catastrophic for a dashboard.
+        Once both windows lapsed this returned ``(False, "", None)`` while
+        Claude was answering 400 `credit balance too low` and DoubleWord 402,
+        and the cockpit reported healthy lanes over two empty accounts. The
+        ledger even still declared 5,000,000 tokens remaining, recorded before
+        the money ran out, so the token path agreed.
+
+        `display_liquidity` keeps a lapsed-but-unverified lane DRY, because
+        time passing is not payment.
+
+        FRACTIONAL, NOT BLANKET — the name returned is lane-specific whenever
+        exactly one lane is out, so "doubleword dry" never becomes a claim
+        about Anthropic. Only when EVERY known lane is dry does it collapse to
+        one phrase, and that phrase says so rather than naming an arbitrary
+        first offender.
+
         Master ``JARVIS_STATUS_LIQUIDITY_SEGMENT_ENABLED`` (default on).
-        NEVER raises."""
+        """
         try:
             if os.environ.get(
                 "JARVIS_STATUS_LIQUIDITY_SEGMENT_ENABLED", "1",
             ).strip().lower() in ("0", "false", "no", "off"):
                 return (False, "", None)
-            from backend.core.ouroboros.governance.provider_liquidity_ledger import (  # noqa: E501
-                _load,
-                liquidity,
-                runway_exhausted,
+            from backend.core.ouroboros.governance.economic_state import (
+                display_liquidity,
             )
-            for name in sorted((_load().get("providers") or {})):
-                if runway_exhausted(name):
-                    _tokens, secs = liquidity(name)
-                    return (True, str(name), secs)
-            return (False, "", None)
+            from backend.core.ouroboros.governance.provider_liquidity_ledger import (  # noqa: E501
+                liquidity,
+            )
+            view = display_liquidity()
+            dry = view.get("dry") or []
+            if not dry:
+                return (False, "", None)
+            if len(dry) == 1:
+                # ONE lane out — name it, even when it is the only lane the
+                # ledger knows. "all lanes" is technically true of a
+                # single-lane roster and useless: it hides the one fact the
+                # operator needs, which is WHICH lane.
+                label = str(dry[0])
+            elif view.get("all_dry"):
+                label = "all lanes"
+            else:
+                label = ", ".join(str(d) for d in dry)
+            # The reset horizon is only meaningful for a single named lane;
+            # two lanes recover on two clocks and one number would be a guess.
+            secs = None
+            if len(dry) == 1:
+                try:
+                    _tokens, secs = liquidity(dry[0])
+                except Exception:  # noqa: BLE001
+                    secs = None
+            return (True, label, secs)
         except Exception:  # noqa: BLE001 — status line never breaks
             return (False, "", None)
+
+    def _sample_funding(self) -> tuple:
+        """``(mode, label)`` telling the cost chip what kind of number it is.
+
+        The ceiling and the balance are different quantities, and the line was
+        printing the first as though it were the second: ``$0.00/$0.71`` reads
+        as "$0.71 of headroom" when the ceiling is a POLICY cap derived from
+        spend HISTORY (p95 of prior sessions x3) and the actual spendable
+        balance is zero. The cap still matters when lanes are funded — it is
+        what stops a runaway session — so it is qualified here, never deleted.
+
+        Modes, in the order they are decided:
+
+          ``"local"``     every paid lane is dry BUT a sovereign local tier is
+                          serving. Not paralysis: work continues at zero
+                          marginal cost, and a ceiling denominated in dollars
+                          is simply not the constraint any more.
+          ``"unfunded"``  every paid lane is dry and nothing else can serve.
+                          The ceiling is inert — say so.
+          ``"partial"``   SOME lane is dry. The ceiling is still real, because
+                          the funded lane can still spend against it. This is
+                          the case a blanket "unfunded" would get wrong, and
+                          it is why the decision is made over the lane ROSTER
+                          rather than an any()/all() on a single boolean.
+          ``""``          nothing to say; the chip renders unchanged.
+
+        Local state is read through `CapabilityEvaluator._read_remote`, which
+        is already the one non-blocking probe of the gateway (in-memory breaker
+        state, no `resident_models()` round-trip) — this runs on the render
+        path at ~500ms and must never wait on a LAN.
+        """
+        try:
+            from backend.core.ouroboros.governance.economic_state import (
+                display_liquidity,
+            )
+            view = display_liquidity()
+            # The ECONOMIC subset, not the display union. A rate-limited lane
+            # is dry — it earns the "⚠ … dry" token and its reset countdown —
+            # but it is not UNFUNDED, and a ceiling qualified as unfunded on
+            # the strength of a per-minute token cap would send an operator to
+            # a billing page to fix a problem a clock fixes.
+            econ = view.get("economic_dry") or []
+            if not view.get("readable") or not econ:
+                return ("", "")
+            if not view.get("all_economic_dry"):
+                # Fractional: name the lanes that are out of money, and leave
+                # the ceiling alone — it is still spendable through the rest.
+                return ("partial", ", ".join(econ))
+            try:
+                from backend.core.ouroboros.governance.capability_state import (
+                    CapabilityEvaluator,
+                )
+                remote_state, endpoint, _readable = (
+                    CapabilityEvaluator._read_remote())
+            except Exception:  # noqa: BLE001
+                remote_state, endpoint = "absent", ""
+            if remote_state == "serving":
+                return ("local", str(endpoint or "local"))
+            return ("unfunded", "")
+        except Exception:  # noqa: BLE001
+            return ("", "")
 
     def _sample_route_and_provider(self, op_id: str) -> tuple:
         """Pull route + provider + MODEL for the primary op. All optional.
@@ -874,6 +981,10 @@ def _format_plain(snap: StatusSnapshot, *, compact: bool) -> str:
                 # Not forwarding it meant the breadcrumb re-asserted a bare
                 # "IDLE" over an answer that had already been computed.
                 detail=getattr(snap, "phase_detail", "") or "",
+                # The ceiling is a POLICY cap, not a balance. Without this
+                # the chip renders `$0.00/$0.71` over two empty accounts.
+                funding=getattr(snap, "funding_mode", "") or "",
+                funding_label=getattr(snap, "funding_label", "") or "",
             )
             # A dry provider runway is MOST relevant while idle — the
             # organism may be idle BECAUSE it is dry. The one exception

--- a/backend/core/ouroboros/cli/boot_progress.py
+++ b/backend/core/ouroboros/cli/boot_progress.py
@@ -62,9 +62,33 @@ ENABLED_ENV = "JARVIS_OV_BOOT_PROGRESS_ENABLED"
 HISTORY_ENV = "JARVIS_OV_BOOT_HISTORY_PATH"
 MAX_SAMPLES_ENV = "JARVIS_OV_BOOT_HISTORY_MAX"
 CEILING_ENV = "JARVIS_OV_BOOT_PROGRESS_CEILING"
+#: How far past its own prediction a boot may run before the line says so.
+OVERRUN_TOLERANCE_ENV = "JARVIS_OV_BOOT_OVERRUN_TOLERANCE"
+OVERRUN_GRACE_ENV = "JARVIS_OV_BOOT_OVERRUN_GRACE_S"
 
 _TRUTHY = ("1", "true", "yes", "on")
 _DEFAULT_HISTORY = os.path.join(".jarvis", "boot_durations.json")
+
+
+def _finite_seconds(value: Any) -> float:
+    """A number of seconds that is safe to format. NEVER raises.
+
+    `elapsed` arrives from a caller's clock arithmetic, and clock arithmetic
+    produces NaN and infinities: a monotonic source read twice across a
+    suspend, a subtraction of two unset timestamps. `int(nan)` raises
+    ValueError, which is how the fallback branch — the one whose entire job is
+    to guarantee this module never breaks a boot — became the only line in it
+    that could. Non-finite and negative both degrade to 0.0; a wait cannot
+    have run for a negative or unknowable time, and printing `0s` is honest
+    where crashing is not.
+    """
+    try:
+        v = float(value)
+        if v != v or v in (float("inf"), float("-inf")) or v < 0.0:
+            return 0.0
+        return v
+    except (TypeError, ValueError):
+        return 0.0
 
 
 def boot_progress_enabled() -> bool:
@@ -89,6 +113,31 @@ def max_samples() -> int:
         return max(3, int(os.environ.get(MAX_SAMPLES_ENV, "40")))
     except (TypeError, ValueError):
         return 40
+
+
+def overrun_tolerance() -> float:
+    """Fraction past the prediction before a boot is called overrun.
+
+    PROPORTIONAL, not a fixed number of seconds: a 2s boot taking 3s is noise
+    and a 90s boot taking 135s is a fact, and no single absolute grace can
+    serve both. Default 0.25.
+    """
+    try:
+        return max(0.0, float(os.environ.get(OVERRUN_TOLERANCE_ENV, "0.25")))
+    except (TypeError, ValueError):
+        return 0.25
+
+
+def overrun_grace_s() -> float:
+    """Floor under the proportional tolerance, in seconds.
+
+    A very short prediction has a very short 25%, which would trip on ordinary
+    scheduler jitter and cry overrun on a healthy boot. Default 3.0.
+    """
+    try:
+        return max(0.0, float(os.environ.get(OVERRUN_GRACE_ENV, "3.0")))
+    except (TypeError, ValueError):
+        return 3.0
 
 
 def progress_ceiling() -> float:
@@ -218,6 +267,88 @@ class Progress:
         except Exception:  # noqa: BLE001
             pass
 
+    def _raw_projection(self) -> Optional[float]:
+        """This boot's own projected total — UNCLAMPED. NEVER raises.
+
+        Split out from :meth:`_projected_total_s` because that method answers
+        an ETA question and therefore clamps to ``elapsed``: an ETA may never
+        point into the past. The clamp is right for a countdown and fatal for
+        an overrun test, because the moment a boot runs long the clamped value
+        starts tracking ``elapsed`` and the two become equal by construction —
+        the evidence that the estimate was exceeded is destroyed by the very
+        function that computed it. One number cannot answer both "when will
+        this finish" and "has this taken longer than predicted".
+        """
+        try:
+            if self._reached <= 0 or not self._stage_times:
+                return None
+            last = float(self._stage_times[-1])
+            if last <= 0:
+                return None
+            per_stage = last / float(self._reached)
+            if per_stage <= 0:
+                return None
+            return per_stage * float(len(self.stages))
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _eta_horizon(self, elapsed: float) -> Optional[float]:
+        """THE horizon an ETA counts down from — history first, else cadence.
+
+        Extracted because :meth:`fraction` and :meth:`render` each spelled
+        ``self.expected_s or self._projected_total_s(elapsed)`` independently.
+        Two copies of a precedence rule is two rules, and the one that drifts
+        is found by an operator watching a bar disagree with its own ETA.
+        """
+        horizon = self.expected_s
+        if not horizon or horizon <= 0:
+            horizon = self._projected_total_s(elapsed)
+        return horizon if horizon and horizon > 0 else None
+
+    def overrun_s(self, elapsed: float) -> Optional[float]:
+        """Seconds this boot is past its own prediction, or ``None``.
+
+        Uses the UNCLAMPED basis (:meth:`_raw_projection`) with the same
+        history-first precedence an ETA uses, so the two never contradict.
+
+        A tolerance stands between "late" and "overrun", and it is
+        proportional rather than a fixed number of seconds: a 2s boot that
+        takes 3s is noise, a 90s boot that takes 135s is a fact, and the same
+        absolute grace cannot serve both. The floor keeps a very short
+        prediction from tripping on jitter. Both are env-tunable
+        (``JARVIS_OV_BOOT_OVERRUN_TOLERANCE`` / ``_GRACE_S``) because the
+        right patience on a cold laptop is not the right patience in CI.
+
+        Returns None when there is no prediction to exceed — an unmeasured
+        boot cannot be late, and claiming otherwise would invent a deadline.
+        """
+        try:
+            basis = self.expected_s
+            if not basis or basis <= 0:
+                basis = self._raw_projection()
+            if not basis or basis <= 0:
+                return None
+            allowance = max(overrun_grace_s(), basis * overrun_tolerance())
+            over = float(elapsed) - (float(basis) + allowance)
+            return over if over > 0.0 else None
+        except Exception:  # noqa: BLE001
+            return None
+
+    @property
+    def awaiting_label(self) -> str:
+        """The stage that has NOT arrived — what the wait is actually on.
+
+        ``stage_label`` names the last milestone REACHED, which during an
+        overrun is the least useful thing on screen: it reports what already
+        succeeded while the operator is asking what is stuck.
+        """
+        try:
+            if self._reached >= len(self.stages):
+                return ""
+            return self.stages[self._reached].label
+        except Exception:  # noqa: BLE001
+            return ""
+
     def _projected_total_s(self, elapsed: float) -> Optional[float]:
         """Expected total boot time, projected from THIS boot's own cadence.
 
@@ -229,32 +360,26 @@ class Progress:
         take about nine more.
 
         This is measurement, not a constant — it adapts to a slow disk, a cold
-        page cache or a loaded machine, and it needs no prior run. Requires
-        TWO arrivals so there is an actual interval to average; one timestamp
-        is a point, not a rate.
+        page cache or a loaded machine, and it needs no prior run.
+
+        Rate measured FROM THE START OF THE WAIT, not between arrivals. The
+        interval form needed two distinct timestamps and returned nothing when
+        several markers landed in the same poll — the common case on a fast
+        boot, since the client reads the log tail every quarter second and a
+        burst of stages can complete between two reads. Anchoring on t=0 makes
+        a single arrival sufficient: two stages reached by second four is two
+        seconds a stage, and that is a rate, not a point.
+
+        The math lives in :meth:`_raw_projection`; this is that value made
+        SAFE FOR A COUNTDOWN. Never project a finish already in the past: an
+        ETA of "0s left" that keeps not arriving is worse than no ETA. Callers
+        asking whether the estimate was EXCEEDED must use the raw projection —
+        the clamp here makes overrun undetectable by design.
         """
         try:
-            if self._reached <= 0 or not self._stage_times:
+            projected = self._raw_projection()
+            if projected is None:
                 return None
-            # Rate measured FROM THE START OF THE WAIT, not between arrivals.
-            #
-            # The interval form needed two distinct timestamps and returned
-            # nothing when several markers landed in the same poll — which is
-            # the common case on a fast boot, since the client reads the log
-            # tail every quarter second and a burst of stages can complete
-            # between two reads. Anchoring on t=0 makes a single arrival
-            # sufficient: two stages reached by second four is two seconds a
-            # stage, and that is a rate, not a point.
-            last = float(self._stage_times[-1])
-            if last <= 0:
-                return None
-            per_stage = last / float(self._reached)
-            if per_stage <= 0:
-                return None
-            projected = per_stage * float(len(self.stages))
-            # Never project a finish already in the past: a boot running long
-            # has disproved its own estimate, and an ETA of "0s left" that
-            # keeps not arriving is worse than no ETA.
             return max(elapsed, projected)
         except Exception:  # noqa: BLE001
             return None
@@ -280,9 +405,7 @@ class Progress:
             # Cross-boot history is the better estimator when it exists (more
             # samples, and it already knows how this machine behaves). Within
             # -boot projection is the fallback that makes a FIRST boot move.
-            horizon = self.expected_s
-            if not horizon or horizon <= 0:
-                horizon = self._projected_total_s(elapsed)
+            horizon = self._eta_horizon(elapsed)
             estimate = None
             if horizon and horizon > 0:
                 estimate = elapsed / horizon
@@ -313,6 +436,7 @@ class Progress:
 
     def render(self, elapsed: float, *, width: int = 18) -> str:
         """One line. Bar + stage + clock + ETA when known. NEVER raises."""
+        elapsed = _finite_seconds(elapsed)
         try:
             frac = self.fraction(elapsed)
             parts = []
@@ -322,14 +446,35 @@ class Progress:
                 parts.append(f"{int(frac * 100):3d}%")
             parts.append(self.stage_label)
             parts.append(f"{int(elapsed)}s")
-            horizon = self.expected_s or self._projected_total_s(elapsed)
-            if frac is not None and horizon and frac > 0.02:
-                remaining = max(0.0, horizon - elapsed)
-                if remaining >= 1.0:
-                    parts.append(f"~{int(remaining)}s left")
+            # An overrun used to be reported by ABSENCE: `remaining` clamped
+            # to 0, the "~Ns left" token simply stopped being appended, and an
+            # operator cannot see a token that is not there. Paired with the
+            # 97% ceiling that is the whole defect — a slow boot and a dead
+            # one rendered identically (`97%  session open  89s`), which is
+            # exactly the line that sent an operator here asking if it hung.
+            over = self.overrun_s(elapsed)
+            if over is not None:
+                parts.append(f"+{int(over)}s over")
+                # Name what has NOT arrived. `stage_label` reports the last
+                # milestone reached, which during an overrun answers a
+                # question nobody is asking.
+                waiting = self.awaiting_label
+                if waiting:
+                    parts.append(f"waiting on {waiting}")
+            else:
+                horizon = self._eta_horizon(elapsed)
+                if frac is not None and horizon and frac > 0.02:
+                    remaining = max(0.0, horizon - elapsed)
+                    if remaining >= 1.0:
+                        parts.append(f"~{int(remaining)}s left")
             return "  ".join(parts)
         except Exception:  # noqa: BLE001
-            return f"waking · {int(elapsed)}s"
+            # The fallback must not be able to fail: `int(nan)` raises
+            # ValueError, so the branch that exists to guarantee "NEVER
+            # raises" was itself the last thing that could break a boot.
+            # Sanitised HERE and not only at entry, because this handler also
+            # catches failures that happen before any sanitising would run.
+            return f"waking · {_finite_seconds(elapsed):.0f}s"
 
 
 def log_size(path: str) -> int:

--- a/backend/core/ouroboros/governance/capability_state.py
+++ b/backend/core/ouroboros/governance/capability_state.py
@@ -199,24 +199,37 @@ class CapabilityEvaluator:
 
     @staticmethod
     def _read_lanes() -> "tuple":
-        """(dry, provider_name, readable). Reuses the ledger the status line
-        already samples — no new probe, no API call."""
+        """(dry, provider_name, readable) — no new probe, no API call.
+
+        Asks :func:`economic_state.display_liquidity`, the same authority
+        `status_line._sample_liquidity` uses, so the badge and the "⚠ … dry"
+        token cannot disagree about which lane is out.
+
+        This used to walk `runway_exhausted`, which is a ROUTING predicate: it
+        fail-opens once the quota-outage WINDOW lapses, because routing wants a
+        topped-up wallet to resume without manual clearing. The badge inherited
+        that optimism and reported `healthy — lanes viable` over two accounts
+        answering 400 and 402. A lapsed window means time passed, not that
+        anyone paid, so the display keeps such a lane DRY.
+        """
         try:
             from backend.core.ouroboros.governance import (  # noqa: PLC0415
                 provider_liquidity_ledger as pl,
             )
             if not pl.liquidity_ledger_enabled():
                 return (False, "", False)
-            # Same walk `status_line._sample_liquidity` performs, so the
-            # badge and the "⚠ … dry" token can never disagree about WHICH
-            # provider is out. `liquidity()` is per-provider, not a snapshot.
-            name = ""
-            for candidate in sorted((pl._load().get("providers") or {})):
-                if pl.runway_exhausted(candidate):
-                    name = str(candidate)
-                    break
-            dry = bool(name) or bool(pl.any_runway_exhausted())
-            return (dry, name, True)
+            from backend.core.ouroboros.governance.economic_state import (  # noqa: PLC0415,E501
+                display_liquidity,
+            )
+            view = display_liquidity()
+            if not view.get("readable"):
+                return (False, "", False)
+            dry_lanes = view.get("dry") or []
+            # The NAME stays the first dry lane (the badge shows one), while
+            # `dry` is the roster-wide answer — so a half-dry fleet still
+            # reports the specific lane rather than an arbitrary verdict.
+            return (bool(dry_lanes), str(dry_lanes[0]) if dry_lanes else "",
+                    True)
         except Exception:  # noqa: BLE001
             return (False, "", False)
 

--- a/backend/core/ouroboros/governance/economic_state.py
+++ b/backend/core/ouroboros/governance/economic_state.py
@@ -407,6 +407,135 @@ def economic_view(provider: str, *, now: Optional[float] = None) -> Dict[str, An
         return out
 
 
+def display_liquidity(*, now: Optional[float] = None) -> Dict[str, Any]:
+    """Which lanes are dry FOR DISPLAY — per lane, never blanket. NEVER raises.
+
+    THE PREDICATE THIS REPLACES, AND WHY IT WAS THE WRONG ONE
+    ---------------------------------------------------------
+    Every display consumer asked `provider_liquidity_ledger.runway_exhausted`,
+    which is a ROUTING predicate and fail-opens on purpose: it folds in
+    `quota_exhausted`, and that is `t < quota_exhausted_until` — a WINDOW test.
+    `record_quota_exhaustion` self-heals after the TTL so a topped-up wallet
+    recovers without manual clearing, which is right for routing and wrong for
+    a dashboard. Once the window lapses the predicate answers False, and the
+    cockpit went back to reporting healthy lanes while both accounts sat at
+    zero: Claude answering 400 `credit balance too low`, DoubleWord 402, and
+    the ledger still declaring 5,000,000 tokens remaining from before the money
+    ran out.
+
+    :func:`economic_view` already draws the distinction this needs — see its
+    ``unverified_since``, and its own summary of the rule: *routing keeps its
+    fail-open optimism; the display stops calling it knowledge.* This function
+    is that rule made callable, so the status line, the capability badge and
+    anything else showing money to a human share ONE answer instead of each
+    re-deriving it from a routing primitive.
+
+    A lane is dry for display when EITHER holds:
+
+      * ``state == ECONOMIC`` — inside a live recorded outage. Certain.
+      * ``unverified_since is not None`` — the outage window lapsed and
+        nothing has since proved the wallet was refilled. Time passing is not
+        payment. Reported as dry but ``verified=False``, so a renderer can say
+        "last known dry" rather than asserting a present-tense fact it cannot
+        support.
+
+    RATE_LIMITED is deliberately NOT dry: a clock fixes it, and telling an
+    operator to buy credits they already have is a worse error than silence.
+
+    Returns::
+
+        {"lanes": {name: {"dry", "verified", "state", "reason", "stale_for_s"}},
+         "dry": [...], "funded": [...],           # ordered, lane-specific
+         "any_dry": bool, "all_dry": bool,
+         "readable": bool}                        # False = could not tell
+
+    ``all_dry`` is computed over lanes the ledger actually knows, and is False
+    when it knows none — "no lanes recorded" is ignorance, not insolvency, and
+    must never render as an empty wallet.
+    """
+    out: Dict[str, Any] = {
+        "lanes": {}, "dry": [], "funded": [],
+        "any_dry": False, "all_dry": False, "readable": False,
+        # The ECONOMIC subset, kept apart from `dry` on purpose. A lane can be
+        # unusable for two unrelated reasons and they demand opposite things
+        # of the operator: an economic lane needs money, a rate-limited one
+        # needs a minute. "⚠ dry" is right for both; "unfunded" is right for
+        # only one, and a funding verdict built on the union would tell
+        # someone to buy credits they already have.
+        "economic_dry": [], "all_economic_dry": False,
+    }
+    try:
+        from backend.core.ouroboros.governance.provider_liquidity_ledger import (
+            _load,
+        )
+        # The lane roster is whatever the ledger has SEEN. Never a literal
+        # list: a hardcoded ("anthropic", "doubleword") goes silently wrong
+        # the day a third lane is added, and goes wrong in the direction that
+        # hides an empty account.
+        names = sorted((_load().get("providers") or {}))
+        out["readable"] = True
+        t = float(now if now is not None else time.time())
+        # A SUPERSET of the routing predicate, never a substitute for it.
+        # `runway_exhausted` answers TWO questions at once — is this lane
+        # inside an economic outage window, AND has it declared fewer tokens
+        # than the floor. Swapping it for the economic half alone made a lane
+        # with 500 tokens left render as perfectly healthy, because the money
+        # was fine and only the runway was gone. Display dryness is the UNION:
+        # the economic case (including the lapsed-but-unverified one routing
+        # deliberately forgets) OR the declared token runway.
+        try:
+            from backend.core.ouroboros.governance.provider_liquidity_ledger import (  # noqa: E501
+                runway_exhausted,
+            )
+        except Exception:  # noqa: BLE001
+            runway_exhausted = None  # type: ignore[assignment]
+
+        for name in names:
+            view = economic_view(name, now=t)
+            unverified = view.get("unverified_since")
+            economic_dry = view.get("state") == ECONOMIC or unverified is not None
+            runway_dry = False
+            if runway_exhausted is not None:
+                try:
+                    runway_dry = bool(runway_exhausted(name))
+                except Exception:  # noqa: BLE001
+                    runway_dry = False
+            dry = economic_dry or runway_dry
+            stale_for = None
+            if unverified is not None:
+                try:
+                    stale_for = max(0.0, t - float(unverified))
+                except (TypeError, ValueError):
+                    stale_for = None
+            # WHY the lane is dry, because the two demand different things of
+            # the operator: "economic" sends them to a billing page, "runway"
+            # resolves itself when the window rolls over.
+            kind = "economic" if economic_dry else ("runway" if runway_dry
+                                                    else "")
+            out["lanes"][name] = {
+                "dry": bool(dry),
+                # Certainty, not just polarity. A live outage window and a
+                # declared token count are both MEASURED; a lapsed economic
+                # window is an assumption that nobody paid.
+                "verified": bool(view.get("hard_open")) or runway_dry,
+                "kind": kind,
+                "state": view.get("state"),
+                "reason": view.get("reason") or "",
+                "stale_for_s": stale_for,
+            }
+            (out["dry"] if dry else out["funded"]).append(name)
+            if economic_dry:
+                out["economic_dry"].append(name)
+        out["any_dry"] = bool(out["dry"])
+        out["all_dry"] = bool(names) and not out["funded"]
+        out["all_economic_dry"] = (
+            bool(names) and len(out["economic_dry"]) == len(names))
+        return out
+    except Exception:  # noqa: BLE001
+        logger.debug("[EconomicState] display_liquidity degraded", exc_info=True)
+        return out
+
+
 def blast_radius(*, now: Optional[float] = None) -> Dict[str, Any]:
     """Who absorbs the traffic when a lane is down — and whether they CAN.
 

--- a/tests/governance/test_boot_progress_overrun.py
+++ b/tests/governance/test_boot_progress_overrun.py
@@ -1,0 +1,175 @@
+"""A boot past its estimate must SAY so, not fall silent.
+
+The wait line pinned at ``97%  session open  89s`` and an operator asked
+whether it had hung. It had not — the machine was loaded — but nothing on the
+line could have told them apart, and that is the defect.
+
+Two mechanisms combined to hide it:
+
+1. ``_projected_total_s`` returned ``max(elapsed, projected)``. The clamp is
+   right for a countdown (an ETA may never point into the past) and fatal for
+   an overrun test, because once a boot runs long the clamped value tracks
+   ``elapsed`` and the two are equal by construction. The function that
+   computed the evidence destroyed it.
+2. ``render`` reported the overrun by ABSENCE: ``remaining`` clamped to 0, the
+   ``~Ns left`` token stopped being appended, and nobody can see a token that
+   is not there.
+
+Paired with the deliberate 97% ceiling — itself correct, since a bar at 100%
+while nothing happens claims a finish that has not occurred — a slow boot and
+a dead one rendered identically.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.cli import boot_progress as bp
+
+
+def _progress(expected, stage_times):
+    p = bp.Progress(stages=bp.DEFAULT_STAGES, expected_s=expected)
+    for t in stage_times:
+        p._reached += 1
+        p._stage_times.append(float(t))
+    return p
+
+
+class TestTheClampNoLongerHidesTheEvidence:
+    def test_the_eta_projection_still_never_points_into_the_past(self):
+        """The clamp is KEPT — it is what stops "0s left" that never arrives."""
+        p = _progress(None, [4, 9, 14])
+        assert p._projected_total_s(500.0) == 500.0
+
+    def test_the_raw_projection_is_unclamped_so_overrun_is_detectable(self):
+        p = _progress(None, [4, 9, 14])
+        raw = p._raw_projection()
+        assert raw is not None and raw < 500.0, (
+            "a clamped basis makes every long boot look exactly on time"
+        )
+
+    def test_overrun_is_measured_against_the_raw_basis(self):
+        p = _progress(None, [4, 9, 14])
+        raw = p._raw_projection()
+        over = p.overrun_s(raw * 4)
+        assert over is not None and over > 0.0
+
+
+class TestYouCannotBeLateWithoutADeadline:
+    def test_no_stages_and_no_history_yields_no_overrun(self):
+        p = _progress(None, [])
+        assert p.overrun_s(9999.0) is None, (
+            "an unmeasured boot cannot be late; claiming otherwise invents a "
+            "deadline the operator never set"
+        )
+
+    def test_a_line_with_no_prediction_shows_only_the_clock(self):
+        p = _progress(None, [])
+        out = p.render(89.0)
+        assert "over" not in out and "left" not in out
+        assert "89s" in out
+
+
+class TestToleranceIsProportionalNotAbsolute:
+    """A 2s boot taking 3s is noise; a 90s boot taking 135s is a fact."""
+
+    def test_a_short_prediction_is_not_tripped_by_jitter(self):
+        p = _progress(2.0, [])
+        assert p.overrun_s(4.0) is None, (
+            "the grace FLOOR must absorb scheduler jitter on a fast boot"
+        )
+
+    def test_a_long_prediction_reports_a_real_overshoot(self):
+        p = _progress(90.0, [])
+        assert p.overrun_s(135.0) is not None
+
+    def test_the_proportional_band_scales_with_the_prediction(self):
+        """The SAME absolute overshoot means different things at different
+        scales, which is the entire argument for a proportional band.
+
+        50s late on a 10s prediction is a boot that has gone wrong. 50s late
+        on a 400s prediction is inside normal variance. A fixed grace would
+        have to pick one of those and be wrong about the other.
+        """
+        assert _progress(10.0, []).overrun_s(60.0) is not None
+        assert _progress(400.0, []).overrun_s(450.0) is None
+
+    @pytest.mark.parametrize("env,value,elapsed,expect_over", [
+        ("JARVIS_OV_BOOT_OVERRUN_TOLERANCE", "0.0", 44.0, True),
+        ("JARVIS_OV_BOOT_OVERRUN_TOLERANCE", "5.0", 200.0, False),
+        ("JARVIS_OV_BOOT_OVERRUN_GRACE_S", "600", 200.0, False),
+    ])
+    def test_both_knobs_are_operator_tunable(self, monkeypatch, env, value,
+                                             elapsed, expect_over):
+        """The right patience on a cold laptop is not the right patience in
+        CI, so neither bound is a literal."""
+        monkeypatch.setenv(env, value)
+        p = _progress(40.0, [])
+        assert (p.overrun_s(elapsed) is not None) is expect_over
+
+    def test_a_malformed_override_degrades_to_the_default(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OV_BOOT_OVERRUN_TOLERANCE", "not-a-number")
+        monkeypatch.setenv("JARVIS_OV_BOOT_OVERRUN_GRACE_S", "")
+        assert bp.overrun_tolerance() == 0.25
+        assert bp.overrun_grace_s() == 3.0
+
+
+class TestTheLineNamesWhatItIsWaitingFor:
+    def test_awaiting_is_the_next_stage_not_the_last_reached(self):
+        p = _progress(40.0, [4, 9, 14])
+        assert p.stage_label == bp.DEFAULT_STAGES[2].label
+        assert p.awaiting_label == bp.DEFAULT_STAGES[3].label, (
+            "during an overrun the reached stage answers a question nobody "
+            "is asking"
+        )
+
+    def test_nothing_is_awaited_once_every_stage_arrived(self):
+        p = _progress(40.0, [1] * len(bp.DEFAULT_STAGES))
+        assert p.awaiting_label == ""
+
+    def test_the_overrun_line_carries_both_the_overshoot_and_the_blocker(self):
+        p = _progress(40.0, [4, 9, 14])
+        out = p.render(89.0)
+        assert "over" in out
+        assert f"waiting on {bp.DEFAULT_STAGES[3].label}" in out
+        assert "left" not in out, "a countdown and an overrun are exclusive"
+
+
+class TestTheHealthyPathIsUnchanged:
+    def test_an_on_time_boot_still_counts_down(self):
+        p = _progress(40.0, [4, 9, 14])
+        out = p.render(20.0)
+        assert "~" in out and "left" in out
+        assert "over" not in out
+
+    def test_the_ceiling_still_reserves_the_last_percent(self):
+        """The 97% pin is CORRECT and must survive: a bar at 100% while
+        nothing happens claims a finish that has not occurred."""
+        p = _progress(1.0, [0.1] * len(bp.DEFAULT_STAGES))
+        assert p.fraction(1000.0) <= bp.progress_ceiling()
+
+    def test_the_bar_never_regresses(self):
+        p = _progress(40.0, [4, 9, 14])
+        seen = [p.fraction(t) for t in (10.0, 40.0, 200.0, 20.0, 5.0)]
+        assert all(b >= a for a, b in zip(seen, seen[1:]))
+
+    def test_render_never_raises_on_a_hostile_progress(self):
+        p = bp.Progress(stages=(), expected_s=-1.0)
+        assert isinstance(p.render(float("nan")), str)
+        assert isinstance(p.render(-5.0), str)
+
+
+class TestOnePrecedenceRule:
+    def test_fraction_and_render_share_one_horizon(self):
+        """Both spelled `expected_s or _projected_total_s(...)` separately.
+        Two copies of a precedence rule is two rules, and the drift is found
+        by an operator watching a bar disagree with its own ETA."""
+        import ast
+        import inspect
+        import textwrap
+        for fn in (bp.Progress.fraction, bp.Progress.render):
+            src = textwrap.dedent(inspect.getsource(fn))
+            called = {
+                n.func.attr for n in ast.walk(ast.parse(src))
+                if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+            }
+            assert "_eta_horizon" in called, f"{fn.__name__} re-derives it"

--- a/tests/governance/test_display_liquidity_authority.py
+++ b/tests/governance/test_display_liquidity_authority.py
@@ -1,0 +1,290 @@
+"""A ceiling is a policy cap; a balance is money. The cockpit conflated them.
+
+The bottom line read ``$0.00/$0.71`` while Claude answered 400 `credit balance
+too low` and DoubleWord answered 402 — presenting $0.71 of headroom that
+nothing could spend. Worse, the "⚠ … dry" token that exists for exactly this
+case stayed silent, and the capability badge reported `healthy — lanes viable`.
+
+ROOT CAUSE — a routing predicate answering a display question.
+
+Every display consumer asked `provider_liquidity_ledger.runway_exhausted`,
+which folds in `quota_exhausted`, which is `t < quota_exhausted_until`: a
+WINDOW test. `record_quota_exhaustion` is TTL-bounded so a topped-up wallet
+resumes routing without manual clearing — correct for routing, and it means the
+predicate fail-opens the moment the window lapses. Both windows had lapsed
+(84.0h and 6.4h), and the ledger still declared 5,000,000 tokens for Anthropic
+from before the money ran out, so the token path agreed it was fine.
+
+`economic_state.economic_view` already drew the distinction, in `unverified_since`
+and in its own words: *routing keeps its fail-open optimism; the display stops
+calling it knowledge*. `display_liquidity` makes that callable, once, for every
+surface that shows money to a human.
+"""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from backend.core.ouroboros.governance import economic_state as es
+
+
+def _seed(tmp_path, monkeypatch, rows):
+    """Write a ledger and point every reader at it."""
+    path = tmp_path / "provider_liquidity.json"
+    path.write_text(json.dumps({"providers": rows}))
+    monkeypatch.setenv("JARVIS_PROVIDER_LIQUIDITY_PATH", str(path))
+    from backend.core.ouroboros.governance import provider_liquidity_ledger as pl
+    pl._read_cache.clear()          # mtime-keyed; a fresh path needs a fresh read
+    return path
+
+
+def _economic(reason, *, until):
+    return {"quota_reason": f"class=economic::{reason}",
+            "quota_exhausted_until": until}
+
+
+class TestALapsedWindowIsNotPayment:
+    """The defect, stated as a test."""
+
+    def test_a_lapsed_economic_flag_is_still_dry_for_display(
+            self, tmp_path, monkeypatch):
+        past = time.time() - 3600            # window closed an hour ago
+        _seed(tmp_path, monkeypatch,
+              {"anthropic": _economic("Error code: 400 - credit balance too low",
+                                      until=past)})
+        view = es.display_liquidity()
+        lane = view["lanes"]["anthropic"]
+        assert lane["dry"] is True, (
+            "a lapsed outage window means time passed, not that anyone paid"
+        )
+        assert lane["verified"] is False, (
+            "an assumption must not be reported with the certainty of a "
+            "measurement"
+        )
+        assert lane["stale_for_s"] and lane["stale_for_s"] >= 3599
+
+    def test_the_routing_predicate_still_fails_open(self, tmp_path, monkeypatch):
+        """Pins WHY the swap was needed — and that routing is left alone.
+
+        `runway_exhausted` must keep its optimism: it is what lets a topped-up
+        wallet resume without manual clearing. This test fails the day someone
+        "fixes" it in place, which would change dispatch behaviour rather than
+        display.
+        """
+        past = time.time() - 3600
+        _seed(tmp_path, monkeypatch, {"anthropic": _economic("400", until=past)})
+        from backend.core.ouroboros.governance import provider_liquidity_ledger as pl
+        assert pl.runway_exhausted("anthropic") is False
+        assert es.display_liquidity()["lanes"]["anthropic"]["dry"] is True
+
+    def test_a_live_window_is_dry_AND_verified(self, tmp_path, monkeypatch):
+        future = time.time() + 600
+        _seed(tmp_path, monkeypatch, {"anthropic": _economic("402", until=future)})
+        lane = es.display_liquidity()["lanes"]["anthropic"]
+        assert lane["dry"] is True and lane["verified"] is True
+
+    def test_rate_limited_is_dry_but_never_unfunded(self, tmp_path,
+                                                    monkeypatch):
+        """The two reasons a lane is unusable demand OPPOSITE actions.
+
+        A rate-limited lane is genuinely dry — it earns the "⚠ … dry" token
+        and its reset countdown — but it is not out of money. A funding
+        verdict built on the display union would send an operator to a billing
+        page to fix something a clock fixes, which is why `economic_dry` is
+        kept apart from `dry` rather than derived from it.
+        """
+        _seed(tmp_path, monkeypatch, {
+            "anthropic": {"quota_reason": "class=rate_limited::429 slow down",
+                          "quota_exhausted_until": time.time() + 600}})
+        view = es.display_liquidity()
+        assert view["lanes"]["anthropic"]["dry"] is True
+        assert view["lanes"]["anthropic"]["kind"] == "runway"
+        assert view["economic_dry"] == []
+        assert view["all_economic_dry"] is False
+        from backend.core.ouroboros.battle_test.status_line import StatusLineBuilder
+        assert StatusLineBuilder()._sample_funding() == ("", ""), (
+            "a per-minute token cap must never qualify the ceiling as unfunded"
+        )
+
+    def test_a_token_runway_exhaustion_is_dry_even_with_money(
+            self, tmp_path, monkeypatch):
+        """The case a straight predicate swap silently dropped.
+
+        `runway_exhausted` answered TWO questions — economic outage AND
+        declared tokens below the floor. Replacing it with the economic half
+        made a lane with 500 tokens left render as perfectly healthy, because
+        the money was fine and only the runway was gone. Display dryness is
+        the UNION.
+        """
+        _seed(tmp_path, monkeypatch, {
+            "anthropic": {"tokens_remaining": 500,
+                          "reset_delta_s": 600,
+                          "recorded_unix": time.time()}})
+        lane = es.display_liquidity()["lanes"]["anthropic"]
+        assert lane["dry"] is True
+        assert lane["kind"] == "runway"
+        assert es.display_liquidity()["economic_dry"] == []
+
+    def test_no_lanes_recorded_is_ignorance_not_insolvency(
+            self, tmp_path, monkeypatch):
+        _seed(tmp_path, monkeypatch, {})
+        view = es.display_liquidity()
+        assert view["all_dry"] is False, "an empty roster must never read broke"
+        assert view["any_dry"] is False
+
+
+class TestFractionalLiquidity:
+    """The edge case a blanket verdict gets exactly wrong.
+
+    One lane out does NOT make the ceiling inert — the funded lane can still
+    spend the whole of it. So the decision is made over the lane ROSTER, never
+    an any()/all() collapse of one boolean, and `partial` keeps the denominator
+    while naming only the lane that is actually out.
+    """
+
+    def test_one_dry_lane_does_not_condemn_the_funded_one(
+            self, tmp_path, monkeypatch):
+        _seed(tmp_path, monkeypatch, {
+            "doubleword": _economic("status 402", until=time.time() - 60),
+            "anthropic": {},                       # healthy, nothing recorded
+        })
+        view = es.display_liquidity()
+        assert view["dry"] == ["doubleword"]
+        assert view["funded"] == ["anthropic"]
+        assert view["any_dry"] is True
+        assert view["all_dry"] is False, (
+            "a working Anthropic key must not be reported as broke"
+        )
+
+    def test_the_status_line_names_the_lane_not_the_fleet(
+            self, tmp_path, monkeypatch):
+        _seed(tmp_path, monkeypatch, {
+            "doubleword": _economic("402", until=time.time() - 60),
+            "anthropic": {},
+        })
+        from backend.core.ouroboros.battle_test.status_line import StatusLineBuilder
+        exhausted, label, _reset = StatusLineBuilder()._sample_liquidity()
+        assert exhausted is True and label == "doubleword"
+        mode, mode_label = StatusLineBuilder()._sample_funding()
+        assert mode == "partial" and mode_label == "doubleword"
+
+    def test_every_lane_dry_collapses_to_one_honest_phrase(
+            self, tmp_path, monkeypatch):
+        past = time.time() - 60
+        _seed(tmp_path, monkeypatch, {
+            "anthropic": _economic("400", until=past),
+            "doubleword": _economic("402", until=past),
+        })
+        from backend.core.ouroboros.battle_test.status_line import StatusLineBuilder
+        exhausted, label, _reset = StatusLineBuilder()._sample_liquidity()
+        assert exhausted is True
+        assert label == "all lanes", (
+            "naming an arbitrary first offender hides that BOTH are out"
+        )
+
+
+class TestTheCeilingIsQualifiedNeverDeleted:
+    """`$0.71` stays on screen when it can still be spent."""
+
+    @pytest.mark.parametrize("mode,label,expect,forbid", [
+        ("",         "",           "$0.00/$0.71",       "unfunded"),
+        ("partial",  "doubleword", "⚠ doubleword dry",  "unfunded"),
+        ("unfunded", "",           "$0.00/$0.71 unfunded", "local tier"),
+        ("local",    "rtx",        "local tier",        "/$0.71"),
+    ])
+    def test_the_chip_says_which_kind_of_number_it_is(
+            self, mode, label, expect, forbid):
+        from backend.core.ouroboros.battle_test.presentation_restraint import (
+            format_idle_breadcrumb,
+        )
+        out = format_idle_breadcrumb(cost_spent=0.0, cost_budget=0.71,
+                                     detail="22 sensors", funding=mode,
+                                     funding_label=label)
+        assert expect in out
+        assert forbid not in out
+
+    def test_a_funded_fleet_renders_exactly_as_before(self):
+        """No behaviour change on the healthy path."""
+        from backend.core.ouroboros.battle_test.presentation_restraint import (
+            format_idle_breadcrumb,
+        )
+        assert format_idle_breadcrumb(
+            cost_spent=0.04, cost_budget=0.50, detail="22 sensors",
+        ) == "IDLE · 22 sensors · $0.04/$0.50"
+
+
+class TestLocalTierMorph:
+    """All paid lanes dry is not paralysis when something else is serving."""
+
+    def test_a_serving_local_tier_replaces_the_dollar_ceiling(
+            self, tmp_path, monkeypatch):
+        past = time.time() - 60
+        _seed(tmp_path, monkeypatch, {
+            "anthropic": _economic("400", until=past),
+            "doubleword": _economic("402", until=past),
+        })
+        from backend.core.ouroboros.governance import capability_state as cs
+        monkeypatch.setattr(cs.CapabilityEvaluator, "_read_remote",
+                            staticmethod(lambda: ("serving", "http://h:11434",
+                                                  True)))
+        from backend.core.ouroboros.battle_test.status_line import StatusLineBuilder
+        mode, label = StatusLineBuilder()._sample_funding()
+        assert mode == "local" and label == "http://h:11434", (
+            "work continues at zero marginal cost — a dollar ceiling is no "
+            "longer the binding constraint"
+        )
+
+    def test_an_unreachable_local_tier_is_not_a_lifeline(
+            self, tmp_path, monkeypatch):
+        past = time.time() - 60
+        _seed(tmp_path, monkeypatch, {
+            "anthropic": _economic("400", until=past),
+            "doubleword": _economic("402", until=past),
+        })
+        from backend.core.ouroboros.governance import capability_state as cs
+        monkeypatch.setattr(cs.CapabilityEvaluator, "_read_remote",
+                            staticmethod(lambda: ("unreachable", "http://h",
+                                                  True)))
+        from backend.core.ouroboros.battle_test.status_line import StatusLineBuilder
+        assert StatusLineBuilder()._sample_funding()[0] == "unfunded"
+
+
+class TestOneAuthority:
+    def test_the_badge_and_the_status_line_cannot_disagree(
+            self, tmp_path, monkeypatch):
+        """Both now ask `display_liquidity`. Before, the badge said `healthy —
+        lanes viable` while the wallet was empty, because both asked the
+        fail-open routing predicate."""
+        past = time.time() - 60
+        _seed(tmp_path, monkeypatch, {
+            "anthropic": _economic("400", until=past),
+            "doubleword": _economic("402", until=past),
+        })
+        from backend.core.ouroboros.battle_test.status_line import StatusLineBuilder
+        from backend.core.ouroboros.governance.capability_state import (
+            CapabilityEvaluator,
+        )
+        line_dry = StatusLineBuilder()._sample_liquidity()[0]
+        ev = CapabilityEvaluator()
+        ev.invalidate()
+        badge_dry = ev._read_lanes()[0]
+        assert line_dry is badge_dry is True
+
+    def test_the_render_path_never_touches_the_network(self):
+        """`_sample_funding` runs at ~500ms on the UI thread. It reads the
+        gateway's in-memory breaker snapshot; a LAN round-trip here would be a
+        worse defect than the one this fixes."""
+        import ast
+        import inspect
+        import textwrap
+        from backend.core.ouroboros.battle_test.status_line import StatusLineBuilder
+        src = textwrap.dedent(inspect.getsource(
+            StatusLineBuilder._sample_funding))
+        called = {
+            n.func.attr for n in ast.walk(ast.parse(src))
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        }
+        assert "resident_models" not in called
+        assert "ensure_model_resident" not in called

--- a/tests/governance/test_wait_clock_and_liveness.py
+++ b/tests/governance/test_wait_clock_and_liveness.py
@@ -1,0 +1,162 @@
+"""Two invariants the boot wait depends on, pinned rather than assumed.
+
+CLOCK DISCIPLINE — and the rule is NOT "monotonic everywhere".
+
+A Tailscale topology between an M1 and a Windows box guarantees NTP skew, so
+the temptation is to ban ``time.time()`` outright. That would be wrong, and
+wrong in a way that silently breaks state: ``time.monotonic()`` is only
+comparable WITHIN one process run. Its epoch is arbitrary and resets when the
+process does, so a value persisted to ``.jarvis/provider_liquidity.json`` and
+read back by the next boot is meaningless. The honest rule has two halves:
+
+  * an IN-PROCESS duration (how long has this wait run, how long since the
+    last tick) MUST use ``time.monotonic()`` — it cannot be dragged backwards
+    by an NTP correction mid-boot;
+  * a PERSISTED or CROSS-PROCESS timestamp MUST use wall clock, and must be
+    read through a plausibility guard, because that is the only clock two
+    processes can agree on and it is the one that can be wrong.
+
+`economic_state._plausible_recorded` is that guard, and `economic_view`
+surfaces its verdict as ``stale_clock`` rather than silently trusting a row.
+
+LIVENESS — the overrun counter must not outlive the daemon.
+
+`+Xs over` is unbounded arithmetic on elapsed time. If the organism dies, or a
+tailnet socket drops, an incrementing counter is a lie told once a second. Two
+existing mechanisms already prevent it and are pinned here so a refactor
+cannot quietly remove them: the wait is bounded by a deadline, and
+``child_poll`` makes a spawned daemon's death observable within one probe.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+import pytest
+
+from backend.core.ouroboros.cli import boot_progress as bp
+from backend.core.ouroboros.cli import thin_client as tc
+
+
+def _calls(fn):
+    """Every ``a.b()`` attribute call inside *fn*, by dotted name."""
+    src = textwrap.dedent(inspect.getsource(fn))
+    out = set()
+    for n in ast.walk(ast.parse(src)):
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute):
+            base = getattr(n.func.value, "id", "")
+            out.add(f"{base}.{n.func.attr}" if base else n.func.attr)
+    return out
+
+
+class TestInProcessDurationsAreMonotonic:
+    """An NTP correction mid-boot must not move a duration."""
+
+    def test_the_wait_path_never_reads_the_wall_clock(self):
+        src = inspect.getsource(tc)
+        assert "time.time()" not in src, (
+            "a wall-clock delta in the wait loop can be dragged backwards by "
+            "an NTP step, which on a skewed tailnet is guaranteed, not rare"
+        )
+        assert "time.monotonic()" in src
+
+    @pytest.mark.parametrize("fn", [tc.await_socket, tc._mk_tick])
+    def test_the_loop_and_the_tick_both_anchor_on_monotonic(self, fn):
+        called = _calls(fn)
+        assert "time.monotonic" in called
+        assert "time.time" not in called
+
+    def test_boot_progress_takes_elapsed_and_reads_no_clock_itself(self):
+        """One clock owner. If the module sampled its own, it could disagree
+        with the deadline that governs the very loop calling it."""
+        src = inspect.getsource(bp)
+        assert "time.time()" not in src
+        assert "time.monotonic()" not in src
+
+
+class TestPersistedTimestampsUseTheOnlySharedClock:
+    def test_staleness_is_measured_against_wall_clock_by_necessity(self):
+        """`unverified_since` is written by one process and read by the next.
+
+        Monotonic here would be a bug, not a hardening: its epoch resets with
+        the process, so the delta would be nonsense across a restart.
+        """
+        from backend.core.ouroboros.governance import economic_state as es
+        called = _calls(es.display_liquidity)
+        assert "time.time" in called
+        assert "time.monotonic" not in called
+
+    def test_an_implausible_row_is_flagged_not_trusted(self):
+        """The guard that makes wall clock safe to use across machines."""
+        from backend.core.ouroboros.governance import economic_state as es
+        assert es._plausible_recorded(0.0) is None            # pre-2020
+        assert es._plausible_recorded(2 ** 40) is None        # far future
+        assert es._plausible_recorded("not-a-number") is None
+        import time as _t
+        assert es._plausible_recorded(_t.time()) is not None
+
+    def test_a_skewed_clock_is_reported_rather_than_believed(self, tmp_path,
+                                                             monkeypatch):
+        import json
+        import time as _t
+        from backend.core.ouroboros.governance import economic_state as es
+        from backend.core.ouroboros.governance import provider_liquidity_ledger as pl
+        p = tmp_path / "liq.json"
+        p.write_text(json.dumps({"providers": {"anthropic": {
+            "recorded_unix": _t.time() + 90_000.0,      # a day+ ahead
+            "quota_reason": "class=economic::402",
+        }}}))
+        monkeypatch.setenv("JARVIS_PROVIDER_LIQUIDITY_PATH", str(p))
+        pl._read_cache.clear()
+        assert es.economic_view("anthropic")["stale_clock"] is True, (
+            "a future-dated row is a clock fault and must be surfaced, not "
+            "folded silently into a duration"
+        )
+
+
+class TestTheCounterCannotOutliveTheDaemon:
+    def test_the_wait_is_bounded_and_the_bound_is_tunable(self):
+        assert tc._boot_wait_s() > 0
+        assert _calls(tc.await_socket) & {"time.monotonic"}
+        src = textwrap.dedent(inspect.getsource(tc.await_socket))
+        assert "deadline" in src, "an unbounded wait can increment forever"
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("5", 5.0), ("0.1", 5.0), ("99999", 900.0), ("junk", 120.0), ("", 120.0),
+    ])
+    def test_the_bound_clamps_and_survives_a_malformed_override(
+            self, monkeypatch, raw, expected):
+        monkeypatch.setenv("JARVIS_OV_BOOT_WAIT_S", raw)
+        assert tc._boot_wait_s() == expected
+
+    def test_a_dead_spawned_daemon_stops_the_wait(self):
+        """`child_poll` is what turns "wait the full deadline over a corpse"
+        into "stop within one probe". Structural pin: the loop must consult
+        it, and both SPAWN call sites must pass it."""
+        src = textwrap.dedent(inspect.getsource(tc.await_socket))
+        assert "child_poll" in src
+        whole = inspect.getsource(tc)
+        # Every call that hands `await_socket` a spawned process must also
+        # hand it that process's poll — a spawn site without it reverts to
+        # the blind full-deadline vigil.
+        spawn_sites = whole.count("record_boot=True")
+        assert spawn_sites >= 1
+        assert whole.count("child_poll=getattr(proc") >= spawn_sites
+
+    def test_render_is_pure_and_cannot_extend_the_wait(self):
+        """The progress line must never be able to keep a dead wait alive:
+        no sleeping, no probing, no I/O of its own."""
+        called = _calls(bp.Progress.render)
+        for forbidden in ("time.sleep", "asyncio.sleep", "socket.connect",
+                          "subprocess.run"):
+            assert forbidden not in called
+
+    def test_overrun_stays_finite_at_absurd_elapsed(self):
+        """Even handed a nonsense clock the arithmetic must not produce
+        inf/NaN — the line is rendered, not evaluated."""
+        p = bp.Progress(stages=bp.DEFAULT_STAGES, expected_s=40.0)
+        for elapsed in (1e12, float("inf"), float("nan"), -1.0):
+            out = p.render(elapsed)
+            assert isinstance(out, str)
+            assert "inf" not in out and "nan" not in out


### PR DESCRIPTION
## A ceiling is a policy cap; a balance is money — and an overrun you cannot see

Two fixes, validated together as one unit. Both suites were run in the
**foreground**; neither commit was made until both were green.

### 1 — `$0.00/$0.71` over two empty accounts

The bottom line presented $0.71 of headroom while Claude answered 400 `credit
balance too low` and DoubleWord 402. The `⚠ … dry` token that exists for exactly
this stayed silent, and the capability badge reported `healthy — lanes viable`.

**Not a stale store — a routing predicate answering a display question.**
`economic_view` and `_sample_liquidity` read the *same* file (`_load()`, mtime
cached). What differed was the question: both display consumers asked
`runway_exhausted`, which folds in `quota_exhausted` → `t < until`, a **window**
test that fail-opens once the TTL lapses so a topped-up wallet resumes routing.
Both windows had lapsed (84.0h / 6.4h), and the ledger still declared **5,000,000
tokens** for Anthropic from before the money ran out.

`economic_view` already had the honest answer in `unverified_since`, and its own
docstring states the rule: *routing keeps its fail-open optimism; the display
stops calling it knowledge.* `display_liquidity` makes that callable once.

```
_sample_liquidity   (False, '', None)      ->  (True, 'all lanes', None)
capability          healthy — lanes viable ->  unfunded — anthropic is out of credit
```

**A superset, never a substitute — and the suite caught me.** My first version
swapped the predicate outright and silently dropped the *other* thing
`runway_exhausted` answered: a lane with 500 tokens left rendered perfectly
healthy, because the money was fine and only the runway was gone. Display dryness
is now the **union**; `economic_dry` is kept apart as the only thing that
qualifies the ceiling, so a per-minute token cap never sends anyone to a billing
page.

**Fractional, computed over the lane roster** — never an `any()/all()` collapse:

```
both funded          IDLE · 22 sensors · $0.00/$0.71
DW dry, Claude ok    IDLE · 22 sensors · $0.00/$0.71 · ⚠ doubleword dry
both dry, no local   IDLE · 22 sensors · $0.00/$0.71 unfunded
both dry, 5090 up    IDLE · 22 sensors · $0.00 · local tier (…:11434)
```

An empty roster reports **not** all_dry — ignorance is not insolvency. Render cost
on the 500ms tick: **0.063ms / 0.072ms**.

⚠️ The local morph renders `absent` on this machine: no remote endpoint is
configured. Tested against a stubbed serving host; **not field-proven**.

### 2 — `97%  session open  89s`

`_projected_total_s` returned `max(elapsed, projected)`. The clamp is right for a
countdown and fatal for an overrun test — once a boot runs long the clamped value
tracks `elapsed` and the two are equal by construction. `render` then reported the
overrun by **absence**: `remaining` clamped to 0 and the `~Ns left` token stopped
appending. Nobody can see a token that isn't there.

```
on-time      43%  aegis serving  20s  ~20s left
overrun      43%  aegis serving  89s  +39s over  waiting on aegis ready
no estimate  igniting  89s
```

Tolerance is **proportional**: 50s late on a 10s prediction is a broken boot; 50s
late on a 400s prediction is variance. No prediction → no overrun; an unmeasured
boot cannot be late.

**A fallback that could fail:** `render(float("nan"))` raised `ValueError` from
inside the `except` branch whose job is to guarantee this module never breaks a
boot. Pre-existing; clock arithmetic genuinely produces NaN across a suspend.

**Clock + liveness pinned, not assumed.** The rule is *not* "monotonic
everywhere" — that breaks persisted state, since monotonic's epoch resets with the
process. In-process durations are monotonic (wait path: 11 uses, zero
`time.time()`); persisted cross-process timestamps use wall clock through a
plausibility guard (`stale_clock`). The counter cannot outlive the daemon: bounded
by `JARVIS_OV_BOOT_WAIT_S` (clamped 5–900s), with `child_poll` wired at both spawn
sites.

### Testing

- **60 new tests.** 668 + 817 passed across every suite touching these modules.
- 3 remaining failures — `test_autonomy_lock` ×2, `test_supervisor_clean_exit` —
  all reproduce **with these changes stashed in the same directory**.
- `tests/governance/test_config_arbiter.py` passes alone (262.75s); it exceeded a
  300s per-test cap only under concurrent load.
- `pyflakes` clean on every changed file.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two cockpit defects: the status line and badge showed headroom and “healthy” while paid lanes were unfunded, and the boot line hid overruns as a missing ETA. Now the display uses a single liquidity authority, qualifies the cost chip, and explicitly reports when a boot exceeds its estimate.

- Old: UI read `runway_exhausted` (fail-open after TTL), rendering `$0.00/$0.71` and “healthy — lanes viable” over empty accounts; boot line pinned at “97% … 89s” with no signal of overrun. New: UI asks `economic_state.display_liquidity`, which keeps lanes dry until verified and unions economic outage with token-runway exhaustion; the cost chip reads `unfunded`, `local tier (…)`, or `⚠ <lane> dry` while preserving the ceiling; boot line shows `+Xs over  waiting on <stage>` once past tolerance. Side effects: healthy path unchanged; render path does not add network calls.

- No migration required. Optional tuning for overrun via `JARVIS_OV_BOOT_OVERRUN_TOLERANCE` and `JARVIS_OV_BOOT_OVERRUN_GRACE_S` (defaults 0.25 and 3.0s).

• Liquidity and status line
- Replace `provider_liquidity_ledger.runway_exhausted` with `economic_state.display_liquidity` in the status line and capability badge. A lapsed outage window remains dry until verified; rate limits are dry for display but do not qualify funding.
- Fractional decisions over the lane roster. One dry lane is named; only when all known lanes are dry do we say “all lanes”.
- Cost chip qualification: `unfunded` when all paid lanes are economically dry; `local tier (<endpoint>)` when a sovereign tier is serving; `⚠ <lane> dry` for partial dryness. The ceiling stays visible to bound spend.
- `StatusLineBuilder` stays non-blocking; it reads the gateway’s in-memory breaker snapshot only.

• Boot progress and overruns
- Split projection into `_raw_projection` (unclamped), `_projected_total_s` (clamped for ETA), and `overrun_s` (detects exceedance). Render adds `+Xs over  waiting on <next stage>`; otherwise shows `~Ns left`.
- Proportional tolerance with a seconds floor; both env-tunable. No prediction -> no overrun reported.
- Hardened rendering with `_finite_seconds` to avoid NaN/inf crashes; a single `_eta_horizon` rule prevents ETA/bar drift. The 97% ceiling and healthy path remain unchanged.
- Monotonic vs wall-clock rules pinned by tests; the wait is bounded and observes child liveness.

<sup>Written for commit edcd872b2bf306803964f391649a45a4c17c918e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

