### PR TITLE
fix(worktree): the boot sweep knew about one of the roots its system writes to

### DIFF
--- a/backend/core/ouroboros/governance/worktree_manager.py
+++ b/backend/core/ouroboros/governance/worktree_manager.py
@@ -185,6 +185,74 @@ def _resolve_reap_prefixes(primary: str) -> "tuple[str, ...]":
     return tuple(out)
 
 
+#: The in-repo worktree root. Kept as a constant so the several modules that
+#: currently spell `.worktrees` as a literal have one name to converge on.
+_IN_REPO_WORKTREE_DIRNAME = ".worktrees"
+
+
+def worktree_sweep_roots(repo_root: object, *extra: object) -> "Tuple[Path, ...]":
+    """Every directory this system materializes worktrees in.
+
+    There is more than one, on purpose, and that is the point. The L3 subagent
+    base defaults to ``$HOME/.jarvis/ouroboros/worktrees`` — deliberately off
+    the repo, because on this host the repo lives on a 9p ``/mnt/c`` mount
+    where checkouts are pathologically slow. The session workspace base is
+    ``<repo_root>/.worktrees``, because ``resolve_loop_project_root`` builds
+    its ``WorktreeManager`` with no explicit base and takes the default.
+
+    Both placements are correct. What was NOT correct is that the boot sweep
+    knew about only one of them: ``reap_orphans`` ran on the L3 manager, so it
+    iterated the home base and never saw in-repo debris. Measured on
+    bt-2026-08-28-083617 — one registered orphan reaped (loop 1 finds those via
+    ``git worktree list``, which reports absolute paths regardless of base)
+    while three marker-only husks under ``<repo>/.worktrees`` survived
+    untouched, as they had for days. That is the unfinished half of Slice 44,
+    whose whole purpose was reclaiming exactly this debris.
+
+    So the fix is NOT to force one base — that would either drag L3 checkouts
+    onto the slow mount or move session workspaces out of the repo, breaking a
+    deliberate decision in each case. The fix is to stop having a sweep that
+    knows about a subset of the places its own system writes to.
+
+    Sources, deduped: the caller's own base(s), the in-repo default, and
+    ``JARVIS_WORKTREE_BASE`` (which ``posture_observer.worktree_orphan_count``
+    already reads as authoritative — a third module with a fourth opinion,
+    which is the smell this helper exists to remove).
+
+    Deduped by ``os.path.realpath`` so ``/mnt/c/...`` versus a symlinked or
+    trailing-slash spelling of the same directory is swept once, not twice.
+    Only extant directories are returned. NEVER raises.
+    """
+    seen: Set[str] = set()
+    roots: List[Path] = []
+
+    def _add(candidate: object) -> None:
+        if candidate in (None, ""):
+            return
+        try:
+            resolved = os.path.realpath(str(candidate))
+        except (OSError, TypeError, ValueError):
+            return
+        if resolved in seen:
+            return
+        seen.add(resolved)
+        path = Path(resolved)
+        try:
+            if path.is_dir():
+                roots.append(path)
+        except OSError:
+            pass
+
+    for candidate in extra:
+        _add(candidate)
+    try:
+        _add(Path(str(repo_root)) / _IN_REPO_WORKTREE_DIRNAME)
+    except (TypeError, ValueError):
+        pass
+    _add(os.environ.get("JARVIS_WORKTREE_BASE"))
+    return tuple(roots)
+
+
 # ---------------------------------------------------------------------------
 # Workspace liveness lock
 # ---------------------------------------------------------------------------
@@ -677,6 +745,16 @@ class WorktreeManager:
         # layer — Oracle was the scanner.)
         prefixes = _resolve_reap_prefixes(branch_prefix)
 
+        # Every root this system writes worktrees into, not just this
+        # manager's own. See :func:`worktree_sweep_roots` for why there is
+        # legitimately more than one and why forcing a single base would be
+        # the wrong repair.
+        sweep_roots = worktree_sweep_roots(self._repo_root, self._worktree_base)
+        logger.debug(
+            "WorktreeManager.reap_orphans: sweeping %d root(s): %s",
+            len(sweep_roots), ", ".join(str(r) for r in sweep_roots) or "(none)",
+        )
+
         # ------------------------------------------------------------------
         # Self-protection: never reap the workspace THIS process is using.
         #
@@ -807,8 +885,10 @@ class WorktreeManager:
                 else ""
             )
             try:
-                base_resolved = self._worktree_base.resolve()
-                lives_under_base = wt_path.parent.resolve() == base_resolved
+                _parent = wt_path.parent.resolve()
+                lives_under_base = any(
+                    _parent == _root for _root in sweep_roots
+                )
             except OSError:
                 lives_under_base = False
             name_matches = any(wt_path.name.startswith(p) for p in prefixes)
@@ -838,8 +918,16 @@ class WorktreeManager:
             if branch_short:
                 await self._git_delete_branch(branch_short)
 
-        if self._worktree_base.exists():
-            for child in self._worktree_base.iterdir():
+        for _root in sweep_roots:
+            try:
+                _children = list(_root.iterdir())
+            except OSError as exc:
+                logger.warning(
+                    "WorktreeManager.reap_orphans: cannot list %s: %s",
+                    _root, exc,
+                )
+                continue
+            for child in _children:
                 if not child.is_dir():
                     continue
                 if not any(child.name.startswith(p) for p in prefixes):

--- a/tests/governance/test_worktree_isolation.py
+++ b/tests/governance/test_worktree_isolation.py
@@ -540,3 +540,103 @@ async def test_unreadable_lock_is_treated_as_reapable(tmp_path: Path, monkeypatc
 
     assert reaped == 1
     assert not wt.exists()
+
+
+# ===========================================================================
+# Multi-root sweeping (bt-2026-08-28-083617)
+# ===========================================================================
+#
+# The boot reaper runs on the L3 manager, whose base defaults to
+# `$HOME/.jarvis/ouroboros/worktrees`. Session workspaces live in
+# `<repo>/.worktrees`. Both placements are deliberate; the bug was a sweep
+# that knew about only one of them, so in-repo husks survived for days while
+# the reaper reported success.
+
+
+@pytest.mark.asyncio
+async def test_sweep_reaches_in_repo_husks_from_a_foreign_base(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """A manager based OUTSIDE the repo must still sweep in-repo debris."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    await _init_git_repo(repo_root)
+    monkeypatch.delenv("JARVIS_AUTO_COMMIT_WORKSPACE", raising=False)
+    monkeypatch.delenv("JARVIS_WORKTREE_BASE", raising=False)
+
+    # The L3 base: elsewhere entirely, as in production.
+    l3_base = tmp_path / "home" / ".jarvis" / "ouroboros" / "worktrees"
+    l3_base.mkdir(parents=True)
+
+    # In-repo husk — the exact observed shape: marker only, no .git, and git
+    # has never heard of it.
+    husk = repo_root / ".worktrees" / "ouroboros__auto__bt-dead-session-aaa111"
+    husk.mkdir(parents=True)
+    (husk / ".jarvis").mkdir()
+
+    mgr = WorktreeManager(repo_root=repo_root, worktree_base=l3_base)
+    reaped = await mgr.reap_orphans()
+
+    assert not husk.exists(), (
+        "in-repo husk survived a sweep run from the L3 base — the bug"
+    )
+    assert reaped == 1
+
+
+@pytest.mark.asyncio
+async def test_multi_root_sweep_still_honours_the_liveness_lock(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Widening the sweep must not widen what it is allowed to destroy."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    await _init_git_repo(repo_root)
+    monkeypatch.delenv("JARVIS_AUTO_COMMIT_WORKSPACE", raising=False)
+    monkeypatch.delenv("JARVIS_WORKTREE_BASE", raising=False)
+
+    l3_base = tmp_path / "l3base"
+    l3_base.mkdir()
+
+    # A LIVE in-repo workspace, created through the default (in-repo) base.
+    session_mgr = WorktreeManager(repo_root=repo_root)
+    live = await session_mgr.create("ouroboros/auto/bt-live-bbb222")
+
+    # A dead one alongside it.
+    dead = await session_mgr.create("ouroboros/auto/bt-dead-ccc333")
+    _orphan(dead)
+
+    # The boot reaper, based elsewhere, now reaches both — and must still
+    # tell them apart.
+    boot_mgr = WorktreeManager(repo_root=repo_root, worktree_base=l3_base)
+    await boot_mgr.reap_orphans()
+
+    assert live.exists(), "the lock must survive the wider sweep"
+    assert (live / ".git").exists()
+    assert not dead.exists()
+
+
+def test_sweep_roots_dedupes_equivalent_spellings(tmp_path: Path, monkeypatch) -> None:
+    """The same directory spelled two ways is one root, not two."""
+    from backend.core.ouroboros.governance.worktree_manager import (
+        worktree_sweep_roots,
+    )
+
+    repo_root = tmp_path / "repo"
+    (repo_root / ".worktrees").mkdir(parents=True)
+    monkeypatch.setenv("JARVIS_WORKTREE_BASE", str(repo_root / ".worktrees") + "/")
+
+    roots = worktree_sweep_roots(repo_root, repo_root / ".worktrees")
+
+    assert len(roots) == 1, f"expected one deduped root, got {roots}"
+
+
+def test_sweep_roots_skips_nonexistent_and_never_raises(tmp_path: Path, monkeypatch) -> None:
+    """A configured-but-absent base is not an error, it is just not a root."""
+    from backend.core.ouroboros.governance.worktree_manager import (
+        worktree_sweep_roots,
+    )
+
+    monkeypatch.setenv("JARVIS_WORKTREE_BASE", str(tmp_path / "does-not-exist"))
+    roots = worktree_sweep_roots(tmp_path / "no-repo-here", None, "")
+
+    assert roots == ()


### PR DESCRIPTION
Soak `bt-2026-08-28-083617` reported `reaped 1 orphan worktree(s)` and looked
healthy. It had reaped **one of four**. Three marker-only husks under
`<repo>/.worktrees` survived — accumulating since 2026-08-24 — while the reaper
logged success.

## Why

The boot reaper runs on the **L3 manager**, whose base is
`$HOME/.jarvis/ouroboros/worktrees`. Session workspaces are created by
`resolve_loop_project_root`, which builds a `WorktreeManager` with no explicit
base and therefore gets **`<repo_root>/.worktrees`**. Loop 2 — the
unregistered-husk sweep — iterated `self._worktree_base` only, so it looked in
the home base and never saw in-repo debris.

Loop 1 masked the problem: `git worktree list` reports absolute paths
regardless of base, so the one *registered* orphan was found and the sweep
appeared to work.

## Why not "unify on one base"

Both placements are deliberate and neither should move. The L3 base is off the
repo because on this host the repo sits on a 9p `/mnt/c` mount where checkouts
are pathologically slow. Session workspaces are in-repo because that is where
the quarantine boundary belongs. Forcing a single base breaks one of those two
decisions.

The defect is not that there are two roots. It is a sweep that knew about a
subset of the places its own system writes to.

## The fix

`worktree_sweep_roots()` is now the single place that answers *"where do
worktrees live"*: the caller's own base(s), the in-repo default, and
`JARVIS_WORKTREE_BASE` — which `posture_observer.worktree_orphan_count` already
reads as authoritative, a third module with a fourth opinion, and the smell
this helper removes.

- Deduped by `os.path.realpath`, so `/mnt/c/...` versus a symlinked or
  trailing-slash spelling of the same directory is swept once, not twice.
- Non-existent roots are skipped rather than raising.
- Both loops consult it: loop 2 iterates every root, and loop 1's
  `lives_under_base` test accepts any of them.

**Widening what a destructive sweep can reach is exactly where care is owed**,
so what it may *destroy* is unchanged: the prefix filter still applies, and the
liveness lock from #70565 still protects anything a live process holds. Pinned
by a test that puts a live and a dead workspace side by side in-repo and sweeps
them from a foreign base — the live one must survive.

## Verified against real debris, not only fixtures

Four husks had accumulated in this repo. Before the change the reaper took one;
after it, four — with `git worktree list` left correct:

```
sweep roots the reaper now sees:
    /home/jarvis_svc/.jarvis/ouroboros/worktrees
    /mnt/c/Users/Jarvis/Desktop/TrinityAi/jarvis/.worktrees
reaped: 4
```

This is the unfinished half of Slice 44, whose stated purpose was reclaiming
this exact debris (62 checkouts, 492k files, 13GB) and which has been
reclaiming only the half of it that git happened to have registered.

## Tests

`tests/governance/test_worktree_isolation.py` — **22 passed** (18 + 4 new:
in-repo husk reached from a foreign base; liveness lock still honoured under
the wider sweep; realpath dedupe; absent roots skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The boot worktree sweep now sweeps every root the system writes worktrees into, not just its own base. Previously it only looked at the L3 manager's base (`$HOME/.jarvis/ouroboros/worktrees`), so in-repo husks under `<repo>/.worktrees` survived while the reaper logged success; now `worktree_sweep_roots()` collects the caller's base(s), the in-repo default, and `JARVIS_WORKTREE_BASE`, dedupes by `os.path.realpath`, and skips absent roots. Both sweep loops use it, and the `lives_under_base` check accepts any root. The prefix filter and liveness lock still limit what the sweep can destroy. Adds 4 tests: in-repo husk removal from a foreign base, liveness lock protection, dedupe of equivalent spellings, and missing-root skipping.

<sup>Written for commit 915e9ae848843f37a28e39116c9a689f61e5180f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

