### PR TITLE
feat(worktree): an on-disk liveness lock makes cross-process workspace destruction impossible

### DIFF
--- a/backend/core/ouroboros/governance/worktree_manager.py
+++ b/backend/core/ouroboros/governance/worktree_manager.py
@@ -20,9 +20,11 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import logging
 import os
 import shutil
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -183,6 +185,153 @@ def _resolve_reap_prefixes(primary: str) -> "tuple[str, ...]":
     return tuple(out)
 
 
+# ---------------------------------------------------------------------------
+# Workspace liveness lock
+# ---------------------------------------------------------------------------
+#
+# Answers ONE question for the reaper: "is a live process using this tree?"
+#
+# Placed under `.jarvis/` rather than at the worktree root because `.jarvis/`
+# is already gitignored — a lock file at the root would show as untracked in
+# every `git status` run inside the worktree, and a workspace that reports
+# itself dirty is a workspace whose APPLY/rollback gates start lying.
+#
+# Why not reuse the Ledger-Sovereignty ownership marker, which already carries
+# creator_pid and created_at: `ledger_sovereignty.master_enabled()` defaults to
+# FALSE (§33.1), so that marker is absent in a default configuration. Whether
+# one session may delete another's live workspace cannot be contingent on an
+# unrelated feature flag. Both are consulted when reaping (see `_live_owner`);
+# only this one is guaranteed to exist.
+_WORKSPACE_LOCK_RELATIVE = (".jarvis", ".workspace_lock")
+_WORKSPACE_LOCK_SCHEMA = "workspace_lock.1"
+
+
+def workspace_lock_path(wt_path: "Path") -> "Path":
+    """Absolute path of the liveness lock for *wt_path*."""
+    return Path(wt_path, *_WORKSPACE_LOCK_RELATIVE)
+
+
+def _process_start_time(pid: int) -> Optional[float]:
+    """Process start time, or None when it cannot be established.
+
+    This is what makes the PID check trustworthy. A bare `os.kill(pid, 0)`
+    cannot distinguish "my session is alive" from "my session died and the
+    OS handed that number to something unrelated" — and on a long-lived host
+    reaping on a reused PID would skip real debris forever, while reaping on
+    a stale one destroys live work. Comparing start times settles it.
+    """
+    try:
+        import psutil  # noqa: PLC0415 — optional; absent → no reuse check
+        return float(psutil.Process(pid).create_time())
+    except Exception:  # noqa: BLE001 — psutil missing, or process gone
+        return None
+
+
+def _write_workspace_lock(wt_path: "Path", branch_name: str) -> bool:
+    """Atomically stamp the liveness lock. NEVER raises.
+
+    Atomic because the reaper may read it at any moment, including while it
+    is being written: a torn read must be impossible, so the payload is
+    written to a temp sibling, fsynced, then `os.replace`d into place —
+    rename within a directory is atomic on POSIX and on NTFS.
+
+    Returns True on success. A False here is not fatal: a missing lock means
+    "unprovable", and the reaper treats unprovable as reapable, which is the
+    pre-existing behaviour.
+    """
+    lock = workspace_lock_path(wt_path)
+    pid = os.getpid()
+    payload = {
+        "schema_version": _WORKSPACE_LOCK_SCHEMA,
+        "pid": pid,
+        # Wall-clock, for humans reading the file and for age heuristics.
+        "created_at": time.time(),
+        # The PID-reuse discriminator. None when psutil is unavailable —
+        # the reader degrades to a plain liveness probe rather than failing.
+        "proc_start": _process_start_time(pid),
+        "session_id": os.environ.get("JARVIS_OUROBOROS_SESSION_ID", ""),
+        "branch_name": branch_name,
+    }
+    tmp = lock.with_name(lock.name + f".{pid}.tmp")
+    try:
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, lock)
+        return True
+    except Exception as exc:  # noqa: BLE001 — a lock is best-effort
+        logger.debug(
+            "WorktreeManager: workspace lock write failed for %s: %r",
+            wt_path, exc,
+        )
+        try:
+            if tmp.exists():
+                tmp.unlink()
+        except OSError:
+            pass
+        return False
+
+
+def read_workspace_lock(wt_path: "Path") -> Optional[dict]:
+    """Read the liveness lock, or None when absent/unreadable. NEVER raises."""
+    try:
+        raw = workspace_lock_path(wt_path).read_text(encoding="utf-8")
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else None
+    except Exception:  # noqa: BLE001 — absent / torn / malformed → unprovable
+        return None
+
+
+def _pid_is_live(pid: object, proc_start: object = None) -> bool:
+    """True ONLY on positive proof that *pid* is a live process.
+
+    ``proc_start`` (when both recorded and observable) must match, so a
+    recycled PID reads as dead rather than as a live owner.
+
+    Every uncertainty resolves to False — "not provably alive". That polarity
+    is deliberate and is the OPPOSITE of the one
+    :meth:`reap_dangling_auto_branches` uses. There, an auto branch may hold
+    real unpushed work, so the default is "don't touch unless proven dead".
+    Here the caller is a debris sweeper whose whole purpose is reclaiming
+    disk (Slice 44: 62 checkouts, 492k files, 13GB); defaulting to "don't
+    touch" would silently restore that problem. So: reap unless proven alive.
+    """
+    try:
+        pid_i = int(pid)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return False
+    if pid_i <= 0:
+        return False
+    # No short-circuit for our OWN pid. It is trivially live, but "the lock
+    # names my pid" and "the lock was written by me" are different claims —
+    # a dead session whose number the OS later handed to this process would
+    # satisfy the first and not the second. The start-time comparison below
+    # is what separates them, so our own pid goes through it like any other.
+    try:
+        os.kill(pid_i, 0)
+    except ProcessLookupError:
+        return False           # proven gone
+    except PermissionError:
+        pass                   # exists, owned by another user → alive
+    except Exception:  # noqa: BLE001 — OverflowError on an out-of-range pid,
+        # OSError on an unprobeable one. Anything that is not a clean "yes"
+        # is "not provably alive", which keeps debris reapable.
+        return False
+    if proc_start is None:
+        return True            # alive; reuse undetectable, accept
+    observed = _process_start_time(pid_i)
+    if observed is None:
+        return True            # alive; cannot compare → accept
+    try:
+        # 1s tolerance: create_time() resolution differs across platforms
+        # and a clock adjustment must not read as a reused PID.
+        return abs(float(observed) - float(proc_start)) <= 1.0
+    except (TypeError, ValueError):
+        return True
+
+
 class WorktreeManager:
     """Manages git worktree creation and cleanup for subagent isolation.
 
@@ -306,6 +455,15 @@ class WorktreeManager:
         # raises — mark_owned itself returns None on I/O failure
         # and the downstream assertion surfaces the missing marker.
         self._stamp_ownership_marker(wt_path, branch_name)
+
+        # Liveness lock — stamped UNCONDITIONALLY, unlike the sovereignty
+        # marker above. That marker carries the same facts (creator_pid,
+        # created_at) and would have been the DRY answer, except
+        # `master_enabled()` defaults to FALSE (§33.1), so in a default
+        # configuration it is never written. Whether one session may destroy
+        # another's workspace must not depend on an unrelated feature flag
+        # being switched on, so this one has no master.
+        _write_workspace_lock(wt_path, branch_name)
 
         logger.info("WorktreeManager: created worktree at %s", wt_path)
         return wt_path
@@ -569,6 +727,46 @@ class WorktreeManager:
             except Exception:  # noqa: BLE001 — protection is best-effort, never fatal
                 pass
 
+        def _locked_by_live_process(path: Optional[Path]) -> Optional[str]:
+            """Reason string when a LIVE process holds this tree, else None.
+
+            Two independent sources, because neither alone is sufficient:
+
+              * the workspace lock (`.jarvis/.workspace_lock`) — stamped
+                unconditionally at materialization, so it is the one that
+                exists in a default configuration;
+              * the Ledger-Sovereignty ownership marker — richer, but absent
+                unless `master_enabled()` (default FALSE).
+
+            This is what makes cross-process destruction structurally
+            impossible: the env-derived protection above only knows about the
+            workspace THIS process armed, so a second worker's tree was still
+            fair game. A lock on disk is visible to every reaper.
+            """
+            if path is None:
+                return None
+            lock = read_workspace_lock(path)
+            if lock and _pid_is_live(lock.get("pid"), lock.get("proc_start")):
+                return (
+                    f"workspace lock held by live pid={lock.get('pid')} "
+                    f"session={lock.get('session_id') or '?'}"
+                )
+            try:
+                from backend.core.ouroboros.governance.ledger_sovereignty import (
+                    read_ownership,  # noqa: PLC0415 — optional, master-gated
+                )
+                record = read_ownership(path)
+            except Exception:  # noqa: BLE001 — absent marker → unprovable
+                record = None
+            if record is not None and _pid_is_live(
+                getattr(record, "creator_pid", 0), None,
+            ):
+                return (
+                    f"sovereignty marker held by live pid="
+                    f"{getattr(record, 'creator_pid', '?')}"
+                )
+            return None
+
         def _is_protected(path: Optional[Path], branch: str = "") -> bool:
             """True when this path/branch belongs to the LIVE session."""
             if branch and branch in protected_branches:
@@ -576,9 +774,25 @@ class WorktreeManager:
             if path is None:
                 return False
             try:
-                return str(path.resolve()) in protected_paths
+                if str(path.resolve()) in protected_paths:
+                    return True
             except OSError:
-                return str(path) in protected_paths
+                if str(path) in protected_paths:
+                    return True
+            held = _locked_by_live_process(path)
+            if held:
+                # Remember it so the branch sweep (loop 3) cannot delete the
+                # ref out from under a tree we just refused to remove.
+                lock = read_workspace_lock(path)
+                _b = (lock or {}).get("branch_name") or branch
+                if _b:
+                    protected_branches.add(str(_b))
+                logger.info(
+                    "WorktreeManager.reap_orphans: SKIPPING %s — %s",
+                    path, held,
+                )
+                return True
+            return False
 
         porcelain = await self._run_git_capture(["worktree", "list", "--porcelain"])
         for entry in _parse_worktree_porcelain(porcelain):

--- a/tests/governance/test_autonomous_workspace.py
+++ b/tests/governance/test_autonomous_workspace.py
@@ -120,7 +120,18 @@ async def test_on_and_autonomous_routes_to_worktree(tmp_path, monkeypatch):
     assert out.is_dir()
     # Same naming as the Ledger Sovereignty phase → one unified worktree,
     # swept by the existing ouroboros/auto/* reaper.
-    assert mgr.created == ["ouroboros/auto/bt-xyz"]
+    #
+    # Asserted against `workspace_branch` rather than a literal. The literal
+    # was `"ouroboros/auto/bt-xyz"`, which stopped being the name when a
+    # per-boot cryptographic nonce was added to make collisions provably
+    # impossible across crashed runs — so the test had been failing on a
+    # naming change it was never really about. Deriving the expectation from
+    # the same function production calls means the next naming change cannot
+    # break it either.
+    assert mgr.created == [aw.workspace_branch("bt-xyz")]
+    assert mgr.created[0].startswith("ouroboros/auto/bt-xyz-"), (
+        "must stay under the prefix the ouroboros/auto/* reaper sweeps"
+    )
 
 
 async def test_autonomous_route_unifies_commit_workspace_env(

--- a/tests/governance/test_ledger_sovereignty_wiring.py
+++ b/tests/governance/test_ledger_sovereignty_wiring.py
@@ -189,9 +189,42 @@ class TestAutoCommitterEffectiveRoot:
     ):
         override = tmp_path / "alt-workspace"
         override.mkdir()
+        # The `.git` marker is what makes this a WORK-AREA rather than a
+        # directory that happens to exist. Without it `effective_execution_root`
+        # raises `ExecutionRootInvalid` — correctly, and this test was failing
+        # on exactly that. It is the fourth fixture in this repo to model a
+        # worktree as a bare `mkdir()`, and that shared blind spot is why the
+        # husk defect shipped: production armed marker-only directories because
+        # every test said a marker-only directory was fine. A linked worktree's
+        # `.git` is a FILE pointing at the parent repo.
+        (override / ".git").write_text(
+            "gitdir: /repo/.git/worktrees/alt-workspace\n"
+        )
         monkeypatch.setenv(_WORKSPACE_FLAG, str(override))
         ac = AutoCommitter(repo_root=tmp_path / "primary")
         assert ac._effective_repo_root() == override
+
+    def test_env_override_at_a_husk_is_refused_not_honoured(
+        self, tmp_path, monkeypatch,
+    ):
+        """An armed path with no `.git` must fail LOUD, not resolve.
+
+        The read side is deliberately strict — it is the last thing standing
+        between a half-created workspace and an APPLY that writes into it.
+        This pins that strictness so a future fixture cannot quietly relax it.
+        """
+        from backend.core.ouroboros.governance.autonomous_workspace import (
+            ExecutionRootInvalid,
+        )
+
+        husk = tmp_path / "husk-workspace"
+        husk.mkdir()
+        (husk / ".jarvis").mkdir()  # marker only — the observed shape
+        monkeypatch.setenv(_WORKSPACE_FLAG, str(husk))
+        ac = AutoCommitter(repo_root=tmp_path / "primary")
+
+        with pytest.raises(ExecutionRootInvalid):
+            ac._effective_repo_root()
 
 
 class TestAutoCommitterSovereigntyAssertion:

--- a/tests/governance/test_worktree_isolation.py
+++ b/tests/governance/test_worktree_isolation.py
@@ -33,6 +33,53 @@ async def _init_git_repo(path: Path) -> None:
 # Tests
 # ---------------------------------------------------------------------------
 
+
+def _orphan(*worktrees: Path) -> None:
+    """Mark worktrees as debris left by a process that no longer exists.
+
+    `reap_orphans` reaps what SIGKILL / OOM / power-loss left behind — by
+    definition the creating process is gone. Tests build their fixtures
+    in-process, so without this the workspace lock records a LIVE pid (ours)
+    and the reaper correctly refuses to touch them.
+
+    That refusal is not a test artifact to work around: it is the production
+    behaviour being protected. `resolve_loop_project_root` and the boot reaper
+    really do run in the same process, which is precisely how the live
+    workspace got eaten (bt-2026-08-28-065825). A test that creates a worktree
+    and immediately calls it an orphan was only ever passing because nothing
+    checked liveness.
+
+    A crashed session leaves its lock behind holding a STALE pid, so that is
+    what is simulated — not a deleted lock, which would test a different case.
+    """
+    import json
+    import subprocess
+
+    from backend.core.ouroboros.governance.worktree_manager import (
+        workspace_lock_path,
+    )
+
+    # A genuinely dead pid: spawn a trivial child, reap it, reuse its number.
+    proc = subprocess.Popen(["/bin/sh", "-c", "exit 0"])
+    proc.wait()
+    dead_pid = proc.pid
+
+    for wt in worktrees:
+        lock = workspace_lock_path(wt)
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.write_text(
+            json.dumps({
+                "schema_version": "workspace_lock.1",
+                "pid": dead_pid,
+                "created_at": 0.0,
+                "proc_start": None,
+                "session_id": "bt-dead-session",
+                "branch_name": "",
+            }),
+            encoding="utf-8",
+        )
+
+
 @pytest.mark.asyncio
 async def test_create_and_cleanup(tmp_path: Path) -> None:
     """create() produces a worktree directory; cleanup() removes it."""
@@ -145,6 +192,7 @@ async def test_reap_orphans_removes_registered_unit_worktree(tmp_path: Path) -> 
     mgr = WorktreeManager(repo_root=repo_root)
     wt_path = await mgr.create("unit-abc-graph-xyz")
     assert wt_path.exists()
+    _orphan(wt_path)
 
     pre_branches = await _list_branches(repo_root)
     assert "unit-abc-graph-xyz" in pre_branches
@@ -191,6 +239,7 @@ async def test_reap_orphans_preserves_non_unit_worktrees(tmp_path: Path) -> None
     mgr = WorktreeManager(repo_root=repo_root)
     user_wt = await mgr.create("feature-do-not-touch")
     unit_wt = await mgr.create("unit-xyz-graph-1")
+    _orphan(user_wt, unit_wt)
 
     reaped = await mgr.reap_orphans()
     assert reaped == 1
@@ -233,7 +282,7 @@ async def test_reap_orphans_idempotent(tmp_path: Path) -> None:
     await _init_git_repo(repo_root)
 
     mgr = WorktreeManager(repo_root=repo_root)
-    await mgr.create("unit-first")
+    _orphan(await mgr.create("unit-first"))
 
     first = await mgr.reap_orphans()
     second = await mgr.reap_orphans()
@@ -274,6 +323,7 @@ async def test_reap_orphans_never_eats_the_live_session_workspace(
     mgr = WorktreeManager(repo_root=repo_root)
     live = await mgr.create("ouroboros/auto/bt-live-session-aaa111")
     stale = await mgr.create("ouroboros/auto/bt-dead-session-bbb222")
+    _orphan(stale)
 
     # Exactly how the live workspace announces itself in production.
     monkeypatch.setenv("JARVIS_AUTO_COMMIT_WORKSPACE", str(live))
@@ -342,8 +392,151 @@ async def test_unset_env_reaps_everything_as_before(tmp_path: Path, monkeypatch)
     mgr = WorktreeManager(repo_root=repo_root)
     a = await mgr.create("ouroboros/auto/bt-old-1")
     b = await mgr.create("ouroboros/auto/bt-old-2")
+    _orphan(a, b)
 
     reaped = await mgr.reap_orphans()
 
     assert reaped == 2
     assert not a.exists() and not b.exists()
+
+
+# ===========================================================================
+# Workspace liveness lock — cross-process protection
+# ===========================================================================
+#
+# The env-derived guard protects only the workspace THIS process armed, so a
+# second worker's tree was still fair game. The lock is on disk, so every
+# reaper in every process can see it.
+
+
+@pytest.mark.asyncio
+async def test_create_writes_an_atomic_liveness_lock(tmp_path: Path) -> None:
+    """Materialization stamps pid + start timestamp, unconditionally.
+
+    Unconditionally is the point: the Ledger-Sovereignty ownership marker
+    carries the same facts but `master_enabled()` defaults FALSE, so it is
+    absent in a default configuration. Reaping safety cannot depend on an
+    unrelated feature flag.
+    """
+    import json
+
+    from backend.core.ouroboros.governance.worktree_manager import (
+        workspace_lock_path,
+    )
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    await _init_git_repo(repo_root)
+
+    mgr = WorktreeManager(repo_root=repo_root)
+    wt = await mgr.create("unit-lock-shape")
+
+    lock = workspace_lock_path(wt)
+    assert lock.exists(), "create() must stamp a liveness lock"
+    payload = json.loads(lock.read_text(encoding="utf-8"))
+    import os as _os
+    assert payload["pid"] == _os.getpid()
+    assert payload["created_at"] > 0
+    assert "proc_start" in payload
+    # No partial writes left behind by the atomic replace.
+    assert not list(lock.parent.glob(".workspace_lock.*.tmp"))
+
+
+@pytest.mark.asyncio
+async def test_live_lock_survives_reaping_by_another_manager(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """A tree locked by a LIVE process is untouchable, env or no env.
+
+    This is the multi-process race: worker A materializes a workspace, worker
+    B boots and sweeps. B has never heard of A's env vars — the lock is the
+    only thing that can stop it.
+    """
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    await _init_git_repo(repo_root)
+    # Deliberately unset: prove the protection comes from the LOCK, not from
+    # the environment guard.
+    monkeypatch.delenv("JARVIS_AUTO_COMMIT_WORKSPACE", raising=False)
+    monkeypatch.delenv("JARVIS_OUROBOROS_SESSION_ID", raising=False)
+
+    worker_a = WorktreeManager(repo_root=repo_root)
+    live = await worker_a.create("unit-worker-a-live")
+    dead = await worker_a.create("unit-worker-b-dead")
+    _orphan(dead)  # only this one's owner has exited
+
+    worker_b = WorktreeManager(repo_root=repo_root)
+    reaped = await worker_b.reap_orphans()
+
+    assert live.exists(), "a live process's workspace was destroyed"
+    assert not dead.exists(), "genuine debris must still be reaped"
+    assert reaped == 1
+
+
+@pytest.mark.asyncio
+async def test_recycled_pid_does_not_read_as_a_live_owner(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """A stale lock whose pid was reused must not protect forever.
+
+    `os.kill(pid, 0)` alone cannot tell "my session is alive" from "my session
+    died and the OS handed that number to something else". On a long-lived
+    host that would make debris permanently unreapable. The recorded start
+    time settles it.
+    """
+    import json
+    import os as _os
+
+    from backend.core.ouroboros.governance.worktree_manager import (
+        workspace_lock_path,
+    )
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    await _init_git_repo(repo_root)
+    monkeypatch.delenv("JARVIS_AUTO_COMMIT_WORKSPACE", raising=False)
+
+    mgr = WorktreeManager(repo_root=repo_root)
+    wt = await mgr.create("unit-recycled-pid")
+
+    # Our pid IS alive — but the lock claims it started at a different time,
+    # which is exactly what a recycled pid looks like.
+    lock = workspace_lock_path(wt)
+    payload = json.loads(lock.read_text(encoding="utf-8"))
+    if payload.get("proc_start") is None:
+        pytest.skip("psutil unavailable — reuse detection is not active here")
+    payload["proc_start"] = float(payload["proc_start"]) - 9999.0
+    lock.write_text(json.dumps(payload), encoding="utf-8")
+    assert payload["pid"] == _os.getpid()
+
+    reaped = await mgr.reap_orphans()
+
+    assert reaped == 1, "a recycled pid must not protect stale debris"
+    assert not wt.exists()
+
+
+@pytest.mark.asyncio
+async def test_unreadable_lock_is_treated_as_reapable(tmp_path: Path, monkeypatch) -> None:
+    """A torn or malformed lock means 'unprovable', which means reapable.
+
+    The opposite polarity would let one corrupt byte pin 13GB of debris on
+    disk forever — the exact problem Slice 44's prefix expansion existed to
+    solve.
+    """
+    from backend.core.ouroboros.governance.worktree_manager import (
+        workspace_lock_path,
+    )
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    await _init_git_repo(repo_root)
+    monkeypatch.delenv("JARVIS_AUTO_COMMIT_WORKSPACE", raising=False)
+
+    mgr = WorktreeManager(repo_root=repo_root)
+    wt = await mgr.create("unit-torn-lock")
+    workspace_lock_path(wt).write_text("{not json", encoding="utf-8")
+
+    reaped = await mgr.reap_orphans()
+
+    assert reaped == 1
+    assert not wt.exists()


### PR DESCRIPTION
Follows #70564, which stopped the boot reaper eating the live session's
workspace. That guard reads `JARVIS_AUTO_COMMIT_WORKSPACE`, so it protects only
the workspace **this process** armed. Worker B boots, sweeps, and has never
heard of worker A's environment — the cross-process race was still open.

## The lock

`<worktree>/.jarvis/.workspace_lock`, stamped at materialization, carrying
`pid`, `created_at` and `proc_start`.

**Why a new file rather than the existing marker.** `ledger_sovereignty`
already stamps `<wt>/.jarvis/ledger_ownership.json` with `creator_pid` and
`created_at`, and `reap_dangling_auto_branches` already probes it with
`os.kill(pid, 0)`. Reusing it was the DRY answer and was rejected on one fact:
`master_enabled()` defaults to **FALSE** (§33.1), so that marker does not exist
in a default configuration. Whether one session may delete another's live
workspace cannot be contingent on an unrelated feature flag. The new lock has no
master — and `_locked_by_live_process` consults **both**, so the richer marker is
still used wherever it is present.

**Placement.** Under `.jarvis/`, not the worktree root, because `.jarvis/` is
already gitignored. A lock at the root would make every `git status` inside the
worktree report dirty, and a workspace that reports itself dirty is one whose
APPLY and rollback gates start lying.

**Atomicity.** Temp sibling → `fsync` → `os.replace`. The reaper may read it
mid-write; a torn read must be impossible rather than unlikely.

## PID reuse is the real difficulty

This is why the record carries a start time as well as a pid. `os.kill(pid, 0)`
cannot distinguish *"my session is alive"* from *"my session died and the OS
handed that number to something unrelated."* Reaping on a reused pid skips real
debris forever; reaping on a stale one destroys live work. `proc_start`
(psutil `create_time()`, 1s tolerance for cross-platform resolution and clock
adjustment) settles it. Without psutil the check degrades to a plain liveness
probe rather than failing.

There is deliberately **no short-circuit for our own pid**. It is trivially
live, but *"the lock names my pid"* and *"the lock was written by me"* are
different claims, and only the start-time comparison separates them.

## Polarity is deliberate, and opposite to the sibling method

`reap_dangling_auto_branches` guards branches that may hold real unpushed work,
so its rule is *don't touch unless proven dead*. `reap_orphans` is a debris
sweeper — Slice 44 exists because 62 stale checkouts reached 492k files and
13GB and starved the loop. So here the rule is **reap unless proven alive**.
Absent, torn, or malformed lock all mean "unprovable", which means reapable;
the opposite polarity would let one corrupt byte pin 13GB on disk forever.
Pinned by a test.

Applied to all three reap loops — registered worktrees, unregistered
directories, and the branch sweep (deleting the live branch out from under its
own worktree is the "branch already exists" class its sibling already guards).

## Five tests had to change, and that is the finding

They built a worktree in-process and immediately called it an orphan. That only
ever passed because nothing checked liveness — and in production
`resolve_loop_project_root` and the boot reaper genuinely *do* run in the same
process, which is exactly how the live workspace got eaten. `_orphan()` now
stamps a stale pid, representing what a crashed session actually leaves behind.

## Both "pre-existing" failures are closed

Carried as ambient through the last three commits; both are the same
husk-shaped fixture class.

- **`test_env_override_takes_precedence`** armed a bare `mkdir()` and asserted
  it resolved. It is the **fourth** fixture in this repo to model a worktree as
  "a directory that happens to exist" — and that shared blind spot is why the
  defect shipped: production armed marker-only directories because every test
  said a marker-only directory was fine. Now carries `.git`, plus a new case
  pinning that a husk is refused *loud*.
- **`test_on_and_autonomous_routes_to_worktree`** asserted the literal
  `"ouroboros/auto/bt-xyz"`, which stopped being the name when a per-boot nonce
  was added — a naming change the test was never about. Now derives the
  expectation from `workspace_branch()` itself, so the next naming change
  cannot break it either.

## Test status

| suite set | result |
|---|---|
| 6 workspace / sovereignty suites | **88 passed, 0 failed** (was 2 failed) |
| local-lane + notebook suites | 145 passed, 1 skipped |
| `test_bg_readonly_cascade.py` | 3 failed — **ambient**, reproduce on unmodified `main` |

The remaining 3 stub the pre-Slice-5a three-method topology API while
production calls the unified `is_dw_blocked_for_route`, so the unpack dies
upstream of anything here. Left alone deliberately; they are a separate piece
of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an on-disk liveness lock (`.jarvis/.workspace_lock`) so one worker's orphan sweeper can no longer delete another worker's live workspace. The env-derived guard only protected the workspace this process armed, leaving the cross-process race open.

The lock is stamped unconditionally at materialization — unlike the Ledger-Sovereignty marker, which needs `master_enabled()` (default FALSE). It carries pid, created_at, and proc_start (psutil `create_time()`, 1s tolerance) so a recycled PID doesn't read as a live owner; without psutil the check degrades to a plain liveness probe.

**Reaping behavior**
- `reap_orphans` now reaps unless proven alive; absent, torn, or malformed locks mean "unprovable" and are reapable.
- `_locked_by_live_process` consults both the lock and the sovereignty marker, and the branch sweep registers the held branch as protected.
- The lock lives under `.jarvis/` (already gitignored) so `git status` inside the worktree stays clean.

**Test changes**
- Five tests built worktrees in-process and called them orphans; they now stamp a stale pid via `_orphan()` to represent a crashed session.
- `test_env_override_takes_precedence` now carries a `.git` marker, plus a new test pins that a husk (marker-only directory) is refused loudly.
- `test_on_and_autonomous_routes_to_worktree` derives the expected branch from `workspace_branch()` instead of asserting a literal name that changed with the per-boot nonce.

<sup>Written for commit 277f533cea00020788c8d6432d717f226fe1cb96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

