### PR TITLE
fix(tests): a zero-edit contract cannot be guarded by a census

### DIFF
--- a/tests/battle_test/test_termination_hook_registry_slice2.py
+++ b/tests/battle_test/test_termination_hook_registry_slice2.py
@@ -852,17 +852,49 @@ class TestDiscovery:
         assert discovered == 0
 
     def test_discover_skips_modules_without_register_function(self):
-        # Modules that don't expose register_termination_hooks
-        # are silently skipped — no error, no log noise that
-        # breaks anything. Slice 3 added 1 module that DOES
-        # expose it (the default-adapters); the rest of the
-        # battle_test + governance packages don't, and the
-        # discovery loop must skip them silently.
+        # The claim in the name is that a module WITHOUT
+        # `register_termination_hooks` contributes NOTHING — not that
+        # some exact number of modules have one.
+        #
+        # This asserted `discovered == 1`, a snapshot of how many
+        # providers existed when Slice 3 landed. So the second provider
+        # to ship anywhere under battle_test/ or governance/ turned this
+        # suite red for doing exactly what the discovery contract
+        # invites — co-locating hooks with the consuming code, "no edits
+        # to this module required". A count is the one thing a
+        # zero-edit contract guarantees will drift.
+        #
+        # That is the same shape `list_verbs()` was written to end: a
+        # hand-written number saying what exists while the code says
+        # something else. So pin the PREMISE, not the census.
         reg = TerminationHookRegistry()
         discovered = discover_module_provided_hooks(reg)
-        # Exactly the default-adapter module's 1 hook —
-        # no spurious registrations from non-provider modules.
-        assert discovered == 1
+
+        # 1. Discovery RAN, and found the providers that do exist.
+        assert discovered >= 1
+
+        # 2. Nothing spurious: every hook now in the registry was
+        #    contributed by a provider, and the walk's own count agrees
+        #    with what actually landed. A non-provider module that
+        #    somehow registered would break this equality.
+        landed = sum(
+            len(reg.for_phase(phase)) for phase in TerminationPhase
+        )
+        assert landed == discovered
+
+        # 3. The actual claim, isolated: point the walk at a package
+        #    tree with no providers in it and it contributes zero,
+        #    silently — no error, no partial registration.
+        import backend.core.ouroboros.battle_test.termination_hook_registry as _thr  # noqa: E501
+        empty = TerminationHookRegistry()
+        with mock.patch.object(
+            _thr, "_TERMINATION_HOOK_PROVIDER_PACKAGES",
+            ("backend.core.ouroboros.governance.meta",),
+        ):
+            assert discover_module_provided_hooks(empty) == 0
+        assert sum(
+            len(empty.for_phase(phase)) for phase in TerminationPhase
+        ) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #70544.

## What broke

`test_discover_skips_modules_without_register_function` asserted `discovered == 1` — a snapshot of how many modules exposed `register_termination_hooks` when Slice 3 landed.

But that discovery loop's contract is, in its own words:

> New modules expose a `register_termination_hooks` callable co-located with the consuming code — **no edits to this module required.**

So the *second* provider to ship anywhere under `battle_test/` or `governance/` turns the suite red for doing exactly what the contract invites. `side_channel.py` was that second provider.

A count is the one thing a zero-edit contract guarantees will drift. This is the same shape `list_verbs()` was written to end: a hand-written number saying what exists while the code says something else, with nothing comparing them.

## The fix

Pin the **premise** the test's own name states, not the census:

1. discovery **ran** and found the providers that exist (`>= 1`)
2. **nothing spurious** — the walk's count equals what actually landed in the registry, so a non-provider module that somehow registered still breaks this
3. **the actual claim, isolated** — point the walk at a package tree with no providers and it contributes zero, silently, with no partial registration

Assertion 3 is the one that carries the test's name, and it is the one the old version never made.

## How it got past me

The narrow suites I ran all went green. The broad `-k` sweeps over `tests/battle_test` + `tests/governance` that would have caught it were reaped mid-run and returned no summary — and I read "no output" as inconclusive without chasing it to a verdict before merging #70544. A census assertion sitting in a neighbouring file is exactly the thing narrow suites cannot see.

I also swept the other registries this class of change touches, since #70544 added 18 flags, 1 verb, and 6 shipped-code invariants:

| suite | result |
|---|---|
| help_dispatcher / flag_registry / verb (491 tests) | 490 pass, 1 pre-existing failure (`'budget'` external-verb leak, red before this work — confirmed by stashing) |
| shipped_code_invariants + isolation + module_discovery | 85 pass |
| termination_hook slices 1–4 + side_channel + btw_repl + grounding | **289 pass** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the termination hook discovery test to validate the zero-edit contract instead of a brittle census. Old behavior asserted discovered == 1; new behavior asserts discovery finds existing providers (>=1), matches the registry, and skips modules without `register_termination_hooks` by contributing zero.

- **Review notes**
  - Test-only change in `tests/battle_test/test_termination_hook_registry_slice2.py`; no runtime impact.
  - Adding new providers under `battle_test` or `governance` no longer breaks the suite; spurious registrations still fail via landed == discovered.
  - No migration required.

<sup>Written for commit 0eef7567249b981eb21794234774c9c694bf3b6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

