### PR TITLE
feat(local-lane): show the model the parse error it never saw

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3088,6 +3088,16 @@ def _refresh_paid_lane_credentials() -> None:
         pass
 
 
+def _syntax_repair_enabled() -> bool:
+    """Master for the local lane's one-shot syntax-repair retry.
+
+    Default ON: without it `all_candidates_syntax_error` is terminal on a
+    topology whose escalation target is the failing model itself. Falsey
+    restores the pre-existing single-attempt behaviour exactly.
+    """
+    return _envb("JARVIS_LOCAL_SYNTAX_REPAIR_ENABLED", True)
+
+
 def _background_local_lane_enabled() -> bool:
     """Master for the cost-optimized routes' zero-cost lane preemption.
 
@@ -5656,6 +5666,94 @@ class CandidateGenerator:
         # is never serialized, only the one-shot cold calibration is gated.
         return await _prof.run_calibrated(_attempts)
 
+    async def _local_dispatch_with_syntax_repair(
+        self,
+        context: OperationContext,
+        deadline: datetime,
+        endpoint: str,
+    ) -> Optional[GenerationResult]:
+        """Local dispatch that shows the model its own parse errors once.
+
+        `all_candidates_syntax_error` was the top non-governance failure on the
+        local lane — 6 dispatches in soak bt-2026-08-28-061124, the model
+        emitting VALID JSON wrapping INVALID Python. That is a recoverable
+        slip, and it was being treated as terminal.
+
+        `syntax_escalation` exists for this class, but it cascades DW →
+        J-Prime, and on a workstation topology the local 32B *is* J-Prime — so
+        it escalates to the model that just failed. The escalation is sound and
+        simply has nowhere to go here; the missing move is not another provider
+        but the feedback the first attempt never received.
+
+        ONE retry, deliberately. Two would be a loop that spends the op's whole
+        budget re-reading the same file; and if a model cannot fix a named
+        `unexpected indent` on the second attempt, a third will not help. The
+        retry is stamped through `with_syntax_retry_feedback`, which advances
+        the hash-chain, so it is auditable as a distinct attempt rather than a
+        silent re-run.
+
+        Falls through to the original exception when the retry also fails, so
+        the operator still reads the real terminal cause.
+        """
+        try:
+            return await self._failover_local_dispatch(context, deadline, endpoint)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — inspected, then re-raised
+            failures = getattr(exc, "syntax_failures", None)
+            if not failures or not _syntax_repair_enabled():
+                raise
+            if getattr(context, "syntax_retry_feedback", ""):
+                # Already the retry. A second correction round is the loop this
+                # method exists to avoid.
+                raise
+            try:
+                from backend.core.ouroboros.governance.providers import (
+                    _format_syntax_feedback,  # noqa: PLC0415
+                )
+                feedback = _format_syntax_feedback(failures)
+            except Exception:  # noqa: BLE001 — no feedback → no retry
+                raise exc from None
+            if not feedback:
+                raise
+            op_id_short = (getattr(context, "op_id", "") or "?")[:16]
+            logger.info(
+                "[CandidateGenerator] local lane returned unparseable Python "
+                "(%d file(s), first: %s line %s) — retrying ONCE with the "
+                "parse errors fed back [%s]",
+                len(failures),
+                (failures[0] or {}).get("file_path", "?"),
+                (failures[0] or {}).get("line", "?"),
+                op_id_short,
+            )
+            # Duck-typed contexts reach this path (the harness and several
+            # call sites build minimal ones). A context that cannot CARRY the
+            # feedback cannot benefit from the retry, and turning a diagnosed
+            # syntax error into an AttributeError would replace a precise
+            # terminal reason with a useless one.
+            _stamp = getattr(context, "with_syntax_retry_feedback", None)
+            if not callable(_stamp):
+                logger.debug(
+                    "[CandidateGenerator] context cannot carry syntax feedback "
+                    "(%s) — not retrying [%s]",
+                    type(context).__name__, op_id_short,
+                )
+                raise
+            retry_ctx = _stamp(feedback)
+            if retry_ctx is context:
+                # Stamping failed (degraded to self); retrying unchanged would
+                # just repeat the failure at full cost.
+                raise
+            result = await self._failover_local_dispatch(
+                retry_ctx, deadline, endpoint,
+            )
+            logger.info(
+                "[CandidateGenerator] syntax-repair retry produced %d "
+                "candidate(s) [%s]",
+                len(getattr(result, "candidates", ()) or ()), op_id_short,
+            )
+            return result
+
     async def _try_free_lane_dispatch(
         self,
         context: OperationContext,
@@ -5729,7 +5827,7 @@ class CandidateGenerator:
             route, reason[:80], endpoint, op_id_short,
         )
         try:
-            result = await self._failover_local_dispatch(
+            result = await self._local_dispatch_with_syntax_repair(
                 context, deadline, endpoint,
             )
         except asyncio.CancelledError:

--- a/backend/core/ouroboros/governance/op_context.py
+++ b/backend/core/ouroboros/governance/op_context.py
@@ -1164,6 +1164,19 @@ class OperationContext:
     force_diff_on_retry: bool = False        # Truncation-retry: force 2b.1-diff output on this retry
     retry_max_tokens_override: int = 0        # Truncation-retry: >0 overrides provider max_tokens for this retry
 
+    # Syntax-retry feedback. Same lifecycle as the two flags above — stamped
+    # when the previous attempt's candidates were rejected by ``ast.parse``,
+    # consumed by the provider tier to change the next attempt rather than
+    # repeating it unchanged.
+    #
+    # It carries the actual parse errors (file, line, message, offending
+    # source line). Before this the SyntaxError was logged and discarded, so
+    # `all_candidates_syntax_error` was terminal on a lane with nowhere to
+    # escalate to: the local 32B IS J-Prime, so `syntax_escalation`'s
+    # DW → J-Prime cascade escalates to the model that just failed. A model
+    # cannot correct an error it is never shown.
+    syntax_retry_feedback: str = ""
+
     # ---- Slice 245 — hibernation resurrection flag ----
     # Set (via with_resurrection()) when an op that failed with provider
     # exhaustion during a dark window is re-ingested after the Grid Sentinel
@@ -1618,6 +1631,35 @@ class OperationContext:
         fields_for_hash = _context_to_hash_dict(intermediate)
         new_hash = _compute_hash(fields_for_hash)
         return dataclasses.replace(intermediate, context_hash=new_hash)
+
+    def with_syntax_retry_feedback(self, feedback: str) -> "OperationContext":
+        """Return a context carrying the previous attempt's parse errors.
+
+        Hash-chain-safe by the same mechanics as :meth:`with_resurrection`:
+        the retry is a genuinely different attempt and must be auditable as
+        one, not a silent re-run wearing the first attempt's identity.
+
+        ``generate_file_hashes`` is deliberately untouched — the retry targets
+        the same files at the same disk state, and rewriting those hashes here
+        would blind the Slice 248 file-drift guillotine to real drift.
+
+        NEVER raises into the caller: a retry that cannot be stamped degrades
+        to no retry, which is the pre-existing behaviour.
+        """
+        try:
+            if not (feedback or "").strip():
+                return self
+            intermediate = dataclasses.replace(
+                self,
+                syntax_retry_feedback=str(feedback),
+                previous_hash=self.context_hash,
+                context_hash="",  # placeholder — recomputed below
+            )
+            fields_for_hash = _context_to_hash_dict(intermediate)
+            new_hash = _compute_hash(fields_for_hash)
+            return dataclasses.replace(intermediate, context_hash=new_hash)
+        except Exception:  # noqa: BLE001 — degrade to no retry
+            return self
 
     def with_steering_guidance(self, guidance: str) -> "OperationContext":
         """Slice 249 — fold live human steering into the context (durable/auditable

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -4032,6 +4032,19 @@ Rules:
     if _s89_enabled and _s89_manifest is not None:
         parts.append(_build_exploration_manifest_block(_s89_manifest))
 
+    # Syntax-retry correction — LAST, and deliberately outside the
+    # `not _is_bg_route` gate above.
+    #
+    # Last because it is a correction to work the model has already done, and
+    # an instruction to fix a specific line is worth little buried above two
+    # thousand lines of source snapshot. Outside the BG gate because BACKGROUND
+    # is precisely the route this exists for: the local lane serves BG, and a
+    # prompt-size economy that drops the one instruction naming the defect
+    # guarantees the retry repeats it. It costs a few hundred characters.
+    _syntax_fb = getattr(ctx, "syntax_retry_feedback", "")
+    if isinstance(_syntax_fb, str) and _syntax_fb.strip():
+        parts.append(f"## Correction Required\n\n{_syntax_fb.strip()}")
+
     prompt = "\n\n".join(parts)
 
     # N7: Prompt-size gate — prevent silent context-window truncation.
@@ -4053,6 +4066,69 @@ Rules:
 # ---------------------------------------------------------------------------
 # Shared: Response Parser helpers
 # ---------------------------------------------------------------------------
+
+
+def _describe_syntax_error(
+    exc: SyntaxError, file_path: str, content: str,
+) -> Dict[str, Any]:
+    """Turn a rejected candidate's SyntaxError into feedback a model can use.
+
+    The offending SOURCE LINE is the load-bearing part. "line 214: unexpected
+    indent" asks the model to recount 214 lines of its own output; quoting the
+    line, and the one before it, points at the mistake directly. Bounded to a
+    couple of short strings so a retry prompt cannot be crowded out by the
+    error report.
+
+    NEVER raises — this runs on the failure path, where a second exception
+    would replace a recoverable error with an unrecoverable one.
+    """
+    try:
+        lineno = int(getattr(exc, "lineno", 0) or 0)
+    except (TypeError, ValueError):
+        lineno = 0
+    detail: Dict[str, Any] = {
+        "file_path": str(file_path),
+        "line": lineno,
+        "message": str(getattr(exc, "msg", "") or exc)[:200],
+    }
+    try:
+        lines = content.splitlines()
+        if 1 <= lineno <= len(lines):
+            detail["source_line"] = lines[lineno - 1][:200]
+            if lineno >= 2:
+                detail["preceding_line"] = lines[lineno - 2][:200]
+    except Exception:  # noqa: BLE001 — feedback is best-effort
+        pass
+    return detail
+
+
+def _format_syntax_feedback(failures: List[Dict[str, Any]]) -> str:
+    """Render :func:`_describe_syntax_error` records as a retry directive.
+
+    Deliberately imperative and specific. A generic "your output was invalid"
+    reliably produces another invalid output; naming the construct and the line
+    gives the model something to act on. Capped at three failures — beyond that
+    the model is not making a fixable slip, and a longer list only eats the
+    token budget the corrected file needs.
+    """
+    if not failures:
+        return ""
+    parts: List[str] = [
+        "Your previous response was rejected: the Python you produced does "
+        "not parse. Fix EXACTLY these errors and return the COMPLETE file "
+        "again — do not summarise, do not elide, do not explain.",
+    ]
+    for fail in failures[:3]:
+        chunk = (
+            f"- {fail.get('file_path', '?')} line {fail.get('line', '?')}: "
+            f"{fail.get('message', 'syntax error')}"
+        )
+        if fail.get("preceding_line"):
+            chunk += f"\n    preceding: {fail['preceding_line']}"
+        if fail.get("source_line"):
+            chunk += f"\n    offending: {fail['source_line']}"
+        parts.append(chunk)
+    return "\n".join(parts)
 
 
 def _try_reconstruct_from_ellipsis(
@@ -5326,6 +5402,13 @@ def _parse_generation_response(
 
     # Step 6: per-candidate validation
     validated: List[Dict[str, Any]] = []
+    # Structured record of WHY each Python candidate failed ast.parse. The
+    # SyntaxError used to be logged and dropped, so all that reached the caller
+    # was the fact that everything failed — no line, no message, nothing a
+    # retry could act on. A model cannot correct an error it is never shown,
+    # which is why `all_candidates_syntax_error` has been a terminal wall on
+    # the local lane rather than a recoverable one.
+    _syntax_failures: List[Dict[str, Any]] = []
     for i, cand in enumerate(raw_candidates):
         if not isinstance(cand, dict):
             raise RuntimeError(f"{pfx}_schema_invalid:candidate_{i}_not_object")
@@ -5397,11 +5480,16 @@ def _parse_generation_response(
         if file_path.endswith(".py"):
             try:
                 ast.parse(full_content)
-            except SyntaxError:
+            except SyntaxError as _se:
+                _syntax_failures.append(_describe_syntax_error(
+                    _se, file_path, full_content,
+                ))
                 logger.warning(
-                    "Skipping candidate %s: SyntaxError in %s",
+                    "Skipping candidate %s: SyntaxError in %s (line %s: %s)",
                     cand["candidate_id"],
                     file_path,
+                    getattr(_se, "lineno", "?"),
+                    getattr(_se, "msg", _se),
                 )
                 continue  # skip this candidate; try next
 
@@ -5500,10 +5588,16 @@ def _parse_generation_response(
                 if _fp_entry.endswith(".py"):
                     try:
                         ast.parse(_fc_entry)
-                    except SyntaxError:
+                    except SyntaxError as _se:
+                        _syntax_failures.append(_describe_syntax_error(
+                            _se, _fp_entry, _fc_entry,
+                        ))
                         logger.warning(
-                            "Skipping multi-file candidate %s: SyntaxError in %s",
+                            "Skipping multi-file candidate %s: SyntaxError in "
+                            "%s (line %s: %s)",
                             cand["candidate_id"], _fp_entry,
+                            getattr(_se, "lineno", "?"),
+                            getattr(_se, "msg", _se),
                         )
                         _skip_candidate = True
                         break
@@ -5537,6 +5631,12 @@ def _parse_generation_response(
 
     if not validated:
         _syntax_exc = RuntimeError(f"{pfx}_schema_invalid:all_candidates_syntax_error")
+        # The parse errors themselves, so a retry can show the model exactly
+        # what it got wrong instead of asking it to guess. Empty when the
+        # candidates failed for a non-syntax reason (placeholders, truncation),
+        # which keeps "no syntax detail" distinguishable from "no syntax
+        # problem" at the consuming end.
+        _syntax_exc.syntax_failures = list(_syntax_failures)  # type: ignore[attr-defined]
         # Attach failure context for the SyntaxExhaustionEscalator so
         # J-Prime receives the DW model's failed candidate preview and
         # target file path — enabling structural avoidance of the same

--- a/tests/governance/test_local_lane_arc.py
+++ b/tests/governance/test_local_lane_arc.py
@@ -1011,6 +1011,8 @@ class _FreeLaneStub:
         self._discover_raises = discover_raises
         self._dispatch_raises = dispatch_raises
         self.dispatched_to = None
+        self.dispatch_calls = 0
+        self.last_context = None
 
     async def _discover_jprime_endpoint(self):
         if self._discover_raises is not None:
@@ -1019,9 +1021,41 @@ class _FreeLaneStub:
 
     async def _failover_local_dispatch(self, context, deadline, endpoint):
         self.dispatched_to = endpoint
+        self.dispatch_calls += 1
+        self.last_context = context
         if self._dispatch_raises is not None:
             raise self._dispatch_raises
         return self._result
+
+    async def _local_dispatch_with_syntax_repair(self, context, deadline, endpoint):
+        """The REAL wrapper, bound to this stub.
+
+        Not a stub of its own: the stub supplies only the true collaborator
+        (`_failover_local_dispatch`) and production's retry logic runs on top,
+        so these tests exercise the shipped code path rather than a second
+        description of it.
+        """
+        mod = importlib.import_module(CG)
+        return await mod.CandidateGenerator._local_dispatch_with_syntax_repair(
+            self, context, deadline, endpoint,
+        )
+
+
+class _RetryableCtx:
+    """A context that can carry syntax feedback, like the real one.
+
+    `OperationContext.with_syntax_retry_feedback` returns a NEW context and
+    advances the hash-chain; the retry has to be auditable as a distinct
+    attempt. This mirrors that shape (new object, feedback set) without
+    dragging the real dataclass and its hashing into these tests.
+    """
+
+    def __init__(self, syntax_retry_feedback=""):
+        self.op_id = "op-free-lane-test"
+        self.syntax_retry_feedback = syntax_retry_feedback
+
+    def with_syntax_retry_feedback(self, feedback):
+        return _RetryableCtx(syntax_retry_feedback=feedback)
 
 
 class _Candidates:
@@ -1038,7 +1072,7 @@ def free_lane(monkeypatch):
 
     async def _call(stub, route="background", reason="topology_block:purged"):
         return await mod.CandidateGenerator._try_free_lane_dispatch(
-            stub, object(), object(), route=route, reason=reason,
+            stub, _RetryableCtx(), object(), route=route, reason=reason,
         )
 
     return _call
@@ -1167,3 +1201,108 @@ async def test_cancellation_is_not_swallowed(free_lane):
 
     with pytest.raises(asyncio.CancelledError):
         await free_lane(stub)
+
+
+# ===========================================================================
+# Phase 4 -- one-shot syntax repair on the local lane
+# ===========================================================================
+#
+# `all_candidates_syntax_error` was the top non-governance failure on the
+# local lane (6 dispatches in bt-2026-08-28-061124): valid JSON wrapping
+# invalid Python. `syntax_escalation` exists for this class but cascades
+# DW -> J-Prime, and on a workstation the local 32B IS J-Prime -- so it
+# escalates to the model that just failed. The missing move was never another
+# provider; it was showing the model the parse error it never saw.
+
+
+def _syntax_exc(failures):
+    exc = RuntimeError("gcp-jprime_schema_invalid:all_candidates_syntax_error")
+    exc.syntax_failures = failures
+    return exc
+
+
+_ONE_FAILURE = [{
+    "file_path": "backend/util.py",
+    "line": 3,
+    "message": "unindent does not match any outer indentation level",
+    "source_line": "  y = 2",
+    "preceding_line": "    x = 1",
+}]
+
+
+class _SyntaxThenSuccessStub(_FreeLaneStub):
+    """Fails the first dispatch on syntax, succeeds on the retry."""
+
+    def __init__(self, endpoint, result):
+        super().__init__(endpoint=endpoint, result=result)
+        self._first = True
+
+    async def _failover_local_dispatch(self, context, deadline, endpoint):
+        self.dispatch_calls += 1
+        self.last_context = context
+        self.dispatched_to = endpoint
+        if self._first:
+            self._first = False
+            raise _syntax_exc(_ONE_FAILURE)
+        return self._result
+
+
+async def test_syntax_failure_is_retried_once_with_the_parse_error(free_lane):
+    """The regression: a fixable slip must not be terminal."""
+    good = _Candidates(1)
+    stub = _SyntaxThenSuccessStub(EP, good)
+
+    assert await free_lane(stub) is good
+    assert stub.dispatch_calls == 2, "expected exactly one retry"
+
+
+async def test_the_retry_actually_carries_the_error_text(free_lane):
+    """Feedback must reach the model, naming the line and the source.
+
+    A retry that does not show the model what broke is just a second roll of
+    the same dice at full token cost.
+    """
+    stub = _SyntaxThenSuccessStub(EP, _Candidates(1))
+    await free_lane(stub)
+
+    fb = getattr(stub.last_context, "syntax_retry_feedback", "")
+    assert "backend/util.py" in fb
+    assert "line 3" in fb
+    assert "unindent" in fb
+    assert "y = 2" in fb, "the offending source line must be quoted"
+
+
+async def test_only_one_retry_even_if_it_fails_again(free_lane):
+    """Two corrections would be a loop that spends the whole op budget."""
+    stub = _FreeLaneStub(
+        endpoint=EP, result=None, dispatch_raises=_syntax_exc(_ONE_FAILURE),
+    )
+
+    assert await free_lane(stub) is None
+    assert stub.dispatch_calls == 2, "must stop after a single retry"
+
+
+async def test_master_off_restores_single_attempt(free_lane, monkeypatch):
+    monkeypatch.setenv("JARVIS_LOCAL_SYNTAX_REPAIR_ENABLED", "0")
+    stub = _SyntaxThenSuccessStub(EP, _Candidates(1))
+
+    assert await free_lane(stub) is None
+    assert stub.dispatch_calls == 1, "no retry when the master is off"
+
+
+async def test_a_non_syntax_failure_is_not_retried(free_lane):
+    """Only parse errors are recoverable this way.
+
+    A timeout or a dead engine retried immediately just burns the budget
+    twice; those have their own recovery paths.
+    """
+    stub = _FreeLaneStub(
+        endpoint=EP, result=None, dispatch_raises=RuntimeError("engine down"),
+    )
+
+    assert await free_lane(stub) is None
+    assert stub.dispatch_calls == 1
+
+
+def test_syntax_repair_defaults_on(cg):
+    assert cg._syntax_repair_enabled() is True


### PR DESCRIPTION
`all_candidates_syntax_error` was the top non-governance failure on the local
lane — 6 dispatches in soak `bt-2026-08-28-061124` — and it was **terminal**.
The model emits valid JSON wrapping invalid Python: a fixable slip treated as a
dead end.

## Why the existing escalation couldn't help

`syntax_escalation` exists for exactly this error class and is sound — it
cascades **DW → J-Prime** with the failed candidate preview. But on a
workstation topology **the local 32B *is* J-Prime**, so the escalation target is
the model that just failed. It has nowhere to go.

The missing move was never another provider. It was the feedback.
`providers._parse_response` ran `ast.parse` on every Python candidate and, on
`SyntaxError`, logged a warning and `continue`d — line number, message and
offending source all discarded. What reached the caller was the bare fact that
everything failed. **A model cannot correct an error it is never shown**, so a
retry was a second roll of the same dice at full token cost.

## Three parts, each on a seam that already existed

**1. Capture.** Both AST rejection sites now record file, line, message, the
offending source line and the one before it. Quoting the *line* is the
load-bearing part: *"line 214: unexpected indent"* asks the model to recount 214
lines of its own output; showing the line points at the mistake. Capped at three
failures — past that the model isn't making a fixable slip, and a longer report
only eats the budget the corrected file needs.

**2. Carry.** `OperationContext.syntax_retry_feedback`, added to the same block
as `force_diff_on_retry` / `retry_max_tokens_override`, with the same documented
lifecycle: *"stamped by the retry path, consumed by the provider tier to change
output shape on the next attempt instead of retrying with the same
parameters."* `with_syntax_retry_feedback()` advances the hash-chain like
`with_resurrection()`, so the retry is auditable as a distinct attempt rather
than a silent re-run wearing the first attempt's identity. It does **not** touch
`generate_file_hashes` — rewriting those would blind the Slice 248 drift
guillotine to real drift.

**3. Consume.** The prompt block is appended **last**, and deliberately
**outside** the `not _is_bg_route` gate that strips most sections for prompt
economy. BACKGROUND is the route this exists for; an economy that drops the one
instruction naming the defect guarantees the retry repeats it.

## Bounded on purpose

- **One retry.** Two is a loop that spends the op's whole budget re-reading the
  same file, and a model that cannot fix a *named* `unexpected indent` on the
  second attempt will not on the third.
- **Parse errors only.** A timeout or dead engine retried immediately just burns
  the budget twice; those have their own recovery paths.
- **Original exception propagates** when the retry also fails, so the operator
  still reads the real terminal cause.
- **Duck-typed contexts** reach this path. One that cannot carry the feedback
  cannot benefit from the retry, so it is detected and the original error
  re-raised — turning a precisely diagnosed syntax failure into an
  `AttributeError` would trade a useful terminal reason for a useless one.
  Found by the test suite doing exactly that.

Master `JARVIS_LOCAL_SYNTAX_REPAIR_ENABLED` default-TRUE; falsey restores
single-attempt behaviour exactly.

## Tests

The free-lane stub now binds the **real** wrapper and supplies only the true
collaborator, so these tests exercise the shipped path rather than a second
description of it — the same delegation the topology fixtures use.

- `test_local_lane_arc.py` — **114 passed / 1 skipped** (108 + 6 new)
- eight touched suites — **224 passed / 1 skipped**

## Not verified end-to-end yet

This has not been proven against a live model. The soak that would prove it
needs ops to reach GENERATE on a sanctioned target, and sanctioning requires an
operator-signed roadmap that does not exist yet — see the discussion on
`self_modification_unsanctioned_source`. The retry logic is unit-proven; the
model's ability to *act* on the feedback is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal `all_candidates_syntax_error` failures on the local lane by retrying once with the actual parse errors shown to the model. Previously parse errors were logged and discarded, so a fixable slip — valid JSON wrapping invalid Python — was a dead end, and escalation couldn't help because the local 32B model is itself the escalation target.

- Both `ast.parse` rejection sites now capture file, line, message, and the offending source line, capped at three failures.
- `OperationContext.syntax_retry_feedback` carries the errors into the retry; `with_syntax_retry_feedback()` advances the hash-chain so the retry is auditable as a distinct attempt.
- A "Correction Required" block is appended to the next prompt last, outside the background-route gate that strips other sections.
- Exactly one retry, for parse errors only; if it fails, the original exception propagates, and contexts that can't carry feedback skip the retry.
- `JARVIS_LOCAL_SYNTAX_REPAIR_ENABLED` defaults to on; a falsey value restores single-attempt behavior exactly.
- Tests now bind the real retry wrapper to the free-lane stub, so they exercise the shipped path; the retry logic is unit-tested but not yet proven against a live model.

<sup>Written for commit 4e451dcf39421f54f28e8068d29a4bafd7f0872e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

