### PR TITLE
feat(local-inference): run the 32B locally — measured VRAM, per-model context physics, serialized residency, predictive pre-warm

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -5036,13 +5036,39 @@ class CandidateGenerator:
             )
             return LatencyProfiler(cfg)
 
-    async def _negotiate_num_ctx(self, endpoint: Optional[str]) -> Optional[int]:
+    async def _negotiate_num_ctx(
+        self, endpoint: Optional[str], *, model: Optional[str] = None,
+    ) -> Optional[int]:
         """Autonomous Context-Hardware Negotiator: derive the VRAM-safe context
         window for *endpoint* from the MEASURED buffer -- node VRAM (awakened GPU
         tier) minus the served model's on-disk bytes (its own /api/tags) -- so the
         KV cache can never overflow VRAM (the warm-32B ServerDisconnect root cause).
         None when undeterminable (not a GPU tier / size unknown) -> caller keeps the
-        legacy path. Fail-soft -- NEVER raises."""
+        legacy path. Fail-soft -- NEVER raises.
+
+        When ``model`` is supplied AND model-physics autodetect is on, two inputs
+        stop being global constants and become properties OF THAT MODEL:
+
+          * ``kv_bytes_per_token`` -- architectural (layers x kv-heads x
+            (key+value) x dtype), spanning 57,344..262,144 across the local
+            fleet. One constant for all of them is necessarily wrong for most.
+          * ``ceiling`` -- the STRICTER of the operator's configured cap and the
+            model's NATIVE trained context. This is the decoupling that matters:
+            VRAM says how much context fits, the model says how much it can
+            actually use, and those are different limits. qwen2.5-coder is 32K
+            native while qwen3-coder:30b is 262K, so a single global ceiling
+            either starves the MoE or pushes the dense model past its training.
+
+        Physics unavailable -> both fall back to the global env constants, which
+        is exactly the pre-existing behaviour.
+
+        ``model`` is an OPTIONAL injection point for tests and is NOT passed by
+        the production caller. It is resolved internally instead, deliberately:
+        this method is overridden by stubs and subclasses that implement the
+        one-argument signature, so widening the CALL to pass a second argument
+        would break them at runtime -- a contract change disguised as an
+        enhancement. Resolution is memoized per-endpoint, so doing it here costs
+        one cached lookup rather than a second round trip."""
         try:
             model_bytes = await _resolve_served_model_bytes(endpoint)
             vram_bytes = _awakened_vram_bytes()
@@ -5051,7 +5077,32 @@ class CandidateGenerator:
             from backend.core.ouroboros.governance.local_inference_director import (  # noqa: PLC0415
                 derive_safe_num_ctx,
             )
-            return derive_safe_num_ctx(vram_bytes=vram_bytes, model_bytes=model_bytes)
+            kwargs: Dict[str, Any] = {}
+            try:
+                from . import local_inference_director as _lid  # noqa: PLC0415
+                from .model_physics import (  # noqa: PLC0415
+                    effective_ceiling,
+                    physics_autodetect_enabled,
+                    resolve_model_physics,
+                )
+                # Resolve the served model ONLY when physics is armed: gate off
+                # means not even a cached lookup runs, so the legacy path stays
+                # byte-identical in work performed, not merely in result.
+                if model is None and physics_autodetect_enabled():
+                    model = await self._resolve_dispatch_model_name(endpoint)
+                physics = await resolve_model_physics(endpoint, model)
+                if physics is not None:
+                    kwargs["kv_bytes_per_token"] = physics.kv_bytes_per_token
+                    # Read the configured ceiling through the SAME env name and
+                    # the SAME default constant derive_safe_num_ctx itself uses,
+                    # so the two can never disagree about what "unset" means.
+                    configured = _lid._int_env(
+                        "JARVIS_NUM_CTX_CEILING", _lid._NUM_CTX_CEILING_DEFAULT)
+                    kwargs["ceiling"] = effective_ceiling(physics, configured)
+            except Exception:  # noqa: BLE001 -- physics is advisory, never required
+                kwargs = {}
+            return derive_safe_num_ctx(
+                vram_bytes=vram_bytes, model_bytes=model_bytes, **kwargs)
         except Exception:  # noqa: BLE001
             return None
 

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2993,10 +2993,49 @@ def _dilate_sovereign_deadline(deadline: "datetime", profiler: Any,
         return deadline
 
 
+def _local_vram_autodetect_enabled() -> bool:
+    """Master switch for preferring a MEASURED local VRAM reading over the GCP
+    provisioning spec. Default OFF -> the legacy spec-derived path, byte-identical."""
+    return _envb("JARVIS_LOCAL_VRAM_AUTODETECT_ENABLED", False)
+
+
+def _measured_local_vram_bytes() -> int:
+    """VRAM (bytes) MEASURED on this host, via the existing compute-topology
+    probe. 0 when the probe is disabled, unavailable, or returned an absence.
+
+    Composes ``compute_topology.resolve_sync()`` -- the module that already owns
+    the ``nvidia-smi`` cascade, its timeout discipline and its caching. A second
+    probe here would be a second authority over the same physics. NEVER raises."""
+    try:
+        from . import compute_topology  # noqa: PLC0415
+        if not compute_topology.is_enabled():
+            return 0
+        reading = compute_topology.resolve_sync()
+        if not getattr(reading, "measured", False):
+            return 0
+        return max(0, int(getattr(reading, "total_bytes", 0) or 0))
+    except Exception:  # noqa: BLE001 -- descriptive helper must never raise
+        return 0
+
+
 def _awakened_vram_bytes() -> int:
-    """VRAM (bytes) of the awakened GPU tier -- the controller's live awakened tier
-    if available, else the QUALITY provisioning spec. 0 if not a GPU tier / unknown
-    (the negotiator then keeps the legacy path). NEVER raises."""
+    """VRAM (bytes) of the serving GPU -- MEASURED on this host when possible,
+    else the awakened tier, else the QUALITY provisioning spec. 0 if not a GPU
+    tier / unknown (the negotiator then keeps the legacy path). NEVER raises.
+
+    WHY MEASURED COMES FIRST. The spec path answers "what did we ASK GCP for",
+    which is the right question for a provisioned failover node and the WRONG
+    one for an operator workstation serving Ollama locally. There, no controller
+    tier is awake, so resolution fell through to ``_quality_tier()`` whose
+    accelerator default is ``nvidia-l4`` -- and a local 32 GiB card was sized as
+    24 GiB. Not an absence the negotiator could floor on, but a confident wrong
+    number that silently halved the derived context window. A reading of the
+    actual hardware outranks a guess about it; the spec chain is retained
+    verbatim beneath as the fallback for genuinely remote tiers."""
+    if _local_vram_autodetect_enabled():
+        measured = _measured_local_vram_bytes()
+        if measured > 0:
+            return measured
     accel = ""
     try:
         from .failover_lifecycle import get_failover_controller  # noqa: PLC0415

--- a/backend/core/ouroboros/governance/failover_tier.py
+++ b/backend/core/ouroboros/governance/failover_tier.py
@@ -23,10 +23,11 @@ from dataclasses import dataclass
 
 _PARAM_RE = re.compile(r"(\d+(?:\.\d+)?)\s*b\b", re.IGNORECASE)
 
-# VRAM (GiB) per GCP accelerator type -- the physical ceiling the Context-Hardware
+# VRAM (GiB) per accelerator -- the physical ceiling the Context-Hardware
 # Negotiator derives the safe num_ctx from. Descriptive hardware facts, NOT a
 # tunable cap; an operator may override the resolved value with JARVIS_GPU_VRAM_GIB.
 _GPU_VRAM_GIB = {
+    # --- GCP accelerator types (as provisioned by the failover tiers) ---
     "nvidia-l4": 24,
     "nvidia-tesla-t4": 16,
     "nvidia-t4": 16,
@@ -38,18 +39,76 @@ _GPU_VRAM_GIB = {
     "nvidia-h100": 80,
     "nvidia-h100-80gb": 80,
     "nvidia-h100-mega-80gb": 80,
+    # --- Consumer / workstation parts (operator-local serving tier) ---
+    #
+    # WHY THESE ARE HERE. The GCP rows above are reached from a provisioning
+    # SPEC (`_quality_tier().accelerator_type`). A local serving host has no
+    # such spec -- it has an `nvidia-smi` device NAME. Before these rows, a
+    # workstation GPU fell through to the QUALITY tier default `nvidia-l4` and
+    # was sized as 24 GiB. That is not a missing reading, it is a CONFIDENTLY
+    # WRONG one: a 32 GiB card gets an L4's KV budget and the negotiator
+    # under-derives num_ctx by ~2x, silently. Keys are stored in normalized
+    # form (see `_normalize_accel_key`) so `nvidia-smi`'s
+    # "NVIDIA GeForce RTX 5090" resolves without the caller pre-cleaning it.
+    "rtx-5090": 32,
+    "rtx-5090-d": 24,
+    "rtx-5080": 16,
+    "rtx-5070-ti": 16,
+    "rtx-5070": 12,
+    "rtx-4090": 24,
+    "rtx-4080": 16,
+    "rtx-4070-ti": 12,
+    "rtx-3090-ti": 24,
+    "rtx-3090": 24,
+    "rtx-a6000": 48,
+    "rtx-6000-ada": 48,
+    "rtx-5000-ada": 32,
+    "rtx-4500-ada": 24,
+    "l40s": 48,
+    "l40": 48,
 }
+
+# Vendor/marketing tokens carried by `nvidia-smi` device names that say nothing
+# about the part. Dropped during normalization so the ledger keys stay short.
+_ACCEL_NAME_NOISE = frozenset({
+    "nvidia", "geforce", "gpu", "graphics", "laptop", "generation", "ada",
+})
+
+_ACCEL_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _normalize_accel_key(raw: str) -> str:
+    """Reduce an accelerator string to a ledger key. Lower-cases, collapses any
+    non-alphanumeric run to a single dash, and drops vendor/marketing tokens, so
+    ``"NVIDIA GeForce RTX 5090"`` and ``"rtx_5090"`` both become ``"rtx-5090"``.
+    Pure; NEVER raises."""
+    try:
+        flat = _ACCEL_NON_ALNUM_RE.sub("-", (raw or "").strip().lower()).strip("-")
+        if not flat:
+            return ""
+        kept = [tok for tok in flat.split("-") if tok and tok not in _ACCEL_NAME_NOISE]
+        return "-".join(kept)
+    except Exception:  # noqa: BLE001 -- descriptive helper must never raise
+        return ""
 
 
 def accelerator_vram_bytes(accel_type: str) -> int:
-    """Physical VRAM (bytes) for a GCP accelerator type. ``JARVIS_GPU_VRAM_GIB``
-    force-overrides the lookup (any node); an unknown type returns 0 so the caller
-    floors the context window rather than guessing. NEVER raises."""
+    """Physical VRAM (bytes) for an accelerator type or device name.
+
+    Resolution order: ``JARVIS_GPU_VRAM_GIB`` force-override -> EXACT ledger hit
+    -> normalized ledger hit. The exact lookup runs first so every pre-existing
+    GCP accelerator type resolves byte-identically to before the consumer rows
+    existed; normalization only ever RESCUES a string that would otherwise have
+    returned 0. An unknown type still returns 0 so the caller floors the context
+    window rather than guessing. NEVER raises."""
     try:
         forced = (os.environ.get("JARVIS_GPU_VRAM_GIB", "") or "").strip()
         if forced:
             return int(float(forced) * (1024 ** 3))
-        gib = _GPU_VRAM_GIB.get((accel_type or "").strip().lower(), 0)
+        raw = (accel_type or "").strip().lower()
+        gib = _GPU_VRAM_GIB.get(raw, 0)
+        if not gib:
+            gib = _GPU_VRAM_GIB.get(_normalize_accel_key(raw), 0)
         return int(gib * (1024 ** 3))
     except Exception:  # noqa: BLE001 -- descriptive helper must never raise
         return 0

--- a/backend/core/ouroboros/governance/inference_gateway.py
+++ b/backend/core/ouroboros/governance/inference_gateway.py
@@ -445,6 +445,12 @@ class InferenceGateway:
         #: read-and-mutated. See `_swap_lock_for` for why a per-endpoint asyncio
         #: lock rather than the shared threading one.
         self._swap_locks: Dict[str, "asyncio.Lock"] = {}
+        #: base_url -> count of generations CURRENTLY streaming on that host.
+        #: The swap mutex is released the moment residency is settled, which is
+        #: BEFORE generation starts -- so the mutex alone cannot stop an
+        #: advisory pre-warm from evicting weights out from under a live
+        #: stream. This counter is what makes that impossible.
+        self._inflight: Dict[str, int] = {}
         self._client_factory = client_factory
 
     # -- resolution --------------------------------------------------------
@@ -625,17 +631,49 @@ class InferenceGateway:
                 prompt_tokens=prompt_tokens, temperature=temperature,
                 max_tokens=max_tokens)
 
+    def _inflight_count(self, base_url: str) -> int:
+        """Generations currently streaming on *base_url*. NEVER raises."""
+        try:
+            with self._lock:
+                return int(self._inflight.get(base_url, 0))
+        except Exception:  # noqa: BLE001
+            # Unknowable reads as BUSY: an advisory swap that cannot prove the
+            # host is idle must not proceed. Fail toward not-evicting.
+            return 1
+
+    def _inflight_adjust(self, base_url: str, delta: int) -> None:
+        """Move the in-flight counter. NEVER raises -- an accounting failure
+        must not propagate into a dispatch."""
+        try:
+            with self._lock:
+                cur = int(self._inflight.get(base_url, 0)) + delta
+                if cur > 0:
+                    self._inflight[base_url] = cur
+                else:
+                    self._inflight.pop(base_url, None)
+        except Exception:  # noqa: BLE001
+            pass
+
     async def _dispatch_to(self, target: GatewayTarget, *, system: str,
                            user: str, prompt_tokens: int, temperature: float,
                            max_tokens: Optional[int]) -> Any:
         client, _profiler = self._client_for(target)
-        result = await client.complete(
-            system=system, user=user, prompt_tokens=prompt_tokens,
-            temperature=temperature, max_tokens=max_tokens,
-            # See the docstring: forced for remote, left to the client's own
-            # policy locally (where a stall is slowness, not a dead peer).
-            stream=True if target.is_remote else None,
-        )
+        # The generation window. Incremented HERE and not in `dispatch` on
+        # purpose: this is the only place weights are actually in use, and the
+        # decrement must survive InterTokenStall, cancellation and any provider
+        # exception -- hence try/finally rather than a post-await line, which a
+        # raised stall would skip and leak the host as permanently busy.
+        self._inflight_adjust(target.base_url, 1)
+        try:
+            result = await client.complete(
+                system=system, user=user, prompt_tokens=prompt_tokens,
+                temperature=temperature, max_tokens=max_tokens,
+                # See the docstring: forced for remote, left to the client's own
+                # policy locally (where a stall is slowness, not a dead peer).
+                stream=True if target.is_remote else None,
+            )
+        finally:
+            self._inflight_adjust(target.base_url, -1)
         if target.is_remote:
             self._health_for(target.base_url).record_success()
         return result
@@ -738,7 +776,11 @@ class InferenceGateway:
             return lk
 
     async def ensure_model_resident(
-        self, target: "GatewayTarget", *, route: Optional[str] = None,
+        self,
+        target: "GatewayTarget",
+        *,
+        route: Optional[str] = None,
+        advisory: bool = False,
     ) -> Dict[str, Any]:
         """Pre-flight: verify the target model is loaded, warm-swapping if not.
 
@@ -779,14 +821,26 @@ class InferenceGateway:
             out["reason"] = "preflight disabled"
             return out
         if not vram_mutex_enabled():
+            # An advisory swap is only safe BECAUSE the mutex and the in-flight
+            # counter exist. With the mutex disabled there is nothing to queue
+            # behind, so a pre-warm would be an unsynchronized eviction -- it
+            # declines rather than degrading into the exact race it prevents.
+            if advisory:
+                out["deferred"] = True
+                out["reason"] = "pre-warm declined: VRAM mutex disabled"
+                return out
             return await self._ensure_model_resident_inner(target, out, route=route)
         try:
             lock = self._swap_lock_for(target.base_url)
         except Exception:  # noqa: BLE001 -- lock creation must never block dispatch
+            if advisory:
+                out["deferred"] = True
+                out["reason"] = "pre-warm declined: no swap lock"
+                return out
             return await self._ensure_model_resident_inner(target, out, route=route)
         async with lock:
             return await self._ensure_model_resident_inner(
-                target, out, route=route, guarded=True)
+                target, out, route=route, guarded=True, advisory=advisory)
 
     async def _ensure_model_resident_inner(
         self,
@@ -795,6 +849,7 @@ class InferenceGateway:
         *,
         route: Optional[str] = None,
         guarded: bool = False,
+        advisory: bool = False,
     ) -> Dict[str, Any]:
         """The residency check-and-swap itself. Split out so the mutex wraps the
         WHOLE read-decide-mutate sequence rather than only the mutation -- a lock
@@ -822,6 +877,29 @@ class InferenceGateway:
             if self._model_matches(target.model_name, resident):
                 out["reason"] = "already resident"
                 return out
+
+            # -- advisory guard: never disturb a live generation ---------------
+            # Re-read the counter HERE, inside the lock and after the residency
+            # probe awaited, rather than before acquiring it: a dispatch can
+            # start during either await, and a check made earlier would be a
+            # stale answer to the only question that matters.
+            #
+            # Holding the swap lock does NOT make this safe on its own. The lock
+            # is released as soon as residency is settled, which is before
+            # `_dispatch_to` begins streaming -- so a pre-warm can hold the lock
+            # legitimately, see a mismatch, and evict weights a running
+            # generation is mid-way through reading. That is the CUDA-OOM /
+            # partial-offload class this guard exists to make unreachable.
+            if advisory:
+                busy = self._inflight_count(target.base_url)
+                if busy > 0:
+                    out["deferred"] = True
+                    out["reason"] = (
+                        f"pre-warm deferred: {busy} generation(s) in flight on "
+                        f"{target.base_url} — an advisory swap never evicts "
+                        f"weights that are in use"
+                    )
+                    return out
 
             # -- capacity admission (mutex path only) --------------------------
             # A swap on a card that cannot hold both models is an EVICTION, not

--- a/backend/core/ouroboros/governance/inference_gateway.py
+++ b/backend/core/ouroboros/governance/inference_gateway.py
@@ -74,6 +74,8 @@ PROBE_TIMEOUT_ENV = "JARVIS_GATEWAY_PROBE_TIMEOUT_S"
 PREFLIGHT_ENV = "JARVIS_GATEWAY_PREFLIGHT_ENABLED"
 RESIDENCY_TTL_ENV = "JARVIS_GATEWAY_RESIDENCY_TTL_S"
 SWAP_BUDGET_ENV = "JARVIS_GATEWAY_WARM_SWAP_BUDGET_S"
+VRAM_MUTEX_ENV = "JARVIS_GATEWAY_VRAM_MUTEX_ENABLED"
+DOWNROUTE_ROUTES_ENV = "JARVIS_GATEWAY_DOWNROUTE_ROUTES"
 
 _TRUTHY = ("1", "true", "yes", "on")
 
@@ -180,6 +182,90 @@ def warm_swap_budget_s() -> float:
         return max(1.0, float(os.environ.get(SWAP_BUDGET_ENV, "180")))
     except (TypeError, ValueError):
         return 180.0
+
+
+def vram_mutex_enabled() -> bool:
+    """Master gate for residency serialization + capacity admission.
+
+    Default OFF -> `ensure_model_resident` behaves exactly as before: an
+    unserialized check-then-swap with no capacity opinion. NEVER raises."""
+    try:
+        return os.environ.get(VRAM_MUTEX_ENV, "").strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def downroute_routes() -> "frozenset":
+    """Routes whose ops may be served by whatever model is ALREADY resident
+    rather than forcing an eviction. Comma-separated; default background +
+    speculative -- the two routes the urgency router already defines as
+    cost-optimized and latency-insensitive. NEVER raises."""
+    try:
+        raw = (os.environ.get(DOWNROUTE_ROUTES_ENV, "") or "").strip()
+        if not raw:
+            return frozenset({"background", "speculative"})
+        return frozenset(
+            p.strip().lower() for p in raw.split(",") if p.strip()
+        )
+    except Exception:  # noqa: BLE001
+        return frozenset({"background", "speculative"})
+
+
+def _serving_vram_bytes() -> int:
+    """VRAM (bytes) of the device serving this endpoint, via the ONE resolver
+    that already owns that question. Lazy + fail-soft: 0 means "undeterminable",
+    which every caller must treat as "do not form a capacity opinion" rather
+    than as "no VRAM". NEVER raises."""
+    try:
+        from .candidate_generator import _awakened_vram_bytes  # noqa: PLC0415
+        return max(0, int(_awakened_vram_bytes() or 0))
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def _model_bytes(model_id: str) -> int:
+    """On-disk bytes for a model label, via the existing GGUF estimator.
+    0 when the label carries no parseable parameter count. NEVER raises."""
+    try:
+        from .failover_tier import estimate_gguf_bytes  # noqa: PLC0415
+        return max(0, int(estimate_gguf_bytes(model_id) or 0))
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def models_can_coexist(wanted: str, resident: "Tuple[str, ...]") -> "Optional[bool]":
+    """Can *wanted* load WITHOUT evicting *resident*?
+
+    True/False is an opinion; ``None`` means undeterminable (unknown VRAM or an
+    unparseable label) and the caller must fall through to legacy behaviour
+    rather than inventing a verdict.
+
+    WHY THIS IS NEEDED AT ALL. Ollama will accept a request for a second model
+    while a first is loaded and try to make room -- and when it cannot, the
+    resolution is not a clean error but eviction plus reload, or worse, a
+    partial offload to system RAM that turns a 40 tok/s model into a 2 tok/s
+    one. On a 32GiB card a 19.85GB coder and an 18.56GB MoE cannot coexist by
+    ~5GB, so the "both resident" state this guards against is not hypothetical.
+    Reserves the SAME overhead the context negotiator reserves, from the same
+    env knob, so the two cannot disagree about the same card. NEVER raises."""
+    try:
+        vram = _serving_vram_bytes()
+        want_b = _model_bytes(wanted)
+        if vram <= 0 or want_b <= 0:
+            return None
+        resident_b = 0
+        for r in resident or ():
+            rb = _model_bytes(r)
+            if rb <= 0:
+                return None  # one unknown resident poisons the whole sum
+            resident_b += rb
+        try:
+            overhead = int(os.environ.get("JARVIS_CTX_OVERHEAD_BYTES", "1500000000"))
+        except (TypeError, ValueError):
+            overhead = 1_500_000_000
+        return (resident_b + want_b + overhead) <= vram
+    except Exception:  # noqa: BLE001
+        return None
 
 
 class HostState(str, enum.Enum):
@@ -355,6 +441,10 @@ class InferenceGateway:
         #: base_url -> (monotonic_at, resident_models_or_None). None is
         #: "unknowable", which is NOT the same as an empty tuple.
         self._residency: Dict[str, Tuple[float, Optional[Tuple[str, ...]]]] = {}
+        #: base_url -> the ONE lock under which that endpoint's residency may be
+        #: read-and-mutated. See `_swap_lock_for` for why a per-endpoint asyncio
+        #: lock rather than the shared threading one.
+        self._swap_locks: Dict[str, "asyncio.Lock"] = {}
         self._client_factory = client_factory
 
     # -- resolution --------------------------------------------------------
@@ -631,8 +721,39 @@ class InferenceGateway:
                 return True
         return False
 
-    async def ensure_model_resident(self, target: "GatewayTarget") -> Dict[str, Any]:
+    def _swap_lock_for(self, endpoint: str) -> "asyncio.Lock":
+        """The one lock under which *endpoint*'s residency may be read-and-mutated.
+
+        Per-endpoint, not global: two DIFFERENT hosts have independent VRAM and
+        must be able to swap concurrently. An ``asyncio.Lock`` rather than the
+        instance's ``threading.Lock`` because the critical section awaits a
+        multi-minute PCIe transfer -- holding a thread lock across that would
+        block the event loop, which is the failure this whole tier exists to
+        avoid. Created lazily inside the running loop. NEVER raises."""
+        with self._lock:
+            lk = self._swap_locks.get(endpoint)
+            if lk is None:
+                lk = asyncio.Lock()
+                self._swap_locks[endpoint] = lk
+            return lk
+
+    async def ensure_model_resident(
+        self, target: "GatewayTarget", *, route: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Pre-flight: verify the target model is loaded, warm-swapping if not.
+
+        ``route`` is optional and advisory: supplied, it lets a cost-optimized
+        route be served by an already-resident model instead of forcing a
+        ~20GB eviction. Omitted, no op is ever down-routed -- the caller gets
+        exactly the swap-or-not behaviour it asked for.
+
+        SERIALIZED when :func:`vram_mutex_enabled`. Without the mutex this is a
+        check-then-act race: two concurrent ops wanting different models both
+        read the same residency snapshot, both see a mismatch, and both call
+        ``warmup()``. The device is then asked to hold both -- and on a card
+        that cannot, the loser is not a queued request but a partial offload to
+        system RAM, silently, for both ops. The lock makes "what is resident"
+        a question only one coroutine per endpoint may act on at a time.
 
         WHY THIS EXISTS. Ollama loads a model on first use. If the resident
         model is the 30B coder and an op asks for the 27B vision model, that
@@ -657,6 +778,28 @@ class InferenceGateway:
         if not preflight_enabled():
             out["reason"] = "preflight disabled"
             return out
+        if not vram_mutex_enabled():
+            return await self._ensure_model_resident_inner(target, out, route=route)
+        try:
+            lock = self._swap_lock_for(target.base_url)
+        except Exception:  # noqa: BLE001 -- lock creation must never block dispatch
+            return await self._ensure_model_resident_inner(target, out, route=route)
+        async with lock:
+            return await self._ensure_model_resident_inner(
+                target, out, route=route, guarded=True)
+
+    async def _ensure_model_resident_inner(
+        self,
+        target: "GatewayTarget",
+        out: Dict[str, Any],
+        *,
+        route: Optional[str] = None,
+        guarded: bool = False,
+    ) -> Dict[str, Any]:
+        """The residency check-and-swap itself. Split out so the mutex wraps the
+        WHOLE read-decide-mutate sequence rather than only the mutation -- a lock
+        held across just the swap would still let two coroutines read the same
+        stale snapshot and both decide to swap. NEVER raises."""
         try:
             now = time.monotonic()
             with self._lock:
@@ -679,6 +822,33 @@ class InferenceGateway:
             if self._model_matches(target.model_name, resident):
                 out["reason"] = "already resident"
                 return out
+
+            # -- capacity admission (mutex path only) --------------------------
+            # A swap on a card that cannot hold both models is an EVICTION, not
+            # an addition. For a latency-insensitive route that is a bad trade:
+            # it pays ~20GB of PCIe transfer, and the op it evicted for will pay
+            # it again in the other direction moments later. Serving such an op
+            # with whatever is already loaded is strictly cheaper and, for
+            # background/speculative work, good enough. A capable model already
+            # in VRAM beats the right model that is not.
+            if guarded:
+                coexist = models_can_coexist(target.model_name, resident)
+                out["can_coexist"] = coexist
+                rt = (route or "").strip().lower()
+                if coexist is False and resident and rt and rt in downroute_routes():
+                    out["downrouted_to"] = resident[0]
+                    out["reason"] = (
+                        f"down-routed: {target.model_name} cannot coexist with "
+                        f"{', '.join(resident)} on this device; route '{rt}' is "
+                        f"eviction-averse — serving with {resident[0]}"
+                    )
+                    logger.info(
+                        "[InferenceGateway] down-route: op wanted %s but %s is "
+                        "resident and they do not fit together; route=%s — "
+                        "serving with the resident model instead of evicting",
+                        target.model_name, ", ".join(resident), rt,
+                    )
+                    return out
 
             logger.info(
                 "[InferenceGateway] warm swap: %s is resident, op needs %s — "

--- a/backend/core/ouroboros/governance/intake/sensors/opportunity_miner_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/opportunity_miner_sensor.py
@@ -46,6 +46,27 @@ from backend.core.ouroboros.governance.target_stratification import (
 logger = logging.getLogger(__name__)
 
 
+def _prewarm_hint(*, urgency: str, complexity: str, source: str) -> str:
+    """Tell the pre-warm director that work of this shape is now queued.
+
+    Imported LAZILY and swallowed unconditionally. A sensor's ingestion path
+    must not acquire a hard dependency on the inference tier -- this sensor runs
+    in deployments with no local GPU at all, and an ImportError here would turn
+    a speculative optimisation into a boot failure. The director itself is
+    gated OFF by default, so on an unconfigured host this costs one function
+    call that returns "disabled".
+
+    NON-BLOCKING: the director schedules its own task and returns immediately.
+    NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.prewarm_director import (  # noqa: PLC0415
+            hint as _hint,
+        )
+        return _hint(urgency=urgency, complexity=complexity, source=source)
+    except Exception:  # noqa: BLE001
+        return "unavailable"
+
+
 # ---------------------------------------------------------------------------
 # Analysis result types
 # ---------------------------------------------------------------------------
@@ -947,6 +968,31 @@ class OpportunityMinerSensor:
                 result = await self._router.ingest(envelope)
                 self._record_ingest_result(counters, result)
                 if result in ("enqueued", "pending_ack"):
+                    # Predictive pre-warm. The router ACCEPTING this envelope is
+                    # the earliest moment the system knows work of a known shape
+                    # is queued -- so it is the earliest moment the ~20GB model
+                    # transfer can start overlapping the queue wait instead of
+                    # following it.
+                    #
+                    # Complexity is this sensor's OWN existing verdict
+                    # (`self._threshold`, the same cutoff that decided this file
+                    # was worth an envelope at all), not a second opinion. The
+                    # tier is then resolved by the dispatcher's own
+                    # `resolve_tier`, so a pre-warm cannot target a model the
+                    # dispatcher would not have chosen.
+                    #
+                    # NON-BLOCKING and NEVER raises: it is deliberately not
+                    # inside the try/except below, because it cannot fail in a
+                    # way that concerns ingestion.
+                    _prewarm_hint(
+                        urgency=envelope.urgency,
+                        complexity=(
+                            "complex"
+                            if analysis.cyclomatic_complexity >= self._threshold
+                            else ""
+                        ),
+                        source="ai_miner",
+                    )
                     self._seen_file_paths.add(rel)
                     self._cooldown_map[rel] = self._scan_cycle
                     ingested.append(StaticCandidate(

--- a/backend/core/ouroboros/governance/model_physics.py
+++ b/backend/core/ouroboros/governance/model_physics.py
@@ -1,0 +1,286 @@
+# backend/core/ouroboros/governance/model_physics.py
+"""Per-model physics, read from the serving engine's own metadata.
+
+WHY THIS MODULE EXISTS
+----------------------
+Two different numbers bound how much context an op may be given, and they are
+owned by two different authorities:
+
+  * What the DEVICE can hold -- ``(VRAM - weights - overhead) / kv_per_token``.
+    Owned by the Context-Hardware Negotiator (``derive_safe_num_ctx``).
+  * What the MODEL was TRAINED for. Owned by the model, and knowable only by
+    asking it.
+
+A single global ``JARVIS_NUM_CTX_CEILING`` collapses those into one constant, so
+every model wears the most restrictive value any model needs. On the current
+local fleet that is an 8x error: ``qwen2.5-coder`` is 32K native while
+``qwen3-coder:30b`` is 262K. Capping the MoE at 32K wastes context it was built
+for; raising the global to 262K would hand ``qwen2.5-coder`` a window past its
+trained limit, where output degrades rather than improves. Neither number is
+wrong -- they are simply not the same number.
+
+The same argument applies to KV cost. ``JARVIS_KV_BYTES_PER_TOKEN`` is a single
+pessimistic constant, but KV cost is architectural:
+
+    kv_bytes_per_token = block_count x kv_heads x (key_len + value_len) x dtype
+
+Across the local fleet that spans 57,344 to 262,144 -- a 4.6x spread. Computed
+from metadata it reproduces the hand-derived 262,144 in
+``local_inference_director`` EXACTLY for ``qwen2.5-coder:32b``, which is the
+check that says the formula is right rather than merely plausible.
+
+WHAT THIS IS NOT
+----------------
+Not a transport (composes ``aiohttp`` the way ``_fetch_served_model_bytes``
+already does), not a cache authority beyond one memo dict, and not a policy: it
+reports what the model IS. Deciding what to do about it stays with the
+negotiator. Every function is fail-soft -- an unresolvable model yields ``None``
+and every caller must keep its legacy path, because a guessed context window is
+worse than an un-negotiated one.
+
+Python 3.9+. Gated by ``JARVIS_MODEL_PHYSICS_AUTODETECT_ENABLED`` (default OFF
+-> byte-identical legacy behaviour).
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.ModelPhysics")
+
+ENABLED_ENV = "JARVIS_MODEL_PHYSICS_AUTODETECT_ENABLED"
+DTYPE_BYTES_ENV = "JARVIS_KV_CACHE_DTYPE_BYTES"
+TIMEOUT_ENV = "JARVIS_MODEL_PHYSICS_TIMEOUT_S"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+#: (endpoint, model) -> ModelPhysics. A model's architecture does not change
+#: while it is loaded, so this is memoized for the process lifetime. Failures
+#: are NOT cached, so a transient probe error retries on the next op.
+_PHYSICS_CACHE: Dict[Tuple[str, str], "ModelPhysics"] = {}
+
+
+def physics_autodetect_enabled() -> bool:
+    """Master gate. Default OFF -> callers keep the global-constant path,
+    byte-identical. NEVER raises."""
+    try:
+        return os.environ.get(ENABLED_ENV, "").strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def kv_cache_dtype_bytes() -> int:
+    """Bytes per KV element. Default 2 (fp16), which is what llama.cpp/Ollama
+    allocate unless KV quantization is explicitly enabled. An operator running a
+    quantized KV cache sets this to 1. NEVER raises."""
+    try:
+        return max(1, int(os.environ.get(DTYPE_BYTES_ENV, "2")))
+    except (TypeError, ValueError):
+        return 2
+
+
+def probe_timeout_s() -> float:
+    """Wall-clock bound on the metadata probe. Default 8s, matching the sibling
+    ``/api/tags`` fetch. NEVER raises."""
+    try:
+        return max(0.5, float(os.environ.get(TIMEOUT_ENV, "8")))
+    except (TypeError, ValueError):
+        return 8.0
+
+
+@dataclass(frozen=True)
+class ModelPhysics:
+    """What a served model's architecture implies for context sizing."""
+
+    #: Tokens the model was TRAINED to handle. A hard ceiling on quality, not a
+    #: memory fact -- exceeding it needs rope-scaling and degrades output.
+    native_context: int
+    #: Bytes of KV cache one token costs on this model.
+    kv_bytes_per_token: int
+    architecture: str
+    block_count: int
+    kv_heads: int
+    key_length: int
+    value_length: int
+    #: "metadata" when every field was read; "metadata+derived_head_dim" when
+    #: key/value length were absent and head_dim was inferred from
+    #: embedding_length / head_count. Provenance is reported, never assumed.
+    source: str = "metadata"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "native_context": self.native_context,
+            "kv_bytes_per_token": self.kv_bytes_per_token,
+            "architecture": self.architecture,
+            "block_count": self.block_count,
+            "kv_heads": self.kv_heads,
+            "key_length": self.key_length,
+            "value_length": self.value_length,
+            "source": self.source,
+        }
+
+
+def _as_int(value: Any) -> int:
+    """Tolerant int coercion -- GGUF metadata arrives as int, float or str
+    depending on the engine build. 0 on anything unusable. NEVER raises."""
+    try:
+        if value is None or isinstance(value, bool):
+            return 0
+        return max(0, int(float(value)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def parse_model_physics(payload: Any) -> "Optional[ModelPhysics]":
+    """Build :class:`ModelPhysics` from an Ollama ``/api/show`` payload.
+
+    PURE and separately testable -- the transport is elsewhere on purpose, so
+    the arithmetic can be proven against captured metadata without a network.
+
+    Keys are architecture-prefixed (``qwen2.block_count``,
+    ``qwen3moe.block_count``, ...), so the architecture is read first from
+    ``general.architecture`` rather than guessed by scanning. Returns ``None``
+    -- never a partial or defaulted object -- when any load-bearing field is
+    missing, because a half-known model must fall back to the global constant
+    rather than be sized from an assumption. NEVER raises."""
+    try:
+        if not isinstance(payload, dict):
+            return None
+        info = payload.get("model_info")
+        if not isinstance(info, dict):
+            return None
+        arch = str(info.get("general.architecture") or "").strip()
+        if not arch:
+            return None
+
+        def field(name: str) -> int:
+            return _as_int(info.get(arch + "." + name))
+
+        native_context = field("context_length")
+        block_count = field("block_count")
+        kv_heads = field("attention.head_count_kv")
+        key_len = field("attention.key_length")
+        val_len = field("attention.value_length")
+        source = "metadata"
+
+        # Older GGUF conversions omit key/value length. Derive head_dim from
+        # embedding_length / head_count -- correct for classic MHA/GQA layouts
+        # but NOT universally: Qwen3 sets head_dim=128 with hidden=2048 and 32
+        # heads, where the division yields 64 and would understate KV by 2x.
+        # So the derivation is a LAST resort and is stamped in `source` so a
+        # consumer can tell a read value from an inferred one.
+        if key_len <= 0 or val_len <= 0:
+            head_count = field("attention.head_count")
+            embedding = field("embedding_length")
+            if head_count > 0 and embedding > 0:
+                derived = embedding // head_count
+                key_len = key_len or derived
+                val_len = val_len or derived
+                source = "metadata+derived_head_dim"
+
+        if min(native_context, block_count, kv_heads, key_len, val_len) <= 0:
+            return None
+
+        kv_per_token = block_count * kv_heads * (key_len + val_len) * kv_cache_dtype_bytes()
+        if kv_per_token <= 0:
+            return None
+
+        return ModelPhysics(
+            native_context=native_context,
+            kv_bytes_per_token=kv_per_token,
+            architecture=arch,
+            block_count=block_count,
+            kv_heads=kv_heads,
+            key_length=key_len,
+            value_length=val_len,
+            source=source,
+        )
+    except Exception:  # noqa: BLE001 -- a parse failure must never break sizing
+        return None
+
+
+async def _fetch_model_show(endpoint: str, model: str) -> Any:
+    """POST <endpoint>/api/show -> the raw metadata payload. Fail-soft -> None.
+
+    Mirrors ``_fetch_served_model_bytes``'s shape deliberately: same client,
+    same bounded timeout, same swallow-and-return-empty contract."""
+    try:
+        import aiohttp  # noqa: PLC0415
+        url = endpoint.rstrip("/") + "/api/show"
+        timeout = aiohttp.ClientTimeout(total=probe_timeout_s())
+        async with aiohttp.ClientSession(timeout=timeout) as sess:
+            async with sess.post(url, json={"model": model}) as resp:
+                if resp.status != 200:
+                    return None
+                return await resp.json(content_type=None)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+async def resolve_model_physics(
+    endpoint: "Optional[str]",
+    model: "Optional[str]",
+    *,
+    fetcher: "Optional[Any]" = None,
+) -> "Optional[ModelPhysics]":
+    """Memoized physics for (endpoint, model). ``None`` when the gate is off or
+    the model is unresolvable -- the caller then keeps the global constants.
+
+    A successful read is cached for the process lifetime (architecture is
+    immutable for a loaded model); a failure is NOT cached, so a probe against a
+    still-booting engine retries rather than poisoning the entry. NEVER raises."""
+    try:
+        if not physics_autodetect_enabled():
+            return None
+        if not endpoint or not model:
+            return None
+        key = (endpoint, model)
+        hit = _PHYSICS_CACHE.get(key)
+        if hit is not None:
+            return hit
+        fn = fetcher or _fetch_model_show
+        payload = await fn(endpoint, model)
+        physics = parse_model_physics(payload)
+        if physics is None:
+            return None
+        _PHYSICS_CACHE[key] = physics
+        logger.info(
+            "[ModelPhysics] %s: native_context=%d kv_per_token=%d "
+            "(%s, %d layers x %d kv-heads x %d+%d, source=%s)",
+            model, physics.native_context, physics.kv_bytes_per_token,
+            physics.architecture, physics.block_count, physics.kv_heads,
+            physics.key_length, physics.value_length, physics.source,
+        )
+        return physics
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def effective_ceiling(
+    physics: "Optional[ModelPhysics]", configured_ceiling: int,
+) -> int:
+    """The context ceiling to hand the negotiator: the STRICTER of what the
+    operator configured and what the model was trained for.
+
+    Deliberately a floor-of-two rather than "model wins". The configured ceiling
+    is an operator's cost/latency decision and must remain able to hold a model
+    BELOW its native limit; the native limit must remain able to hold a model
+    below a permissive operator setting. Neither is allowed to override the
+    other upward. With no physics, the configured value passes through
+    unchanged. NEVER raises."""
+    try:
+        cfg = max(0, int(configured_ceiling))
+        if physics is None or physics.native_context <= 0:
+            return cfg
+        if cfg <= 0:
+            return physics.native_context
+        return min(cfg, physics.native_context)
+    except Exception:  # noqa: BLE001
+        return configured_ceiling
+
+
+def reset_cache_for_tests() -> None:
+    """Drop the memo. Tests only."""
+    _PHYSICS_CACHE.clear()

--- a/backend/core/ouroboros/governance/prewarm_director.py
+++ b/backend/core/ouroboros/governance/prewarm_director.py
@@ -1,0 +1,403 @@
+# backend/core/ouroboros/governance/prewarm_director.py
+"""Predictive model pre-warming -- pay the PCIe transfer before it is on the
+critical path.
+
+THE PROBLEM
+-----------
+A model swap is ~20GB across PCIe. ``InferenceGateway.ensure_model_resident``
+already moves that cost OUT of the op's generation clock, which stops it being
+misattributed as model slowness -- but the op still WAITS for it. The transfer
+is serial with the work either way; only the blame moved.
+
+The information needed to start it earlier already exists and is thrown away.
+When a sensor ingests an envelope the router ACCEPTS, that acceptance is a
+statement that work of a known shape is queued. The tier that work will use is
+derivable from its urgency and complexity by the same function the dispatcher
+uses. So the swap can begin the moment work is ENQUEUED rather than the moment
+it is DEQUEUED, and the transfer overlaps the queue wait instead of following
+it.
+
+WHAT MAKES THIS SAFE RATHER THAN A RACE
+---------------------------------------
+Pre-warming is speculative eviction on a device with one set of weights. Three
+properties, none optional:
+
+  * **It is advisory.** ``ensure_model_resident(advisory=True)`` refuses to swap
+    while any generation is in flight on that host. Weights in use are never
+    evicted, so the worst outcome of a wrong prediction is a wasted probe.
+  * **It queues, never barges.** It goes through the SAME per-endpoint swap
+    mutex as a real dispatch, so it serializes with real work by construction
+    rather than by timing.
+  * **It is bounded and droppable.** Rate-limited by the same
+    :class:`TokenBucket` the sensors use, single-flighted per endpoint,
+    debounced per model, and wrapped in a hard wall. A pre-warm that cannot run
+    cheaply does not run.
+
+Being wrong is CHEAP BY DESIGN and that is the whole argument for doing it
+speculatively: a correct prediction hides ~20GB of latency, an incorrect one
+costs one HTTP probe and a bucket token.
+
+WHAT THIS IS NOT
+----------------
+Not a scheduler, not a queue, and not a second opinion about which model an op
+should use -- it asks ``failover_tier.resolve_tier`` exactly like the dispatch
+path does, so a pre-warm can never warm a model the dispatcher would not have
+chosen. Not a polling loop: there is no timer here. It is edge-triggered by
+sensor emissions and idle otherwise.
+
+Python 3.9+. Gated by ``JARVIS_PREWARM_ENABLED`` (default OFF -> no task is ever
+created, byte-identical).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from typing import Any, Dict, Optional, Set
+
+from .intake.sensors.emission_control import TokenBucket, env_flag, env_num
+
+logger = logging.getLogger("Ouroboros.PrewarmDirector")
+
+ENABLED_ENV = "JARVIS_PREWARM_ENABLED"
+CAPACITY_ENV = "JARVIS_PREWARM_BUCKET_CAPACITY"
+REFILL_ENV = "JARVIS_PREWARM_REFILL_PER_S"
+DEBOUNCE_ENV = "JARVIS_PREWARM_DEBOUNCE_S"
+WALL_ENV = "JARVIS_PREWARM_WALL_S"
+
+#: Outcomes, returned by `hint` for observability. A pre-warm is best-effort, so
+#: every refusal is a NAMED state rather than an exception or a silent return.
+OUTCOME_DISABLED = "disabled"
+OUTCOME_NO_LOOP = "no_running_loop"
+OUTCOME_THROTTLED = "throttled"
+OUTCOME_DEBOUNCED = "debounced"
+OUTCOME_SINGLE_FLIGHT = "single_flight"
+OUTCOME_UNRESOLVED = "unresolved_target"
+OUTCOME_SCHEDULED = "scheduled"
+
+
+def prewarm_enabled() -> bool:
+    """Master gate. Default OFF -- and OFF means no task is created at all, not
+    a task that returns early. NEVER raises."""
+    return env_flag(ENABLED_ENV, "0")
+
+
+def bucket_capacity() -> float:
+    """Burst size. Small on purpose: pre-warming is speculative, and a burst
+    large enough to chain several swaps would spend more PCIe bandwidth on
+    guesses than on work. Clamped, live-read. NEVER raises."""
+    return env_num(CAPACITY_ENV, 2.0, 0.0, 32.0)
+
+
+def bucket_refill_per_s() -> float:
+    """Sustained rate. Default one token per ~5 minutes, i.e. pre-warming is a
+    rare event tied to queue transitions, not a background activity. Clamped,
+    live-read. NEVER raises."""
+    return env_num(REFILL_ENV, 1.0 / 300.0, 0.0, 10.0)
+
+
+def debounce_s() -> float:
+    """How long the same (endpoint, model) stays un-repeatable. Default 300s.
+
+    Guards the shape a miner scan actually produces: one cycle emits many
+    envelopes of the SAME strategy within seconds, and every one of them
+    predicts the same tier. Without this they would be N identical pre-warms,
+    of which the first is useful and the rest are pure probe traffic. NEVER
+    raises."""
+    return env_num(DEBOUNCE_ENV, 300.0, 0.0, 86_400.0)
+
+
+def wall_s() -> float:
+    """Hard ceiling on one pre-warm attempt, INCLUDING time spent waiting for
+    the swap mutex. Default 600s.
+
+    Required, not defensive: the mutex is fair to real dispatches, so under
+    sustained load an advisory waiter could sit behind them indefinitely. A
+    pre-warm that has been waiting ten minutes has already lost its reason to
+    exist -- the work it was predicting has long since dequeued. NEVER raises."""
+    return env_num(WALL_ENV, 600.0, 5.0, 3_600.0)
+
+
+class PrewarmDirector:
+    """Edge-triggered, non-blocking speculative residency.
+
+    Not a singleton by construction -- :func:`get_default_director` provides the
+    process-wide one and tests build their own.
+    """
+
+    def __init__(
+        self,
+        *,
+        gateway: "Optional[Any]" = None,
+        bucket: "Optional[TokenBucket]" = None,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._gateway = gateway
+        self._bucket = bucket or TokenBucket(bucket_capacity, bucket_refill_per_s)
+        #: (endpoint, model) -> monotonic time of the last ATTEMPT. Records the
+        #: attempt, not the success: a failed pre-warm that is immediately
+        #: retried is the failure mode debouncing exists to prevent.
+        self._last_attempt: Dict[str, float] = {}
+        #: Endpoints with a pre-warm in flight. Bounds concurrency to one swap
+        #: per device -- two speculative swaps racing on one GPU is strictly
+        #: worse than none.
+        self._in_flight: Set[str] = set()
+        #: Strong refs to scheduled tasks. asyncio only holds weak references,
+        #: so a fire-and-forget task can be garbage collected mid-await and
+        #: vanish without running.
+        self._tasks: Set["asyncio.Task"] = set()
+        self._stats: Dict[str, int] = {}
+
+    # -- resolution --------------------------------------------------------
+
+    def _get_gateway(self) -> "Optional[Any]":
+        """The gateway to warm against. Lazy so importing this module never
+        constructs one. NEVER raises."""
+        if self._gateway is not None:
+            return self._gateway
+        try:
+            from .inference_gateway import get_default_gateway  # noqa: PLC0415
+            return get_default_gateway()
+        except Exception:  # noqa: BLE001
+            return None
+
+    @staticmethod
+    def _predicted_model(urgency: str, complexity: str) -> str:
+        """The model the DISPATCHER would pick for this shape of work.
+
+        Delegates to ``failover_tier.resolve_tier`` rather than reimplementing
+        the urgency/complexity rules. That is not merely DRY: a private copy
+        could drift and start warming a model the dispatcher would never
+        request, which is worse than not warming at all -- it would evict the
+        right weights to install the wrong ones. NEVER raises."""
+        try:
+            from .failover_tier import resolve_tier  # noqa: PLC0415
+            tier = resolve_tier(urgency=urgency or "", complexity=complexity or "")
+            return (getattr(tier, "model_label", "") or "").strip()
+        except Exception:  # noqa: BLE001
+            return ""
+
+    def _resolve_target(self, model: str, route: Optional[str]) -> "Optional[Any]":
+        """A :class:`GatewayTarget` for *model* on the endpoint the gateway
+        would route to. Reuses ``target_for`` for endpoint + health resolution
+        and substitutes only the model, so a pre-warm can never aim at a host
+        the router considers unhealthy. NEVER raises."""
+        gw = self._get_gateway()
+        if gw is None:
+            return None
+        try:
+            import dataclasses  # noqa: PLC0415
+            base = gw.target_for(route=route)
+            if base is None:
+                return None
+            if not model or model == getattr(base, "model_name", None):
+                return base
+            return dataclasses.replace(base, model_name=model)
+        except Exception:  # noqa: BLE001
+            return None
+
+    # -- the emission seam -------------------------------------------------
+
+    def _bump(self, outcome: str) -> None:
+        try:
+            with self._lock:
+                self._stats[outcome] = self._stats.get(outcome, 0) + 1
+        except Exception:  # noqa: BLE001
+            pass
+
+    def hint(
+        self,
+        *,
+        urgency: str = "",
+        complexity: str = "",
+        route: Optional[str] = None,
+        source: str = "",
+    ) -> str:
+        """Signal that work of this shape has been ENQUEUED. NON-BLOCKING.
+
+        Returns a named outcome and NEVER raises, NEVER awaits and NEVER
+        performs I/O on the caller's stack. The caller is a sensor on the
+        intake hot path: it must be able to call this without knowing whether a
+        gateway, an event loop or a GPU exists.
+
+        Every refusal path is checked BEFORE a task is created, so the common
+        case (gate off, or throttled) allocates nothing."""
+        try:
+            if not prewarm_enabled():
+                return OUTCOME_DISABLED
+
+            # A loop is required to schedule onto. Sensors run under asyncio,
+            # but this may also be reached from a sync test or a worker thread,
+            # where the correct answer is to decline rather than to block.
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                self._bump(OUTCOME_NO_LOOP)
+                return OUTCOME_NO_LOOP
+
+            model = self._predicted_model(urgency, complexity)
+            if not model:
+                self._bump(OUTCOME_UNRESOLVED)
+                return OUTCOME_UNRESOLVED
+
+            target = self._resolve_target(model, route)
+            if target is None:
+                self._bump(OUTCOME_UNRESOLVED)
+                return OUTCOME_UNRESOLVED
+
+            endpoint = getattr(target, "base_url", "") or ""
+            key = endpoint + "|" + model
+            now = time.monotonic()
+
+            with self._lock:
+                if endpoint in self._in_flight:
+                    outcome = OUTCOME_SINGLE_FLIGHT
+                else:
+                    last = self._last_attempt.get(key)
+                    if last is not None and (now - last) < debounce_s():
+                        outcome = OUTCOME_DEBOUNCED
+                    else:
+                        outcome = ""
+            if outcome:
+                self._bump(outcome)
+                return outcome
+
+            # Throttle LAST among the cheap checks: a token spent on a hint that
+            # would have been debounced anyway is a token the next genuinely
+            # novel prediction does not get.
+            if not self._bucket.take():
+                self._bump(OUTCOME_THROTTLED)
+                return OUTCOME_THROTTLED
+
+            with self._lock:
+                self._last_attempt[key] = now
+                self._in_flight.add(endpoint)
+
+            task = loop.create_task(self._prewarm(target, endpoint, source))
+            self._tasks.add(task)
+            task.add_done_callback(self._tasks.discard)
+            self._bump(OUTCOME_SCHEDULED)
+            return OUTCOME_SCHEDULED
+        except Exception:  # noqa: BLE001 -- a hint must never break an emission
+            return OUTCOME_UNRESOLVED
+
+    async def _prewarm(self, target: "Any", endpoint: str, source: str) -> None:
+        """The background attempt. Owns its own wall and swallows everything.
+
+        Nothing awaits this and nothing consumes its result, so an exception
+        escaping here would surface only as an "exception was never retrieved"
+        warning at interpreter shutdown -- the least useful place to learn about
+        it. It is therefore logged where it happens and never propagated."""
+        gw = self._get_gateway()
+        try:
+            if gw is None:
+                return
+            started = time.monotonic()
+            report = await asyncio.wait_for(
+                gw.ensure_model_resident(target, advisory=True),
+                timeout=wall_s(),
+            )
+            elapsed = time.monotonic() - started
+            reason = (report or {}).get("reason", "")
+            if (report or {}).get("swapped"):
+                logger.info(
+                    "[PrewarmDirector] pre-warmed %s on %s in %.1fs "
+                    "(predicted from source=%s) — this transfer is no longer on "
+                    "the op's critical path",
+                    getattr(target, "model_name", "?"), endpoint, elapsed,
+                    source or "?",
+                )
+            else:
+                logger.debug(
+                    "[PrewarmDirector] no swap for %s on %s (%.1fs): %s",
+                    getattr(target, "model_name", "?"), endpoint, elapsed, reason,
+                )
+        except asyncio.TimeoutError:
+            # Expected under sustained load: the mutex is fair to real work.
+            logger.debug(
+                "[PrewarmDirector] pre-warm for %s abandoned at the %.0fs wall — "
+                "real dispatches held the device; the prediction has expired",
+                getattr(target, "model_name", "?"), wall_s(),
+            )
+        except asyncio.CancelledError:  # noqa: PERF203 -- shutdown, not an error
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "[PrewarmDirector] pre-warm degraded for %s: %s: %s",
+                getattr(target, "model_name", "?"), type(exc).__name__, exc,
+            )
+        finally:
+            try:
+                with self._lock:
+                    self._in_flight.discard(endpoint)
+            except Exception:  # noqa: BLE001
+                pass
+
+    # -- observability -----------------------------------------------------
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Counts per outcome + live state. Read-only. NEVER raises."""
+        try:
+            with self._lock:
+                return {
+                    "enabled": prewarm_enabled(),
+                    "outcomes": dict(self._stats),
+                    "in_flight": sorted(self._in_flight),
+                    "tracked_keys": len(self._last_attempt),
+                    "tokens": round(float(self._bucket.tokens), 3),
+                    "capacity": bucket_capacity(),
+                    "refill_per_s": bucket_refill_per_s(),
+                    "debounce_s": debounce_s(),
+                    "wall_s": wall_s(),
+                }
+        except Exception:  # noqa: BLE001
+            return {"enabled": False, "outcomes": {}}
+
+    async def aclose(self) -> None:
+        """Cancel any in-flight pre-warms. Used on shutdown so a speculative
+        swap cannot outlive the loop that owns it. NEVER raises."""
+        try:
+            tasks = list(self._tasks)
+            for t in tasks:
+                t.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+_DEFAULT: "Optional[PrewarmDirector]" = None
+_DEFAULT_LOCK = threading.Lock()
+
+
+def get_default_director() -> "PrewarmDirector":
+    """Process-wide director. NEVER raises."""
+    global _DEFAULT  # noqa: PLW0603
+    with _DEFAULT_LOCK:
+        if _DEFAULT is None:
+            _DEFAULT = PrewarmDirector()
+        return _DEFAULT
+
+
+def hint(
+    *,
+    urgency: str = "",
+    complexity: str = "",
+    route: Optional[str] = None,
+    source: str = "",
+) -> str:
+    """Module-level convenience over the default director. NON-BLOCKING,
+    NEVER raises. This is the ONE call a sensor needs to make."""
+    try:
+        return get_default_director().hint(
+            urgency=urgency, complexity=complexity, route=route, source=source)
+    except Exception:  # noqa: BLE001
+        return OUTCOME_UNRESOLVED
+
+
+def reset_for_tests() -> None:
+    """Drop the process-wide director. Tests only."""
+    global _DEFAULT  # noqa: PLW0603
+    with _DEFAULT_LOCK:
+        _DEFAULT = None


### PR DESCRIPTION
Runs the QUALITY-tier 32B locally on a consumer GPU, and stops the model-load
transfer from sitting on the critical path.

Measured on an RTX 5090 (32,607 MiB) serving Ollama on Windows, with O+V in WSL2.

## 1. The serving GPU is measured, not inferred

`_awakened_vram_bytes()` resolved through `_quality_tier().accelerator_type`,
whose default is `nvidia-l4`. On a workstation no controller tier is awake, so a
32 GiB card was sized as **24 GiB** — not a missing reading but a confidently
wrong one, silently halving the negotiator's derived window (16,896 vs 32,768
tokens).

- `failover_tier._GPU_VRAM_GIB` gains consumer/workstation rows plus a
  normalizer for `nvidia-smi` device names. Exact-match is tried first, so all
  11 pre-existing GCP types resolve byte-identically; normalization only ever
  rescues a string that would otherwise have returned 0.
- `_awakened_vram_bytes()` prefers a **measured** `compute_topology` reading,
  composing the existing probe rather than adding a second VRAM authority.

## 2. Context ceiling and KV cost are per-model

One global `JARVIS_NUM_CTX_CEILING` conflates two limits owned by different
authorities: what the *device* can hold, and what the *model was trained for*.

| model | native context | KV bytes/token |
|---|---|---|
| qwen2.5-coder:32b | 32,768 | 262,144 |
| qwen3-coder:30b | 262,144 | 98,304 |
| qwen2.5-coder:7b | 32,768 | 57,344 |

An 8x spread in context and 4.6x in KV cost. `model_physics.py` reads both from
the engine's own `/api/show` and takes the **stricter** of operator-configured
and model-native — a floor-of-two, so neither can raise the other upward.

**Load-bearing check:** the computed KV for the 32B is 262,144, byte-identical
to the constant hand-derived in `local_inference_director`. The formula
reproduces a known-correct value rather than merely resembling it.

`key_length`/`value_length` are preferred over deriving head_dim from
`embedding_length / head_count`, because that derivation is wrong for Qwen3
(2048/32 = 64, but head_dim is 128) and would understate KV by 2x. When the
fallback is used it is stamped in `source` rather than silently trusted.

## 3. Residency is serialized, and pre-warmed

`ensure_model_resident` was a check-then-act race: concurrent ops wanting
different models all read one snapshot, all see a mismatch, all call `warmup()`.
On a card that cannot hold both, the result is not a queued request but a
partial offload to system RAM — for both ops. On this device the numbers are not
hypothetical: 19.85 GB + 18.56 GB against a 34.2 GB card.

Adds a per-endpoint asyncio lock over the whole read-decide-mutate sequence,
capacity admission composing the existing GGUF estimator, and optional
down-routing so an eviction-averse route is served by the resident model.

Pre-warming then starts the ~20GB transfer at **enqueue** rather than dequeue,
overlapping the queue wait. Edge-triggered from the miner's ingest seam; no
timer, no polling. Composes `TokenBucket` from the sensors' own
`emission_control` and `resolve_tier` from `failover_tier`, so a pre-warm cannot
target a model the dispatcher would not have chosen.

**The mutex alone is not sufficient.** It is released the moment residency is
settled, which is *before* `_dispatch_to` begins streaming — so a pre-warm could
hold the lock legitimately and evict weights a live generation was mid-read. The
gateway now counts in-flight generations at that one seam, under `try/finally`
so a stall or cancellation cannot leak a host as busy, and an advisory swap
refuses while the count is non-zero. The count is re-read inside the lock and
after the residency probe awaits, because a dispatch can start during either
await. An unreadable count reads as BUSY: fail toward not-evicting.

## Gating

Every behaviour is behind a default-OFF master switch, so this merges
byte-identical:

- `JARVIS_LOCAL_VRAM_AUTODETECT_ENABLED`
- `JARVIS_MODEL_PHYSICS_AUTODETECT_ENABLED`
- `JARVIS_GATEWAY_VRAM_MUTEX_ENABLED`
- `JARVIS_PREWARM_ENABLED` (OFF creates no task at all)

## Verification

- **150/150** pass in the negotiator / gateway / compute-topology /
  device-affinity suites.
- **A/B against a stashed tree**: 41 failed / 179 passed *identically* with and
  without these changes across the targeted set. The failures are pre-existing
  in `test_opportunity_miner_auto_ack_lane.py` (references
  `_CycleCounters.auto_acked`, which does not exist in the source) and are
  untouched by this branch.
- Advisory pre-warm defers mid-stream with zero evictions and resumes once idle;
  9 concurrent callers (6 advisory + 3 real) collapse to 1 swap with zero
  exceptions; the in-flight counter survives a raising dispatch.
- Live: `qwen2.5-coder:32b` at num_ctx 32768 loads **100% GPU**, 29,447 /
  32,607 MiB, 39.6 tok/s.

Full-suite run not included: `tests/governance` + `tests/test_ouroboros_governance`
collect **47,433 items** and abort on 16 pre-existing collection errors unrelated
to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables running the 32B locally by measuring the serving GPU’s VRAM, making context/KV costs per model, and removing cold-loads from the critical path via serialized residency and predictive pre‑warm. Previously VRAM was inferred from a GCP spec, context/KV were global constants, and swaps raced; now VRAM is measured on host, ceilings/KV come from model metadata, swaps are serialized with capacity checks, and pre‑warm can start at enqueue.

- Adds consumer/workstation GPUs and name normalization to the VRAM ledger; `_awakened_vram_bytes()` prefers a measured `compute_topology` reading when `JARVIS_LOCAL_VRAM_AUTODETECT_ENABLED` is on; exact-match GCP types remain byte-identical.
- Makes the negotiator per-model aware: new `model_physics.py` reads `/api/show`, computes `kv_bytes_per_token`, and applies the stricter of operator ceiling and model native context; gated by `JARVIS_MODEL_PHYSICS_AUTODETECT_ENABLED` and falls back to legacy constants on miss.
- Serializes residency in `inference_gateway` with a per-endpoint asyncio mutex, adds an in-flight counter to prevent evicting weights in use, and introduces capacity admission and optional down‑routing (default `background`/`speculative`); gated by `JARVIS_GATEWAY_VRAM_MUTEX_ENABLED` and `JARVIS_GATEWAY_DOWNROUTE_ROUTES`.
- Adds predictive pre‑warm (`prewarm_director.py`) triggered from the miner on accepted work; advisory, queued behind the same mutex, and rate‑limited; gated by `JARVIS_PREWARM_ENABLED`.

**Rollout**
- Default is no behavior change. To opt in, enable flags as needed: `JARVIS_LOCAL_VRAM_AUTODETECT_ENABLED`, `JARVIS_MODEL_PHYSICS_AUTODETECT_ENABLED`, `JARVIS_GATEWAY_VRAM_MUTEX_ENABLED`, and `JARVIS_PREWARM_ENABLED`. Optionally tune `JARVIS_CTX_OVERHEAD_BYTES`, `JARVIS_KV_CACHE_DTYPE_BYTES`, and the `JARVIS_PREWARM_*` limits.

<sup>Written for commit 549de2b5c0058a67eac23e461de1a94128f291b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

