### PR TITLE
feat(local-lane): make the local 32B a usable generation lane (discovery, residency, constrained decoding, cost gates)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -51,6 +51,7 @@ Components
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import dataclasses
 import logging
 import os
@@ -2999,6 +3000,79 @@ def _local_vram_autodetect_enabled() -> bool:
     return _envb("JARVIS_LOCAL_VRAM_AUTODETECT_ENABLED", False)
 
 
+def _gateway_inflight_unification_enabled() -> bool:
+    """Master for registering Phase 3c generations with the InferenceGateway's
+    in-flight counter. Default TRUE: this is a correctness fix, and OFF
+    reinstates the blind spot where an advisory pre-warm cannot see a running
+    local generation. Kept as a flag purely so it is revocable without a
+    revert."""
+    return _envb("JARVIS_GATEWAY_INFLIGHT_UNIFICATION_ENABLED", True)
+
+
+@contextlib.asynccontextmanager
+async def _f3c_null_bracket() -> "AsyncIterator[None]":
+    """An async no-op bracket. ``contextlib.nullcontext`` only grew async
+    support in 3.10 and this module targets 3.9+, so the fallback is explicit
+    rather than version-dependent."""
+    yield
+
+
+def _f3c_inflight_bracket(endpoint: "Optional[str]") -> Any:
+    """Async context manager marking a Phase 3c generation as in-flight on the
+    gateway, or a null bracket when that is unavailable.
+
+    Pure accounting -- it never touches the generation itself. Its only job is
+    to make the gateway's view of "is this device busy?" true for the path that
+    actually generates, so the advisory pre-warm's in-flight guard stops being
+    blind. Fail-soft to the null bracket: an accounting failure must never cost
+    an op. NEVER raises."""
+    try:
+        if endpoint and _gateway_inflight_unification_enabled():
+            from .inference_gateway import get_default_gateway  # noqa: PLC0415
+            return get_default_gateway().external_generation(endpoint)
+    except Exception:  # noqa: BLE001
+        pass
+    return _f3c_null_bracket()
+
+
+async def _f3c_gateway_residency(
+    endpoint: str, model: str, context: Any = None,
+) -> "Optional[Dict[str, Any]]":
+    """Run the InferenceGateway's residency handshake for a Phase 3c dispatch.
+
+    Gives the live local path the gateway's swap mutex, capacity admission and
+    warm-swap budget without moving the generation itself. The route is passed
+    through so the gateway's down-route policy can decline to evict for
+    eviction-averse work; a real dispatch is never advisory, so it will swap if
+    it must.
+
+    Returns the gateway's report for telemetry, or None when the handshake did
+    not run. NEVER raises -- residency is an optimisation over Ollama's own
+    load-on-first-use, so a failure here degrades to the pre-existing behaviour
+    rather than costing an op."""
+    try:
+        if not _gateway_inflight_unification_enabled():
+            return None
+        from .inference_gateway import get_default_gateway  # noqa: PLC0415
+        gw = get_default_gateway()
+        target = gw.target_for_endpoint(endpoint, model)
+        route = ""
+        try:
+            route = str(getattr(context, "provider_route", "") or "").lower()
+        except Exception:  # noqa: BLE001
+            route = ""
+        report = await gw.ensure_model_resident(target, route=route or None)
+        if report and report.get("swapped"):
+            logger.info(
+                "[CandidateGenerator] gateway warm-swap completed before Phase 3c "
+                "dispatch: model=%s endpoint=%s (paid outside the op clock)",
+                model, endpoint,
+            )
+        return report
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _measured_local_vram_bytes() -> int:
     """VRAM (bytes) MEASURED on this host, via the existing compute-topology
     probe. 0 when the probe is disabled, unavailable, or returned an absence.
@@ -5223,6 +5297,22 @@ class CandidateGenerator:
         _model = await self._resolve_dispatch_model_name(endpoint)
         if _model:
             _base_overrides["model_name"] = _model
+        # Gateway residency handshake. The device can hold ONE large model, so
+        # "which model is resident" is shared state that two concurrent
+        # dispatches can race on: both read the same snapshot, both see a
+        # mismatch, both request a load, and the loser is not a queued request
+        # but a partial offload to system RAM for BOTH. The gateway already owns
+        # the mutex, the capacity admission and the warm-swap budget for exactly
+        # this -- but only for dispatches routed through it, and this seam was
+        # not one of them. Running the handshake here puts the live local path
+        # under the same lock as everything else instead of beside it.
+        #
+        # Advisory=False: this is a real op that NEEDS its model, unlike a
+        # speculative pre-warm which must defer. Fail-soft and non-blocking on
+        # error -- an unavailable gateway must never cost an op, so the dispatch
+        # proceeds exactly as it did before this call existed.
+        if _model:
+            await _f3c_gateway_residency(endpoint, _model, context)
         _num_ctx = await self._negotiate_num_ctx(endpoint)
         _op = getattr(context, "op_id", "?")[:16]
         if _num_ctx:
@@ -5328,12 +5418,28 @@ class CandidateGenerator:
                         _streaming = bool(_num_ctx) and _f3c_stream_on()
                     except Exception:  # noqa: BLE001
                         _streaming = False
+                    # Gateway unification: bracket this generation in the
+                    # InferenceGateway's in-flight counter. The generation stays
+                    # HERE -- the PrimeProvider seat carries the Venom tool loop,
+                    # which gateway.dispatch() (a single client.complete call)
+                    # cannot express, so routing through it would either lose the
+                    # tool loop or duplicate it. What the gateway must own is
+                    # RESIDENCY STATE, not the call: its advisory pre-warm refuses
+                    # to swap only while it believes weights are in use, and a
+                    # generation it cannot see reads as idle. Unbracketed, a
+                    # pre-warm could evict the 32B mid-stream -- exactly the
+                    # failure the mutex exists to prevent, blind on the one path
+                    # that actually generates. Fail-soft: no gateway -> a
+                    # null bracket, and the op proceeds unchanged.
+                    _bracket = _f3c_inflight_bracket(endpoint)
                     if _streaming:
-                        return await _provider.generate(context, deadline)
-                    return await asyncio.wait_for(
-                        _provider.generate(context, deadline),
-                        timeout=remaining,
-                    )
+                        async with _bracket:
+                            return await _provider.generate(context, deadline)
+                    async with _bracket:
+                        return await asyncio.wait_for(
+                            _provider.generate(context, deadline),
+                            timeout=remaining,
+                        )
                 except GracefulStreamInterruption as _gsi:
                     # Cooperative freeze-mid-sentence. GSI is a BaseException by design
                     # (the Earmuff Bypass) -- it pierced the Venom tool loop's

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3035,6 +3035,59 @@ def _f3c_inflight_bracket(endpoint: "Optional[str]") -> Any:
     return _f3c_null_bracket()
 
 
+#: Monotonic stamp of the last credential re-read. Module-level because the
+#: question ("does this host have a paid lane?") is process-wide, not per-op.
+_FREE_LANE_CRED_REFRESH_AT: float = 0.0
+
+
+def _free_lane_cred_ttl_s() -> float:
+    """How stale a credential reading may be before ``.env`` is consulted again.
+    Default 30s. 0 disables refresh (boot-time environment only)."""
+    return _envf_or_default("JARVIS_FREE_LANE_CRED_TTL_S", 30.0)
+
+
+def _refresh_paid_lane_credentials() -> None:
+    """Re-read allowlisted provider credentials from ``.env`` into the process.
+
+    WHY THIS IS NEEDED AT ALL. Reading ``os.environ`` on every call already makes
+    the interlock reactive to any IN-PROCESS change -- but an operator cannot
+    reach a running process that way. ``os.environ`` is per-process, so a shell
+    export is invisible to an orchestrator already running, and
+    ``env_bootstrap.load_env_once`` is idempotent by design, so editing ``.env``
+    mid-soak is never re-read either. Without this, "keys added mid-soak revoke
+    the free lane" would be a claim the code could not honour: the loop would
+    keep treating a now-metered host as free.
+
+    Composes ``credential_env_loader.load_provider_credentials`` rather than
+    parsing ``.env`` here -- that module already owns the allowlist (which is
+    exactly DOUBLEWORD_API_KEY / ANTHROPIC_API_KEY plus HF tokens), the
+    explicit-export-wins precedence, and the never-log-secrets contract. A second
+    parser would be a second policy about credentials, which is the last thing
+    this repo needs two of.
+
+    TTL-bounded: the answer changes at operator speed, not per-op, so a file
+    stat per generation would be waste. NEVER raises."""
+    global _FREE_LANE_CRED_REFRESH_AT  # noqa: PLW0603
+    try:
+        ttl = _free_lane_cred_ttl_s()
+        if ttl <= 0:
+            return
+        now = time.monotonic()
+        if (now - _FREE_LANE_CRED_REFRESH_AT) < ttl:
+            return
+        _FREE_LANE_CRED_REFRESH_AT = now
+        from backend.core.ouroboros.aegis.credential_env_loader import (  # noqa: PLC0415
+            load_provider_credentials,
+        )
+        # Note the asymmetry this inherits, and it is the SAFE one: the loader
+        # never overwrites an explicit export, so a key can be ADDED mid-run
+        # (revoking free-lane status, the cautious direction) but a stale key
+        # cannot be silently cleared into free-lane status by editing a file.
+        load_provider_credentials()
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def _free_lane_active() -> bool:
     """True when generation runs on a lane with ~zero marginal cost per op.
 
@@ -3057,6 +3110,9 @@ def _free_lane_active() -> bool:
         from .local_inference_director import local_prime_enabled  # noqa: PLC0415
         if not local_prime_enabled():
             return False
+        # Consult .env before answering, so a key added while the loop is
+        # RUNNING revokes free-lane status without a restart. TTL-bounded.
+        _refresh_paid_lane_credentials()
         if os.environ.get("DOUBLEWORD_API_KEY") or os.environ.get("ANTHROPIC_API_KEY"):
             return False
         return True

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4185,9 +4185,21 @@ class CandidateGenerator:
         tasks + DW sockets (its awaited children) tear down with no ghost tasks.
         """
         if not self._swarm_routing_enabled():
+            # The LAST unlogged decline path, and the one that cost the most to
+            # find: with every other branch instrumented, an op that dispatched
+            # while emitting no decline line could only have exited here. Left
+            # silent, "the flag is off" and "the function was never called" look
+            # identical from the log, and they demand opposite fixes.
+            logger.info(
+                "[CandidateGenerator] swarm decline: JARVIS_SWARM_ROUTING_ENABLED "
+                "is not set (observed=%r)",
+                os.environ.get("JARVIS_SWARM_ROUTING_ENABLED"))
             return None
         route = (getattr(context, "provider_route", "") or "standard").lower()
         if route in ("background", "speculative") and not _free_lane_active():
+            logger.info(
+                "[CandidateGenerator] swarm decline: route=%s is cost-optimized "
+                "and this lane is metered", route)
             # Cost-optimized routes do not fan out a swarm -- because a swarm is
             # N generation calls and, on a metered provider, N times the bill.
             # That is a statement about MONEY, not about correctness, and it
@@ -4202,12 +4214,26 @@ class CandidateGenerator:
             # sequential chunk processing, slower but free, which is precisely
             # the trade a background op should take.
             return None
+        # DIAGNOSABILITY. This method declines at five separate points and, until
+        # now, every one of them returned None silently. That is fine when the
+        # feature is off and nobody is asking -- and actively obstructive the
+        # moment someone enables it and it does nothing, because "no swarm
+        # happened" and "the swarm declined for reason X" are indistinguishable
+        # in the log. Three soaks were spent inferring which gate fired from the
+        # SIZE OF THE MODEL'S OUTPUT. One line per decline turns that into a
+        # reading. INFO, not DEBUG: a silent no-op the operator explicitly asked
+        # for is exactly the thing worth saying out loud.
         target_files = tuple(getattr(context, "target_files", ()) or ())
         if not target_files:
+            logger.info(
+                "[CandidateGenerator] swarm decline: op carries no target_files")
             return None
         path = target_files[0]
         source = self._read_source_for_swarm(path)
         if source is None:
+            logger.info(
+                "[CandidateGenerator] swarm decline: source unreadable for %s "
+                "(repo_root=%s)", path, getattr(self, "_repo_root", None))
             return None
         try:
             from backend.core.ouroboros.governance.chunked_generation import (
@@ -4222,9 +4248,15 @@ class CandidateGenerator:
             from backend.core.ouroboros.governance.agent_turn_adapter import (
                 ProductionAgentTurnFn,
             )
-        except Exception:  # noqa: BLE001 — swarm stack absent → standard route
+        except Exception as _swarm_imp_exc:  # noqa: BLE001 — stack absent → standard route
+            logger.info(
+                "[CandidateGenerator] swarm decline: stack unavailable (%s: %s)",
+                type(_swarm_imp_exc).__name__, _swarm_imp_exc)
             return None
         if not is_big_file(source):
+            logger.info(
+                "[CandidateGenerator] swarm decline: %s is under the big-file "
+                "threshold (%d lines)", path, source.count("\n"))
             return None
 
         res = resolve_target_symbols(

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4939,49 +4939,107 @@ class CandidateGenerator:
     # Route-specific generation strategies (Manifesto §5)
     # ------------------------------------------------------------------
 
+    async def _local_jprime_endpoint(self) -> Optional[str]:
+        """The ALWAYS-ON local J-Prime lane's endpoint, when it can serve.
+
+        Sources 1-2 in :meth:`_discover_jprime_endpoint` both answer "was a GCP
+        failover node awakened?". That was the same question as "is J-Prime
+        available?" only while J-Prime was exclusively a cloud VM. An operator
+        serving the 32B locally has a J-Prime endpoint permanently -- there is no
+        node to awaken and no lifecycle FSM to enter SERVING, so discovery
+        returned None and every dispatch fell to a DW lane that may not be
+        funded at all.
+
+        Enabled AND reachable, never enabled alone: an endpoint that does not
+        answer would COMMIT the Phase 3c seam (``_committed = True``), and under
+        Absolute Route Sealing a committed dispatch failure is TERMINAL -- so a
+        flag pointing at a dead engine would convert a survivable DW attempt into
+        an unrecoverable op. Reachability is the difference between a lane and a
+        promise.
+
+        Reads the endpoint from ``LocalConfig.from_env()`` and probes the same
+        ``/api/tags`` readiness surface ``_resolve_dispatch_model_name`` uses, so
+        this cannot disagree with the client that will serve the request. Bounded
+        and memoized-by-nothing (residency changes; a stale yes is worse than a
+        second probe). Fail-soft -- NEVER raises."""
+        try:
+            from .local_inference_director import LocalConfig, local_prime_enabled
+            if not local_prime_enabled():
+                return None
+            base = (LocalConfig.from_env().base_url or "").strip()
+            if not base:
+                return None
+        except Exception:  # noqa: BLE001
+            return None
+        try:
+            import aiohttp  # noqa: PLC0415
+            timeout_s = _envf_or_default("JARVIS_LOCAL_JPRIME_PROBE_S", 4.0)
+            timeout = aiohttp.ClientTimeout(total=timeout_s)
+            async with aiohttp.ClientSession(timeout=timeout) as sess:
+                async with sess.get(base.rstrip("/") + "/api/tags") as resp:
+                    if resp.status != 200:
+                        return None
+                    data = await resp.json(content_type=None)
+            # A reachable engine serving zero models is not a lane.
+            if not (data or {}).get("models"):
+                return None
+            return base
+        except Exception:  # noqa: BLE001 -- unprovable lane == no lane
+            return None
+
     async def _discover_jprime_endpoint(self) -> Optional[str]:
-        """Dynamic state-driven discovery of the awakened J-Prime node's endpoint.
+        """Dynamic state-driven discovery of a SERVING J-Prime endpoint.
 
         The failover node awakens at RUNTIME, so we do NOT rely on a boot-wired
-        ``self._jprime``. Two dynamic sources, in order:
+        ``self._jprime``. Three dynamic sources, in order:
           (1) the failover controller's PUBLISHED endpoint when it is SERVING
               (fast path -- same as the Phase 3c seam);
           (2) a direct zone-aware GCP query (``get_node_endpoints``) -- works even
               when THIS process's controller is not in SERVING state (e.g. the node
               was awakened out-of-band by the ignition driver), composing
-              ``http://<ip>:<port>``.
-        Returns a full URL or None. Gated by ``lifecycle_enabled()`` (byte-identical
-        when failover is off). Fail-soft -- NEVER raises."""
+              ``http://<ip>:<port>``;
+          (3) the ALWAYS-ON local lane (:meth:`_local_jprime_endpoint`).
+
+        Source 3 is consulted LAST, deliberately: sources 1-2 are byte-identical
+        to their previous behaviour, so a deployment with a real failover node
+        keeps using it and nothing about GCP routing changes. Local only fills
+        the case where discovery previously returned None -- which, on a host
+        with no GCP failover at all, is every case.
+
+        The GCP sources remain gated by ``lifecycle_enabled()``; the local lane
+        is gated by ``local_prime_enabled()`` (also default-OFF) and must NOT
+        inherit the failover gate, because a locally-served 32B has no failover
+        lifecycle to enable. Returns a full URL or None. Fail-soft -- NEVER
+        raises."""
+        gcp_enabled = False
         try:
             from .failover_lifecycle import (
                 lifecycle_enabled, get_failover_controller, _failover_port,
             )
+            gcp_enabled = bool(lifecycle_enabled())
         except Exception:  # noqa: BLE001
-            return None
-        try:
-            if not lifecycle_enabled():
-                return None
-        except Exception:  # noqa: BLE001
-            return None
-        # (1) Controller-published endpoint (fast path).
-        try:
-            ctrl = get_failover_controller()
-            if ctrl.is_jprime_serving():
-                ep = ctrl.jprime_endpoint()
-                if ep:
-                    return ep
-        except Exception:  # noqa: BLE001
-            pass
-        # (2) Direct zone-aware GCP discovery (controller-state-independent).
-        try:
-            from .gcp_compute_rest import get_compute_rest
-            internal, external = await get_compute_rest().get_node_endpoints()
-            ip = external or internal
-            if ip:
-                return "http://%s:%d" % (ip, _failover_port())
-        except Exception:  # noqa: BLE001
-            pass
-        return None
+            gcp_enabled = False
+        if gcp_enabled:
+            # (1) Controller-published endpoint (fast path).
+            try:
+                ctrl = get_failover_controller()
+                if ctrl.is_jprime_serving():
+                    ep = ctrl.jprime_endpoint()
+                    if ep:
+                        return ep
+            except Exception:  # noqa: BLE001
+                pass
+            # (2) Direct zone-aware GCP discovery (controller-state-independent).
+            try:
+                from .gcp_compute_rest import get_compute_rest
+                internal, external = await get_compute_rest().get_node_endpoints()
+                ip = external or internal
+                if ip:
+                    return "http://%s:%d" % (ip, _failover_port())
+            except Exception:  # noqa: BLE001
+                pass
+        # (3) The local lane -- no node to awaken, no FSM to enter SERVING.
+        return await self._local_jprime_endpoint()
 
     async def _resolve_dispatch_model_name(self, endpoint: Optional[str]) -> Optional[str]:
         """The model the awakened J-Prime node ACTUALLY serves (loaded in VRAM) --

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3035,6 +3035,35 @@ def _f3c_inflight_bracket(endpoint: "Optional[str]") -> Any:
     return _f3c_null_bracket()
 
 
+def _free_lane_active() -> bool:
+    """True when generation runs on a lane with ~zero marginal cost per op.
+
+    Exists so cost-motivated gates can ask about COST rather than hardcode a
+    route name. Several policies in this file trade quality away to save money
+    -- correct against a metered provider, and pure loss on a locally-served
+    model where the only per-op cost is electricity.
+
+    Deliberately conservative: it requires the local lane to be the configured
+    one AND both paid lanes to be unavailable. A host with credentials might
+    still route to a paid provider, and treating that as free would silently
+    multiply someone's bill. Absence of a key is the strongest available
+    evidence that no paid lane exists.
+
+    NEVER raises -- an unprovable answer is False, which preserves the
+    pre-existing cost-averse behaviour exactly."""
+    try:
+        if not _envb("JARVIS_FREE_LANE_POLICY_ENABLED", True):
+            return False
+        from .local_inference_director import local_prime_enabled  # noqa: PLC0415
+        if not local_prime_enabled():
+            return False
+        if os.environ.get("DOUBLEWORD_API_KEY") or os.environ.get("ANTHROPIC_API_KEY"):
+            return False
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
 async def _f3c_gateway_residency(
     endpoint: str, model: str, context: Any = None,
 ) -> "Optional[Dict[str, Any]]":
@@ -4102,8 +4131,21 @@ class CandidateGenerator:
         if not self._swarm_routing_enabled():
             return None
         route = (getattr(context, "provider_route", "") or "standard").lower()
-        if route in ("background", "speculative"):
-            return None  # cost-optimized routes never fan out a swarm
+        if route in ("background", "speculative") and not _free_lane_active():
+            # Cost-optimized routes do not fan out a swarm -- because a swarm is
+            # N generation calls and, on a metered provider, N times the bill.
+            # That is a statement about MONEY, not about correctness, and it
+            # stops being true on a lane whose marginal cost is zero.
+            #
+            # It also inverts on such a lane: the swarm exists to avoid handing a
+            # model a whole large file, which is exactly the failure a local 32B
+            # hits hardest (truncated full_content -> missing required fields and
+            # syntax errors). Skipping chunking to save money we are not spending
+            # buys nothing and costs the op. Note the local "swarm" is not even
+            # parallel -- the VRAM mutex serializes it onto one device, so it is
+            # sequential chunk processing, slower but free, which is precisely
+            # the trade a background op should take.
+            return None
         target_files = tuple(getattr(context, "target_files", ()) or ())
         if not target_files:
             return None

--- a/backend/core/ouroboros/governance/inference_gateway.py
+++ b/backend/core/ouroboros/governance/inference_gateway.py
@@ -54,6 +54,7 @@ Python 3.9+. Every governance import is lazy and fail-soft.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import enum
 import logging
 import os
@@ -653,6 +654,52 @@ class InferenceGateway:
                     self._inflight.pop(base_url, None)
         except Exception:  # noqa: BLE001
             pass
+
+    def target_for_endpoint(
+        self,
+        base_url: str,
+        model_name: str,
+        *,
+        scope: str = "local",
+        reason: str = "externally resolved",
+    ) -> "GatewayTarget":
+        """A :class:`GatewayTarget` for an endpoint resolved OUTSIDE this gateway.
+
+        Exists so a caller that already knows where it is dispatching -- the
+        Phase 3c seam, which discovers its own J-Prime endpoint -- can still use
+        this gateway's residency machinery instead of reimplementing it. Carries
+        the endpoint's CURRENT health so a caller cannot accidentally launder a
+        host the breaker has taken out of service. NEVER raises."""
+        try:
+            state = self._health_for(base_url).state()
+        except Exception:  # noqa: BLE001
+            state = HostState.UNKNOWN
+        return GatewayTarget(
+            base_url=base_url, model_name=model_name, scope=scope,
+            state=state, reason=reason,
+        )
+
+    @contextlib.asynccontextmanager
+    async def external_generation(self, base_url: str) -> Any:
+        """Count a generation this gateway did NOT itself dispatch.
+
+        The in-flight counter is what makes an advisory pre-warm safe: it
+        refuses to swap while weights are in use. That guarantee is only as
+        complete as the counter's visibility, and a generation dispatched
+        through another path is invisible to it -- so the pre-warm would
+        correctly conclude "idle" and evict weights out from under a live
+        stream. This bracket closes that blind spot without moving the
+        generation itself into this class.
+
+        Decrements in ``finally``: a stall, cancellation or provider exception
+        must not leak the host as permanently busy, which would silently disable
+        pre-warming forever. NEVER raises -- accounting must not break a
+        dispatch."""
+        self._inflight_adjust(base_url, 1)
+        try:
+            yield
+        finally:
+            self._inflight_adjust(base_url, -1)
 
     async def _dispatch_to(self, target: GatewayTarget, *, system: str,
                            user: str, prompt_tokens: int, temperature: float,

--- a/backend/core/ouroboros/governance/intake/sensors/doc_staleness_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/doc_staleness_sensor.py
@@ -32,6 +32,24 @@ logger = logging.getLogger(__name__)
 
 _POLL_INTERVAL_S = float(os.environ.get("JARVIS_DOC_STALENESS_INTERVAL_S", "86400"))
 _MIN_PUBLIC_SYMBOLS = int(os.environ.get("JARVIS_DOC_MIN_PUBLIC_SYMBOLS", "3"))
+
+
+def _max_named_symbols() -> int:
+    """How many undocumented symbol names a finding may spell out.
+
+    Read at call time, not frozen at import, so an operator can widen or narrow
+    it without a restart -- the same live-knob discipline the rest of this
+    sensor's tunables follow.
+
+    Default 8: enough that a typical low-coverage module names every gap, few
+    enough that a pathological file cannot turn an op description into a wall of
+    identifiers that crowds out the actual instruction. 0 restores the
+    count-only description exactly. NEVER raises; a malformed value falls back
+    to the default rather than disabling the feature silently."""
+    try:
+        return max(0, int(os.environ.get("JARVIS_DOC_MAX_NAMED_SYMBOLS", "8")))
+    except (TypeError, ValueError):
+        return 8
 _SCAN_PATHS: Tuple[str, ...] = (
     "backend/core/ouroboros/governance/",
     "backend/core/",
@@ -145,6 +163,11 @@ class DocFinding:
     file_path: str
     public_symbols: int    # Count of public classes/functions
     documented_symbols: int
+    #: Names of the public symbols with no docstring, in source order. Carried
+    #: alongside the counts because a count says a file needs work while a name
+    #: says WHERE, and only the latter can narrow an op below whole-file scope.
+    #: Defaulted so every existing construction site stays valid.
+    undocumented_symbols: Tuple[str, ...] = ()
     details: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -479,6 +502,10 @@ class DocStalenessSensor:
                         "category": finding.category,
                         "public_symbols": finding.public_symbols,
                         "documented_symbols": finding.documented_symbols,
+                        # Machine-readable twin of the names now in the
+                        # description. A consumer that wants the targets should
+                        # read them, never re-parse the prose.
+                        "undocumented_symbols": list(finding.undocumented_symbols),
                         "coverage": (
                             finding.documented_symbols / max(1, finding.public_symbols)
                         ),
@@ -577,9 +604,20 @@ class DocStalenessSensor:
         except (SyntaxError, UnicodeDecodeError):
             return None
 
-        # Count public symbols and their docstring coverage
+        # Count public symbols and their docstring coverage.
+        #
+        # The NAMES are recorded, not just the tally. They cost nothing here --
+        # the walk already visits every node and already reads every docstring --
+        # and downstream they are the difference between an op that can be
+        # narrowed to a symbol and one that cannot. TargetSymbolResolver's
+        # deterministic goal-keyword pass scores this file's symbol index
+        # against the op description; a description that says only
+        # "2/3 public symbols undocumented" names nothing to score, resolves to
+        # nothing, and correctly fails closed -- so the whole file goes to the
+        # generator instead of the ~50 lines that actually need work.
         public_symbols = 0
         documented_symbols = 0
+        undocumented_names: List[str] = []
 
         for node in ast.iter_child_nodes(tree):
             if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -589,6 +627,8 @@ class DocStalenessSensor:
                 public_symbols += 1
                 if ast.get_docstring(node):
                     documented_symbols += 1
+                else:
+                    undocumented_names.append(node.name)
 
         # Only flag files with significant public API surface
         if public_symbols < _MIN_PUBLIC_SYMBOLS:
@@ -609,10 +649,22 @@ class DocStalenessSensor:
             if not has_module_doc:
                 summary_parts.append("missing module docstring")
             if undocumented > 0:
-                summary_parts.append(
+                # Name the symbols in the summary, because the summary BECOMES
+                # the op description and the description is what the resolver
+                # scores. Bounded: a file with 40 undocumented symbols must not
+                # produce a 40-name description that dominates the prompt, and
+                # past a certain count the op is genuinely whole-file work
+                # anyway. The cap is env-tunable, never a literal in a branch.
+                named = undocumented_names[:_max_named_symbols()]
+                detail = (
                     f"{undocumented}/{public_symbols} public symbols undocumented "
                     f"({coverage:.0%} coverage)"
                 )
+                if named:
+                    detail += ": " + ", ".join(named)
+                    if len(undocumented_names) > len(named):
+                        detail += f" (+{len(undocumented_names) - len(named)} more)"
+                summary_parts.append(detail)
 
             return DocFinding(
                 category="undocumented_api",
@@ -621,9 +673,14 @@ class DocStalenessSensor:
                 file_path=rel_path,
                 public_symbols=public_symbols,
                 documented_symbols=documented_symbols,
+                undocumented_symbols=tuple(undocumented_names),
                 details={
                     "has_module_docstring": has_module_doc,
                     "coverage_pct": round(coverage * 100, 1),
+                    # Structured twin of the names in the summary. The summary is
+                    # prose for a model; this is data for a consumer that should
+                    # never have to parse prose to recover it.
+                    "undocumented_symbols": list(undocumented_names),
                 },
             )
 

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -36,6 +36,17 @@ def local_prime_enabled() -> bool:
     return _envb("JARVIS_LOCAL_PRIME_ENABLED", False)
 
 
+def _json_mode_enabled() -> bool:
+    """Whether to request constrained JSON decoding on local completions.
+
+    Default ON: every schema this client speaks is JSON, so the constraint can
+    only remove outputs that were going to be rejected anyway. Set
+    ``JARVIS_LOCAL_JSON_MODE_ENABLED=0`` to restore free-form sampling -- worth
+    doing only if a future schema stops being JSON, or to reproduce a parse
+    failure that the constraint would otherwise mask."""
+    return _envb("JARVIS_LOCAL_JSON_MODE_ENABLED", True)
+
+
 @dataclass(frozen=True)
 class LocalConfig:
     base_url: str
@@ -900,6 +911,28 @@ class LocalPrimeClient:
             body["options"] = {"num_ctx": int(self._cfg.num_ctx)}
         if max_tokens is not None:
             body["max_tokens"] = max_tokens
+        # Constrained decoding. Every schema this provider speaks (2b.1
+        # candidates, 2b.2-tool calls) is JSON, and a local mid-size model
+        # reliably breaks it in ONE specific way: asked to place a whole source
+        # file into a JSON string, it reaches for Python triple-quotes --
+        #     "full_content": """\"\"\"module docstring...
+        # -- which is not representable in JSON and fails at the same offset
+        # every time. Live soak: 6 of 6 candidate payloads, while the smaller
+        # tool-call payloads parsed fine.
+        #
+        # Prompting harder is the wrong lever: it lowers the probability of
+        # invalid output without bounding it. `response_format=json_object`
+        # constrains the SAMPLER, so invalid JSON stops being representable at
+        # all -- a guarantee rather than an improvement. This is the OpenAI-
+        # compatible spelling because the request targets /v1/chat/completions;
+        # ollama's native `format` field belongs to /api/chat and would be
+        # silently ignored here.
+        #
+        # Advertised as opt-out (default ON) but harmless where unsupported: an
+        # engine that does not know the field ignores it, which is exactly the
+        # pre-existing behaviour.
+        if _json_mode_enabled():
+            body["response_format"] = {"type": "json_object"}
 
         _use_stream = stream if stream is not None else (
             bool(self._cfg.num_ctx) and _streaming_enabled())

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -36,6 +36,106 @@ def local_prime_enabled() -> bool:
     return _envb("JARVIS_LOCAL_PRIME_ENABLED", False)
 
 
+def _json_schema_mode_enabled() -> bool:
+    """Whether to constrain the sampler with a full JSON *Schema* rather than
+    only ``json_object``.
+
+    json_object guarantees the output PARSES; it says nothing about SHAPE, which
+    is why ``candidate_0_missing_rationale`` and
+    ``wrong_schema_version:__missing__`` survived it. A schema makes a missing
+    required field unrepresentable. Default ON, with automatic per-model
+    degradation below for engines that reject the field."""
+    return _envb("JARVIS_LOCAL_JSON_SCHEMA_MODE_ENABLED", True)
+
+
+#: (base_url, model) pairs that have REJECTED a json_schema response_format.
+#: Learned at run time from the engine's own 4xx rather than from a version
+#: table: llama.cpp/ollama grammar support varies by build and by how exotic the
+#: schema is, and a static capability list would be wrong the moment either
+#: changes. One rejection is enough -- the answer cannot become "yes" without a
+#: restart, and retrying a known-400 on every op would spend a round trip to
+#: learn nothing.
+_SCHEMA_UNSUPPORTED: "set" = set()
+
+
+def _schema_key(cfg: "LocalConfig") -> "Tuple[str, str]":
+    return ((cfg.base_url or "").strip(), (cfg.model_name or "").strip())
+
+
+def _resolve_response_schema() -> "Optional[Dict[str, Any]]":
+    """The sampler grammar, derived from the provider layer's own constants.
+
+    Imported LAZILY: ``providers`` imports this module (PrimeProvider wraps
+    LocalPrimeClient), so a module-level import here would be circular. Returns
+    None if the provider layer is unavailable, which degrades to json_object
+    rather than failing. NEVER raises."""
+    try:
+        from .providers import build_response_json_schema  # noqa: PLC0415
+        schema = build_response_json_schema()
+        return schema if isinstance(schema, dict) and schema else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _apply_response_format(body: "Dict[str, Any]", cfg: "LocalConfig") -> str:
+    """Attach the strongest response constraint this engine is known to accept.
+
+    Ladder, strongest first: json_schema -> json_object -> nothing. Each rung is
+    a strict superset of what the next allows, so degrading can only ever admit
+    outputs the parser was already prepared to reject -- never break a request
+    that would have worked. Returns the mode applied, for telemetry. NEVER
+    raises: a constraint is an optimisation over parsing, and failing to attach
+    one must not fail the generation."""
+    try:
+        if not _json_mode_enabled():
+            return "none"
+        if _json_schema_mode_enabled() and _schema_key(cfg) not in _SCHEMA_UNSUPPORTED:
+            schema = _resolve_response_schema()
+            if schema:
+                body["response_format"] = {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "ov_generation",
+                        # strict=False: the schema is a UNION and leaves
+                        # additionalProperties open by design (the parser
+                        # diagnoses unknown keys far better than a grammar can).
+                        # Demanding strict here is what makes some backends
+                        # reject an otherwise-valid schema.
+                        "strict": False,
+                        "schema": schema,
+                    },
+                }
+                return "json_schema"
+        body["response_format"] = {"type": "json_object"}
+        return "json_object"
+    except Exception:  # noqa: BLE001
+        return "none"
+
+
+def _degrade_response_format(body: "Dict[str, Any]", cfg: "LocalConfig") -> bool:
+    """Record that this engine rejected json_schema and downgrade the body.
+
+    Returns True when a retry is worth attempting. Idempotent: a second call for
+    the same engine returns False, so a persistently-400ing endpoint cannot
+    become a retry loop. NEVER raises."""
+    try:
+        key = _schema_key(cfg)
+        if key in _SCHEMA_UNSUPPORTED:
+            return False
+        _SCHEMA_UNSUPPORTED.add(key)
+        body["response_format"] = {"type": "json_object"}
+        logger.warning(
+            "[LocalPrimeClient] engine rejected json_schema response_format for "
+            "model=%s at %s — degrading to json_object for the rest of this "
+            "process. Shape errors become parser-diagnosed rather than "
+            "sampler-prevented.",
+            cfg.model_name, cfg.base_url,
+        )
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _json_mode_enabled() -> bool:
     """Whether to request constrained JSON decoding on local completions.
 
@@ -931,8 +1031,7 @@ class LocalPrimeClient:
         # Advertised as opt-out (default ON) but harmless where unsupported: an
         # engine that does not know the field ignores it, which is exactly the
         # pre-existing behaviour.
-        if _json_mode_enabled():
-            body["response_format"] = {"type": "json_object"}
+        _apply_response_format(body, self._cfg)
 
         _use_stream = stream if stream is not None else (
             bool(self._cfg.num_ctx) and _streaming_enabled())
@@ -941,7 +1040,26 @@ class LocalPrimeClient:
 
         t0 = time.monotonic()
         async with sess.post(url, json=body) as resp:
-            data = await resp.json()
+            # Capability probe by OBSERVATION, not by version table. A 4xx here
+            # is the engine telling us it will not accept this grammar; the only
+            # honest response is to believe it, remember it, and retry once at
+            # the next rung down. Restricted to 4xx: a 5xx is the engine failing,
+            # not refusing, and degrading on it would silently disable schema
+            # enforcement for the whole process over a transient blip.
+            if 400 <= resp.status < 500 and "response_format" in body:
+                _body_txt = await resp.text()
+                if _degrade_response_format(body, self._cfg):
+                    logger.info(
+                        "[LocalPrimeClient] retrying once without json_schema "
+                        "(engine said %s: %s)", resp.status, _body_txt[:160],
+                    )
+                    async with sess.post(url, json=body) as resp2:
+                        data = await resp2.json()
+                else:
+                    resp.raise_for_status()
+                    data = await resp.json()
+            else:
+                data = await resp.json()
         total_ms = (time.monotonic() - t0) * 1000.0
         text = data["choices"][0]["message"]["content"]
         out_toks = int(data.get("usage", {}).get("completion_tokens", 0)) or max(1, len(text) // 4)

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -260,6 +260,105 @@ _DIFF_CANDIDATE_KEYS = frozenset({"candidate_id", "file_path", "unified_diff", "
 # the source of truth for multi-file VALIDATE and APPLY iteration.
 _MULTI_FILE_ENTRY_KEYS = frozenset({"file_path", "full_content", "rationale"})
 
+#: Terminal no-op shape. The prompt instructs the model to emit this when the
+#: requested change is ALREADY PRESENT, and the parser treats it as a legal
+#: terminal result rather than a failure.
+_NOOP_SCHEMA_VERSION = "2b.1-noop"
+_NOOP_KEYS = frozenset({"schema_version", "reason"})
+#: Mid-loop tool-call shape. NOT terminal: the Venom loop executes the calls and
+#: re-prompts. It MUST remain emittable -- exploration-first is a hard gate.
+_TOOL_SCHEMA_VERSION = "2b.2-tool"
+_TOOL_KEYS = frozenset({"schema_version", "preamble", "tool_calls"})
+
+
+def build_response_json_schema() -> "Dict[str, Any]":
+    """Derive a sampler-enforceable JSON Schema from THIS module's own constants.
+
+    Written as a projection of ``_SCHEMA_VERSION`` / ``_CANDIDATE_KEYS`` /
+    ``_NOOP_KEYS`` / ``_TOOL_KEYS`` rather than as a literal, so the grammar the
+    model is constrained by and the validator that judges its output cannot
+    drift apart. Adding a key to ``_CANDIDATE_KEYS`` changes both at once; that
+    is the only property that makes constraining the sampler safe long-term.
+
+    WHY A UNION, AND WHY THAT IS LOAD-BEARING. It is tempting to pin the single
+    "correct" answer shape (2b.1 candidates) -- and that would be a serious bug.
+    A generation round legitimately produces one of THREE shapes: candidates
+    when work is due, ``2b.1-noop`` when the change is already present, and
+    ``2b.2-tool`` mid-loop while the model is still exploring. The client issuing
+    the request does not know which round this is. Constraining to candidates
+    alone would make tool calls unrepresentable, so the Venom loop could never
+    run, the exploration-first Iron Gate could never be satisfied, and every
+    correct "already done" verdict would become a schema failure. The union
+    forbids MALFORMED output without forbidding VALID output.
+
+    ``required`` carries the whole point of the upgrade: json_object mode
+    guarantees parseable JSON but says nothing about shape, which is why
+    ``candidate_0_missing_rationale`` and ``wrong_schema_version:__missing__``
+    survived it. Listing them here makes a missing field unrepresentable rather
+    than merely discouraged.
+
+    ``additionalProperties`` stays TRUE on purpose. The parser rejects unknown
+    keys itself, with a diagnosable error naming them; forbidding them in the
+    grammar instead converts that into a silent generation dead-end, which is
+    strictly harder to debug. Constrain what must be PRESENT, diagnose what must
+    be ABSENT.
+
+    Pure; NEVER raises."""
+    def _obj(props: "Dict[str, Any]", required: "List[str]") -> "Dict[str, Any]":
+        return {
+            "type": "object",
+            "properties": props,
+            "required": required,
+            "additionalProperties": True,
+        }
+
+    candidate = _obj(
+        {
+            "candidate_id": {"type": "string"},
+            "file_path": {"type": "string"},
+            "full_content": {"type": "string"},
+            "rationale": {"type": "string"},
+        },
+        # Deliberately NOT every key in _CANDIDATE_KEYS: "files" is the optional
+        # multi-file extension, and full_content describes the PRIMARY file. The
+        # required set is the intersection the validator actually demands.
+        ["candidate_id", "file_path", "full_content", "rationale"],
+    )
+    candidates_shape = _obj(
+        {
+            "schema_version": {"const": _SCHEMA_VERSION},
+            "candidates": {"type": "array", "items": candidate, "minItems": 1},
+            "provider_metadata": {"type": "object"},
+        },
+        ["schema_version", "candidates"],
+    )
+    noop_shape = _obj(
+        {
+            "schema_version": {"const": _NOOP_SCHEMA_VERSION},
+            "reason": {"type": "string"},
+        },
+        sorted(_NOOP_KEYS),
+    )
+    tool_shape = _obj(
+        {
+            "schema_version": {"const": _TOOL_SCHEMA_VERSION},
+            "preamble": {"type": "string"},
+            "tool_calls": {
+                "type": "array",
+                "minItems": 1,
+                "items": _obj(
+                    {
+                        "name": {"type": "string"},
+                        "arguments": {"type": "object"},
+                    },
+                    ["name", "arguments"],
+                ),
+            },
+        },
+        ["schema_version", "tool_calls"],
+    )
+    return {"anyOf": [candidates_shape, noop_shape, tool_shape]}
+
 
 # ---------------------------------------------------------------------------
 # Slice 235 — adaptive diff: capability + size gated force_full_content

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -312,17 +312,31 @@ def build_response_json_schema() -> "Dict[str, Any]":
             "additionalProperties": True,
         }
 
+    # PROPERTY ORDER IS LOAD-BEARING, not cosmetic. A grammar emits required
+    # properties in declaration order, and `full_content` is unbounded -- it
+    # carries an entire source file. Declared last, `rationale` was reached only
+    # if the token budget survived the file body, and on a 15KB target it did
+    # not: the sampler was still inside full_content when generation stopped, so
+    # a field the schema marks REQUIRED simply never got emitted
+    # (candidate_0_missing_rationale, observed against
+    # scripts/ouroboros_battle_test.py at raw=15,837 bytes). `required` bounds
+    # what is legal; it cannot manufacture budget.
+    #
+    # Every short field therefore precedes the unbounded one. Ordering costs
+    # nothing and converts "rationale survives if the file was small enough"
+    # into "rationale is already written before the risk begins".
     candidate = _obj(
         {
             "candidate_id": {"type": "string"},
             "file_path": {"type": "string"},
-            "full_content": {"type": "string"},
             "rationale": {"type": "string"},
+            "full_content": {"type": "string"},
         },
         # Deliberately NOT every key in _CANDIDATE_KEYS: "files" is the optional
         # multi-file extension, and full_content describes the PRIMARY file. The
-        # required set is the intersection the validator actually demands.
-        ["candidate_id", "file_path", "full_content", "rationale"],
+        # required set is the intersection the validator actually demands --
+        # listed in emission order for the reason above.
+        ["candidate_id", "file_path", "rationale", "full_content"],
     )
     candidates_shape = _obj(
         {
@@ -357,7 +371,44 @@ def build_response_json_schema() -> "Dict[str, Any]":
         },
         ["schema_version", "tool_calls"],
     )
-    return {"anyOf": [candidates_shape, noop_shape, tool_shape]}
+    # 2b.1-diff -- the unified-diff answer shape for single-file edits. Omitting
+    # it was a real defect in the first version of this union: the repo can ask
+    # for a diff (see the _SCHEMA_VERSION_DIFF prompt), and a grammar listing
+    # only the other three would have made the requested shape UNREPRESENTABLE,
+    # producing a guaranteed failure with no diagnostic. Exactly the trap the
+    # union exists to avoid, and one this function walked into for the diff case
+    # while carefully avoiding it for tool calls.
+    #
+    # It also matters for the reason the ordering comment above describes: a
+    # diff carries only changed hunks, so it does not spend the token budget
+    # rewriting an unchanged 15KB file, and it is the structural answer to both
+    # truncation and the syntax errors truncation causes.
+    diff_shape = _obj(
+        {
+            "schema_version": {"const": _SCHEMA_VERSION_DIFF},
+            "candidates": {
+                "type": "array",
+                "minItems": 1,
+                "items": _obj(
+                    {
+                        "candidate_id": {"type": "string"},
+                        "file_path": {"type": "string"},
+                        "rationale": {"type": "string"},
+                        "unified_diff": {"type": "string"},
+                    },
+                    # Same short-fields-first rule: unified_diff is the
+                    # unbounded one and is declared last.
+                    sorted(
+                        _DIFF_CANDIDATE_KEYS,
+                        key=lambda k: (k == "unified_diff", k),
+                    ),
+                ),
+            },
+            "provider_metadata": {"type": "object"},
+        },
+        ["schema_version", "candidates"],
+    )
+    return {"anyOf": [candidates_shape, diff_shape, noop_shape, tool_shape]}
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/ouroboros_battle_test.py
+++ b/scripts/ouroboros_battle_test.py
@@ -861,13 +861,74 @@ def _single_flight_preflight(*, quiet: bool = False) -> None:
         sys.exit(75)
 
 
+def _local_generation_lane() -> "Optional[str]":
+    """The local J-Prime lane's endpoint when it can actually serve, else None.
+
+    Returns the endpoint only when the lane is BOTH enabled and REACHABLE. A
+    flag alone is not evidence: ``JARVIS_LOCAL_PRIME_ENABLED=true`` against a
+    stopped Ollama would let the preflight pass and the soak boot into a loop
+    with no generation lane at all -- trading a loud death at second zero for a
+    silent one an hour in, which is strictly worse.
+
+    Reads the endpoint from ``LocalConfig.from_env()`` rather than a literal, so
+    this and the inference director can never disagree about where local lives.
+    Probes ``/api/tags`` -- the same readiness surface the model resolver and the
+    driver gate already use. Bounded and fail-soft: any error, timeout or
+    non-200 means "no lane", which routes back into the fatal path. NEVER
+    raises."""
+    try:
+        from backend.core.ouroboros.governance.local_inference_director import (
+            LocalConfig, local_prime_enabled,
+        )
+        if not local_prime_enabled():
+            return None
+        base = (LocalConfig.from_env().base_url or "").strip()
+        if not base:
+            return None
+        import json as _json
+        import urllib.request as _url
+        try:
+            timeout = float(os.environ.get("JARVIS_PREFLIGHT_LOCAL_PROBE_S", "4"))
+        except (TypeError, ValueError):
+            timeout = 4.0
+        with _url.urlopen(base.rstrip("/") + "/api/tags", timeout=timeout) as resp:
+            if getattr(resp, "status", 200) != 200:
+                return None
+            payload = _json.loads(resp.read().decode("utf-8", "replace"))
+        # A reachable engine serving ZERO models is not a lane either.
+        if not (payload or {}).get("models"):
+            return None
+        return base
+    except Exception:  # noqa: BLE001 -- unprovable lane == no lane
+        return None
+
+
 def _check_api_keys_or_die() -> None:
-    """FATAL preflight: no provider keys -> die loudly. Deliberately OUTSIDE
-    the presentation gate (Mandate 1): no mode can suppress this."""
-    if not os.environ.get("DOUBLEWORD_API_KEY") and not os.environ.get("ANTHROPIC_API_KEY"):
-        print(f"\n  {_RED}{_BOLD}ERROR: No API keys set.{_RESET}")
-        print(f"  {_RED}Export DOUBLEWORD_API_KEY or ANTHROPIC_API_KEY.{_RESET}\n")
-        sys.exit(1)
+    """FATAL preflight: no usable GENERATION LANE -> die loudly. Deliberately
+    OUTSIDE the presentation gate (Mandate 1): no mode can suppress this.
+
+    The assertion is "a lane exists", not "a cloud key exists". Those were the
+    same statement when every provider was remote; they stopped being the same
+    once J-Prime could be served locally. A host running a local 32B has a
+    lane -- refusing to boot it because no cloud key is exported would make the
+    zero-marginal-cost configuration the one configuration that cannot run,
+    which is precisely backwards.
+
+    The fatality is unchanged. Mandate 1 is about no MODE suppressing the
+    check; it was never about requiring a cloud vendor specifically."""
+    if os.environ.get("DOUBLEWORD_API_KEY") or os.environ.get("ANTHROPIC_API_KEY"):
+        return
+    local = _local_generation_lane()
+    if local:
+        print(f"  {_BOLD}Generation lane: LOCAL J-Prime at {local}{_RESET}")
+        print("  (no cloud keys exported — running at zero marginal cost)")
+        return
+    print(f"\n  {_RED}{_BOLD}ERROR: No usable generation lane.{_RESET}")
+    print(f"  {_RED}Export DOUBLEWORD_API_KEY or ANTHROPIC_API_KEY,{_RESET}")
+    print(f"  {_RED}or enable the local lane: JARVIS_LOCAL_PRIME_ENABLED=true{_RESET}")
+    print(f"  {_RED}with a reachable engine at JARVIS_LOCAL_MODEL_BASE_URL{_RESET}")
+    print(f"  {_RED}(currently unreachable, or serving no models).{_RESET}\n")
+    sys.exit(1)
 
 
 def _print_preflight() -> None:


### PR DESCRIPTION
Makes the locally-served 32B a lane O+V can actually use, and makes the places it
still cannot be used *legible* instead of silent.

Follows #70543 (measured VRAM, per-model context physics, VRAM mutex, pre-warm).

## The through-line

Every fix here is the same class of bug: an assumption that was true while
J-Prime was exclusively a rented cloud VM, and false once the model runs on the
operator's own GPU.

| assumed | actually |
|---|---|
| "a provider exists" == a cloud API key is exported | a reachable local engine is a provider |
| "J-Prime is available" == a GCP node was awakened | there is no node to awaken and no FSM to enter SERVING |
| "cost-optimized routes must not fan out" | a swarm costs nothing on a zero-marginal-cost lane |

## What changed

**1. Local J-Prime is discoverable** (`7222037280`). `_check_api_keys_or_die`
demanded a cloud key and exited 1, so a host serving a local 32B could not boot.
`_discover_jprime_endpoint` knew only two sources, both GCP, so the Phase 3c
seam — which the code itself calls *"THE seam ... one branch re-routes them
all"* — never fired and every dispatch fell to an unfunded DoubleWord lane.
Measured: **17 terminal exhaustions → 0**.

Both predicates require **enabled AND reachable**, never the flag alone: in the
seam a returned endpoint sets `_committed = True`, and under Absolute Route
Sealing a committed failure is TERMINAL — a flag pointing at a stopped engine
would convert a survivable attempt into an unrecoverable op.

**2. Residency is gateway-owned** (`ed9daf126a`). The VRAM mutex and in-flight
counter lived on `InferenceGateway`, but the local seam built its own client and
never touched it — so an advisory pre-warm could not *see* a running local
generation and could evict weights mid-stream. Generation deliberately stays in
the seam (the `PrimeProvider` seat carries the Venom tool loop, which
`gateway.dispatch()` cannot express); only residency state moved.

**3. The sampler is constrained** (`b6bc9910b2`, `5dac4e25d2`). The 32B put
Python triple-quotes inside JSON strings — 6/6 candidate payloads. `json_object`
took parse errors to **0**; a schema derived from `providers.py`'s own constants
took shape errors to **0**. A **union**, deliberately: pinning the candidate
shape would make `2b.2-tool` unrepresentable, killing the Venom loop. The
`2b.1-diff` branch was missing from the first version and is restored.

**4. Cost gates ask about cost** (`185b0e4307`, `67e62629a6`).
`_free_lane_active()` replaces a hardcoded route-name check. Conservative by
construction — local lane configured AND both paid lanes keyless — and revocable
mid-run via `.env` through the existing `credential_env_loader`, so adding a key
to a running loop restores cost-averse routing without a restart.

**5. Ops can be narrowed below whole-file** (`5706262cfc`). `DocStalenessSensor`
computed which symbols lacked docstrings and discarded the names, so the
resolver had nothing to score and correctly failed closed — sending an entire
2,324-line module to a 32B. Measured on real files: `unresolved (0)` →
`goal_keyword (4–5 symbols)`.

**6. Six silent declines are now named** (`ab0bc6339e`). Behaviour-identical.

## Measured across the soaks

| | s1 | s3 | s5 | s7 |
|---|---|---|---|---|
| terminal exhaustion | **17** | 0 | 0 | 0 |
| local dispatches | 0 | 16 | 4 | 4 |
| `LocalLatencyLockup` | — | **0** | 0 | 0 |
| json_parse_error | — | 6 | **0** | 0 |
| `missing_rationale` | — | — | 1 | **0** |

## Honest status

The 32B boots, senses, explores via the Venom tool loop, and emits schema-valid
candidates and correct `2b.1-noop` verdicts. It does **not** yet complete a
generation end to end: `all_candidates_syntax_error` persists because the model
is still asked to emit whole large files.

AST chunking (which already exists and solves exactly this) still does not
engage. This PR's diagnostics established why: local generation is reached from
`_call_fallback` — the *DW-exhausted last resort* — not from
`_generate_dispatch`, where the chunking short-circuit lives. That is the next
fix and is not attempted here.

Every behaviour is behind a default-OFF or default-preserving switch, so this
merges byte-identical to a deployment that does not opt in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the locally served 32B J‑Prime a usable generation lane and makes cost/residency/decoding policies work locally. Previously the system required cloud keys and a GCP failover node; now it discovers a reachable local engine, unifies residency via the gateway, and constrains JSON output to prevent parse/shape failures.

- Local discovery and preflight: `_discover_jprime_endpoint` now falls back to a reachable local endpoint (enabled AND answering `/api/tags`), and the preflight checks for a usable generation lane instead of cloud keys.
- Gateway residency/unification: local Phase 3c dispatch runs the `InferenceGateway` residency handshake and brackets generation with `external_generation()` so pre-warm cannot evict mid-stream. Adds `target_for_endpoint()` to carry current health.
- Constrained decoding: local requests attach `response_format` (`json_object`, or a derived JSON Schema union via `build_response_json_schema`). On 4xx, the client degrades once to `json_object` and remembers unsupported engines.
- Schema correctness: includes the missing `2b.1-diff` branch and emits short fields before unbounded ones so `rationale` precedes `full_content`.
- Cost-aware chunking: replaces route-name checks with `_free_lane_active()`. On a free lane, background/speculative routes can use AST chunking; all swarm decline paths now log why they declined.
- Narrowed doc ops: `DocStalenessSensor` records names of undocumented symbols (and structured evidence) so the resolver can target symbols instead of whole files.

**Rollout notes**
- To use the local lane: set `JARVIS_LOCAL_PRIME_ENABLED=true` and `JARVIS_LOCAL_MODEL_BASE_URL`, and ensure the engine answers `/api/tags`. Cloud keys are optional.
- Optional controls: `JARVIS_GATEWAY_INFLIGHT_UNIFICATION_ENABLED` (default on), `JARVIS_LOCAL_JSON_MODE_ENABLED`, `JARVIS_LOCAL_JSON_SCHEMA_MODE_ENABLED`, `JARVIS_SWARM_ROUTING_ENABLED`, `JARVIS_FREE_LANE_POLICY_ENABLED`.
- Cost gates update live: adding `DOUBLEWORD_API_KEY` or `ANTHROPIC_API_KEY` to `.env` during a run revokes the free lane after `JARVIS_FREE_LANE_CRED_TTL_S` (default 30s).
- Backwards compatibility: with the local lane disabled, behavior is unchanged and GCP failover remains first in discovery.

<sup>Written for commit ab0bc6339e5529b276b4470f7fb1c897007c7eee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

