### PR TITLE
feat(local-lane): local engine as primary, syntax feedback, episodic clamp

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3088,6 +3088,56 @@ def _refresh_paid_lane_credentials() -> None:
         pass
 
 
+#: Parse-error messages that mean "the output stopped early", not "the model
+#: mistyped". CPython's wording for each is stable and is the only signal
+#: available at the parse seam — the generator cannot see its own token budget.
+_TRUNCATION_SIGNATURES: Tuple[str, ...] = (
+    "unterminated string literal",
+    "unterminated triple-quoted string literal",
+    "unexpected eof while parsing",
+    "was never closed",
+    "expected an indented block",
+)
+
+
+def _truncation_shaped(failures: Any) -> bool:
+    """True when the parse failures look like a cut-off payload.
+
+    Deliberately conservative: ANY failure bearing a truncation signature
+    makes the whole retry truncation-shaped. Reshaping a retry that did not
+    need it costs a smaller output; NOT reshaping one that did costs the op,
+    because a whole-file retry hits the same ceiling. Asymmetric, so it errs
+    toward the cheaper mistake. NEVER raises.
+    """
+    try:
+        for fail in failures or ():
+            msg = str((fail or {}).get("message", "")).lower()
+            if any(sig in msg for sig in _TRUNCATION_SIGNATURES):
+                return True
+    except Exception:  # noqa: BLE001
+        return False
+    return False
+
+
+def _truncation_reshape_enabled() -> bool:
+    """Master for coupling truncation-shaped parse failures to a reduced
+    output shape. Falsey retries whole-file with feedback only (the
+    pre-coupling behaviour)."""
+    return _envb("JARVIS_TRUNCATION_RESHAPE_ENABLED", True)
+
+
+def _local_primary_enabled() -> bool:
+    """Master for serving ANY route on the local lane when no paid lane exists.
+
+    Default ON, but the master alone changes nothing: `_try_local_primary`
+    still requires `_free_lane_active()` (local configured AND no provider
+    credentials) plus an endpoint that answers. A host with a paid key is
+    byte-identical either way. Falsey pins the local lane back to a fallback
+    for BACKGROUND/SPECULATIVE only.
+    """
+    return _envb("JARVIS_LOCAL_PRIME_PRIMARY_ENABLED", True)
+
+
 def _syntax_repair_enabled() -> bool:
     """Master for the local lane's one-shot syntax-repair retry.
 
@@ -4393,6 +4443,7 @@ class CandidateGenerator:
         if _override_result is not None:
             return _override_result
 
+
         # ── Big-file Agentic Swarm short-circuit (default-OFF; fail-closed) ──
         # When JARVIS_SWARM_ROUTING_ENABLED and the op targets a big file with a
         # deterministically-resolvable symbol, route through the swarm
@@ -4402,6 +4453,33 @@ class CandidateGenerator:
         _swarm_result = await self._maybe_swarm_short_circuit(context, deadline)
         if _swarm_result is not None:
             return _swarm_result
+
+        # ── Local-primary: the free lane runs BEFORE the cascade ───────────
+        # ORDER IS LOAD-BEARING, and getting it wrong is measured, not
+        # theoretical. This block originally sat ABOVE the swarm short-circuit,
+        # which meant that on a host with no paid credential it answered every
+        # op first and the swarm interceptor was never reached — soak
+        # bt-2026-08-28-111858 logged ZERO occurrences of "swarm" with
+        # JARVIS_SWARM_ROUTING_ENABLED=true. Enabling the chunker and then
+        # short-circuiting past it is worse than leaving it off, because the
+        # telemetry says it is on.
+        #
+        # The two are answering different questions and must run in that
+        # order: the swarm decides WHAT to generate (scope reduction — slice
+        # the 75-line symbol out of a 10,923-line file), this decides WHO
+        # generates it (provider selection). Reducing scope first is what
+        # makes the local engine's 32,768-token ceiling sufficient; choosing
+        # the engine first throws the reduction away.
+        #
+        # Still ahead of every route handler, which is the point: a lane that
+        # runs only after the cascade has failed is a fallback, and on a host
+        # with no paid credential the cascade does not fail usefully — it
+        # exhausts (bt-2026-08-28-100733: a SANCTIONED op died
+        # `all_providers_exhausted:circuit_breaker_tripped` on route=standard
+        # while a warm 32B sat resident on the GPU).
+        _local_first = await self._try_local_primary(context, deadline)
+        if _local_first is not None:
+            return _local_first
 
         # ── Route-based dispatch (Manifesto §5 Tier 0: deterministic) ──
         _provider_route = getattr(context, "provider_route", "") or "standard"
@@ -5666,6 +5744,89 @@ class CandidateGenerator:
         # is never serialized, only the one-shot cold calibration is gated.
         return await _prof.run_calibrated(_attempts)
 
+    async def _try_local_primary(
+        self,
+        context: OperationContext,
+        deadline: datetime,
+    ) -> Optional[GenerationResult]:
+        """Serve ANY route on the local lane when no paid lane exists.
+
+        `_try_free_lane_dispatch` made the free lane reachable for BACKGROUND
+        and SPECULATIVE, and deliberately refused the rest: "a STANDARD op has
+        a working cascade and an explicit cost contract; quietly moving it onto
+        a local model would change what the operator paid for." That reasoning
+        is sound while a paid lane exists. It is what stranded a SANCTIONED op
+        in soak bt-2026-08-28-100733, which routed STANDARD by SOURCE (the
+        UrgencyRouter keys on source, not urgency alone, so `source="roadmap"`
+        never reaches BACKGROUND however low its urgency), then died
+        `all_providers_exhausted:circuit_breaker_tripped` — with a warm 32B
+        resident on the GPU the whole time.
+
+        The gate is `_free_lane_active()`, and the choice of predicate is the
+        whole design. It does not ask "which route is this" — route names are
+        exactly the hardcoded mapping that produced the bug. It asks whether
+        any PAID lane exists at all: it requires the local lane to be
+        configured AND both provider credentials to be absent, re-reading
+        `.env` on a TTL so a key added mid-run revokes this immediately. When
+        no paid lane exists there is no cost contract to protect, so the
+        objection above does not apply; when one does exist this returns None
+        and every route cascades exactly as before, byte-identical.
+
+        Evidence, not assertion: a reachable endpoint must answer before
+        anything is dispatched. A configured-but-dead engine falls through to
+        the legacy cascade rather than swallowing the op.
+
+        Returns the result, or None to fall through — including on dispatch
+        failure, so the local lane can only ever ADD a way for an op to
+        succeed, never a new way for it to die.
+        """
+        if not _local_primary_enabled():
+            return None
+        if not _free_lane_active():
+            # A paid lane exists (or the local lane is not configured). Do not
+            # re-route work the operator is paying for.
+            return None
+
+        op_id_short = (getattr(context, "op_id", "") or "?")[:16]
+        route = (getattr(context, "provider_route", "") or "standard").lower()
+        try:
+            endpoint = await self._discover_jprime_endpoint()
+        except Exception:  # noqa: BLE001 — discovery is advisory
+            return None
+        if not endpoint:
+            logger.debug(
+                "[CandidateGenerator] local-primary declined: no endpoint "
+                "(route=%s) [%s]", route, op_id_short,
+            )
+            return None
+
+        logger.info(
+            "[CandidateGenerator] local-primary: no paid lane is configured, "
+            "serving route=%s on the local engine at %s BEFORE the cascade "
+            "[%s]", route, endpoint, op_id_short,
+        )
+        try:
+            result = await self._local_dispatch_with_syntax_repair(
+                context, deadline, endpoint,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[CandidateGenerator] local-primary dispatch failed "
+                "(%s: %.120s) — falling through to the legacy cascade [%s]",
+                type(exc).__name__, str(exc), op_id_short,
+            )
+            return None
+
+        if result is None:
+            return None
+        if getattr(result, "is_noop", False):
+            return result
+        if len(getattr(result, "candidates", ()) or ()) > 0:
+            return result
+        return None
+
     async def _local_dispatch_with_syntax_repair(
         self,
         context: OperationContext,
@@ -5739,6 +5900,43 @@ class CandidateGenerator:
                     type(context).__name__, op_id_short,
                 )
                 raise
+            # Truncation is not a typo, and must not be retried as one.
+            #
+            # The first live firing (soak bt-2026-08-28-100733) showed the
+            # distinction in one trace: line 231 "unterminated string literal"
+            # → retry → line 196 "unterminated string literal". The model did
+            # not mis-type a quote; its OUTPUT WAS CUT OFF, and the second
+            # attempt was cut off earlier. Telling it "fix line 231" asks it to
+            # repair a line it never finished writing, and a full-file retry
+            # spends the same budget to hit the same ceiling.
+            #
+            # `force_diff_on_retry` already exists for exactly this: the
+            # truncation-retry seam whose documented purpose is "change output
+            # SHAPE on the next attempt instead of retrying with the same
+            # parameters". A diff is a fraction of a whole file, so the payload
+            # that overran the budget stops being the payload.
+            if _truncation_shaped(failures) and _truncation_reshape_enabled():
+                _reshape = getattr(context, "with_forced_diff_retry", None)
+                logger.info(
+                    "[CandidateGenerator] the parse failure is TRUNCATION-"
+                    "shaped (%s) — retrying with a reduced output shape rather "
+                    "than another whole-file attempt [%s]",
+                    (failures[0] or {}).get("message", "?")[:60], op_id_short,
+                )
+                if callable(_reshape):
+                    context = _reshape()
+                else:
+                    # No reshape helper on this context: dataclasses.replace is
+                    # the same mechanism the field's own owner uses.
+                    try:
+                        import dataclasses as _dc  # noqa: PLC0415
+                        context = _dc.replace(context, force_diff_on_retry=True)
+                    except Exception:  # noqa: BLE001 — reshape is best-effort
+                        pass
+                _stamp = getattr(context, "with_syntax_retry_feedback", None)
+                if not callable(_stamp):
+                    raise
+
             retry_ctx = _stamp(feedback)
             if retry_ctx is context:
                 # Stamping failed (degraded to self); retrying unchanged would

--- a/backend/core/ouroboros/governance/episodic_core.py
+++ b/backend/core/ouroboros/governance/episodic_core.py
@@ -45,6 +45,48 @@ _DEFAULT_LONGTERM_MAX = 512
 _DEFAULT_RELEVANCE_K = 3
 
 
+_ENV_SUMMARY_MAX = "JARVIS_EPISODIC_SUMMARY_MAX_CHARS"
+_DEFAULT_SUMMARY_MAX = 240
+
+
+def _summary_max_chars() -> int:
+    """Per-episode summary ceiling. ``0`` disables the clamp entirely."""
+    try:
+        return max(0, int(os.getenv(_ENV_SUMMARY_MAX, "").strip()
+                          or _DEFAULT_SUMMARY_MAX))
+    except (TypeError, ValueError):
+        return _DEFAULT_SUMMARY_MAX
+
+
+def _clamp_summary(summary: object) -> str:
+    """Bound a summary at RECORD time, where the cost is paid once.
+
+    Every other dimension of episodic injection is already bounded: the window
+    is count-bounded (``JARVIS_EPISODIC_WINDOW``, default 8), long-term recall
+    is count-bounded (``JARVIS_EPISODIC_RELEVANCE_K``), and ``Episode.render``
+    emits exactly ONE line per episode. Summary length was the only unbounded
+    input, so a single caller passing a stack trace or a file body could put
+    an arbitrarily large block into the prompt tail — on a 32K-context local
+    model, memory bloat causing truncation would be a self-inflicted version
+    of the very failure the truncation work exists to prevent.
+
+    Clamped here rather than at render because an oversized summary is also
+    written to the durable hash-chained receipt; trimming only at display
+    would leave the ledger carrying what the prompt refuses to show.
+
+    Nothing in-tree writes a long summary today (they read like
+    "economic CASCADE_CHEAP → cheap-default"), so this is a guard against a
+    future caller, not a fix for a present bug. NEVER raises.
+    """
+    text = str(summary or "")
+    limit = _summary_max_chars()
+    if limit <= 0 or len(text) <= limit:
+        return text
+    # Marked, not silently cut: a reader of the ledger must be able to tell
+    # a short summary from a truncated one.
+    return text[:limit].rstrip() + f" …[+{len(text) - limit} chars]"
+
+
 def episodic_core_enabled() -> bool:
     """Master gate, default-FALSE per §33.1. NEVER raises."""
     return os.getenv(_ENV_MASTER, "false").strip().lower() in ("1", "true", "yes", "on")
@@ -184,11 +226,12 @@ class EpisodicLedger:
         terminal episodes out of the window (no append → no eviction → no extra
         durable I/O). Fail-soft — never raises."""
         try:
+            summary = _clamp_summary(summary)
             with self._lock:
                 if coalesce_key:
                     for existing in self._window:
                         if existing.coalesce_key == coalesce_key:
-                            existing.summary = str(summary or "")
+                            existing.summary = summary
                             existing.ts = time.time()
                             existing.context.update(dict(context or {}))
                             existing.context["coalesced_count"] = (
@@ -196,7 +239,7 @@ class EpisodicLedger:
                             )
                             return existing  # coalesced — no append, no eviction
                 ep = Episode(self._seq, time.time(), str(kind), str(op_id),
-                             str(summary or ""), dict(context or {}),
+                             summary, dict(context or {}),
                              str(coalesce_key or ""))
                 self._seq += 1
                 evicted: Optional[Episode] = None

--- a/tests/governance/test_local_lane_arc.py
+++ b/tests/governance/test_local_lane_arc.py
@@ -1050,12 +1050,28 @@ class _RetryableCtx:
     dragging the real dataclass and its hashing into these tests.
     """
 
-    def __init__(self, syntax_retry_feedback=""):
+    def __init__(self, syntax_retry_feedback="", force_diff_on_retry=False):
         self.op_id = "op-free-lane-test"
+        self.provider_route = "background"
         self.syntax_retry_feedback = syntax_retry_feedback
+        self.force_diff_on_retry = force_diff_on_retry
 
     def with_syntax_retry_feedback(self, feedback):
-        return _RetryableCtx(syntax_retry_feedback=feedback)
+        # PRESERVES sibling fields, because the real implementation is
+        # `dataclasses.replace(self, ...)` and replace copies everything it is
+        # not told to change. A double that rebuilds from scratch silently
+        # drops whatever a caller stamped just before — which is exactly how
+        # this fixture hid the truncation reshape.
+        return _RetryableCtx(
+            syntax_retry_feedback=feedback,
+            force_diff_on_retry=self.force_diff_on_retry,
+        )
+
+    def with_forced_diff_retry(self):
+        return _RetryableCtx(
+            syntax_retry_feedback=self.syntax_retry_feedback,
+            force_diff_on_retry=True,
+        )
 
 
 class _Candidates:
@@ -1306,3 +1322,145 @@ async def test_a_non_syntax_failure_is_not_retried(free_lane):
 
 def test_syntax_repair_defaults_on(cg):
     assert cg._syntax_repair_enabled() is True
+
+
+# ===========================================================================
+# Phase 5 -- local as PRIMARY when no paid lane exists
+# ===========================================================================
+#
+# `_try_free_lane_dispatch` refused non-cost-optimized routes to protect a cost
+# contract. Soak bt-2026-08-28-100733 showed the cost of that when there IS no
+# contract: a SANCTIONED roadmap op routed STANDARD (the UrgencyRouter keys on
+# SOURCE, so source="roadmap" never reaches BACKGROUND however low its urgency)
+# and died all_providers_exhausted with a warm 32B resident on the GPU.
+
+
+class _PrimaryStub(_FreeLaneStub):
+    async def _try_local_primary(self, context, deadline):
+        mod = importlib.import_module(CG)
+        return await mod.CandidateGenerator._try_local_primary(
+            self, context, deadline,
+        )
+
+
+@pytest.fixture()
+def local_primary(monkeypatch):
+    """`_try_local_primary` bound to a stub, with NO paid credentials."""
+    mod = importlib.import_module(CG)
+    monkeypatch.setattr(mod, "_FREE_LANE_CRED_REFRESH_AT", -1e9)
+    monkeypatch.setenv("JARVIS_LOCAL_PRIME_ENABLED", "true")
+    for k in ("DOUBLEWORD_API_KEY", "ANTHROPIC_API_KEY",
+              "JARVIS_LOCAL_PRIME_PRIMARY_ENABLED"):
+        monkeypatch.delenv(k, raising=False)
+
+    async def _call(stub, route="standard"):
+        ctx = _RetryableCtx()
+        ctx.provider_route = route
+        return await mod.CandidateGenerator._try_local_primary(
+            stub, ctx, object(),
+        )
+
+    return _call
+
+
+@pytest.mark.parametrize("route", ["standard", "immediate", "complex"])
+async def test_local_primary_serves_paid_routes_when_no_paid_lane(
+    local_primary, route,
+):
+    """The regression: a sanctioned STANDARD op must not die exhausted."""
+    good = _Candidates(1)
+    stub = _PrimaryStub(endpoint=EP, result=good)
+
+    assert await local_primary(stub, route=route) is good
+    assert stub.dispatched_to == EP
+
+
+@pytest.mark.parametrize("key", ["DOUBLEWORD_API_KEY", "ANTHROPIC_API_KEY"])
+async def test_local_primary_declines_when_a_paid_lane_exists(
+    local_primary, monkeypatch, key,
+):
+    """One credential is enough to restore the legacy cascade untouched.
+
+    This is the guard that keeps a cloud deployment byte-identical: the
+    predicate asks whether a PAID lane exists, never which route this is.
+    """
+    monkeypatch.setenv(key, "sk-not-a-real-key")
+    stub = _PrimaryStub(endpoint=EP, result=_Candidates(1))
+
+    assert await local_primary(stub) is None
+    assert stub.dispatched_to is None
+
+
+async def test_local_primary_master_off_restores_fallback_only(
+    local_primary, monkeypatch,
+):
+    monkeypatch.setenv("JARVIS_LOCAL_PRIME_PRIMARY_ENABLED", "0")
+    stub = _PrimaryStub(endpoint=EP, result=_Candidates(1))
+
+    assert await local_primary(stub) is None
+
+
+async def test_local_primary_requires_a_reachable_endpoint(local_primary):
+    """A flag is not evidence; an endpoint that answers is."""
+    stub = _PrimaryStub(endpoint=None, result=_Candidates(1))
+
+    assert await local_primary(stub) is None
+
+
+async def test_local_primary_failure_falls_through_to_the_cascade(local_primary):
+    """The local lane may only ADD a way to succeed, never a way to die."""
+    stub = _PrimaryStub(
+        endpoint=EP, result=None, dispatch_raises=RuntimeError("engine down"),
+    )
+
+    assert await local_primary(stub) is None
+
+
+# ---------------------------------------------------------------------------
+# Truncation-shaped failures reshape the retry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("msg,expected", [
+    ("unterminated string literal (detected at line 231)", True),
+    ("unterminated triple-quoted string literal", True),
+    ("unexpected EOF while parsing", True),
+    ("'(' was never closed", True),
+    ("expected an indented block", True),
+    ("invalid syntax", False),
+    ("unindent does not match any outer indentation level", False),
+])
+def test_truncation_classifier(cg, msg, expected):
+    """Truncation is a cut-off payload; a typo is not. They need opposite
+    remedies, so the classifier must not blur them."""
+    assert cg._truncation_shaped([{"message": msg}]) is expected
+
+
+async def test_truncation_reshapes_the_retry_instead_of_repeating_it(free_lane):
+    """A cut-off payload must be retried SMALLER, not identically.
+
+    Measured: line 231 unterminated -> retry -> line 196 unterminated. The
+    model was not mis-typing; its output was being cut off, and the second
+    attempt was cut off earlier. `force_diff_on_retry` is the existing seam
+    for changing output SHAPE rather than repeating parameters.
+    """
+    trunc = [{
+        "file_path": "tests/x.py", "line": 231,
+        "message": "unterminated string literal (detected at line 231)",
+        "source_line": '    assert x == "abc',
+    }]
+    stub = _SyntaxThenSuccessStub(EP, _Candidates(1))
+    stub._first_failures = trunc
+
+    async def _dispatch(context, deadline, endpoint):
+        stub.dispatch_calls += 1
+        stub.last_context = context
+        if stub.dispatch_calls == 1:
+            raise _syntax_exc(trunc)
+        return stub._result
+
+    stub._failover_local_dispatch = _dispatch
+    assert await free_lane(stub) is stub._result
+    assert getattr(stub.last_context, "force_diff_on_retry", False) is True, (
+        "a truncation-shaped failure must reduce the output shape on retry"
+    )


### PR DESCRIPTION
Four related changes from one investigation: why a **sanctioned** operation
still could not run on a host whose GPU held a warm 32B the entire time.

## 1. Local engine as primary, not fallback

`_try_free_lane_dispatch` reached BACKGROUND and SPECULATIVE only, refusing the
rest to protect a cost contract — *"a STANDARD op has a working cascade and an
explicit cost contract; quietly moving it onto a local model would change what
the operator paid for."* Sound while a paid lane exists.

Soak `bt-2026-08-28-100733` showed the cost when none does: a sanctioned
roadmap op routed STANDARD — the `UrgencyRouter` keys on **source**, so
`source="roadmap"` never reaches BACKGROUND however low its urgency — and died
`all_providers_exhausted:circuit_breaker_tripped` with the 32B resident and idle.

The gate is `_free_lane_active()`, and **the choice of predicate is the design**:
it never asks *which route is this* (route names are the hardcoded mapping that
caused the bug), it asks *does any paid lane exist at all* — local configured
**and** both credentials absent, `.env` re-read on a TTL so a key added mid-run
revokes it instantly. No paid lane ⇒ no cost contract to protect. One present ⇒
returns `None`, every route cascades byte-identically. Pinned for both
`DOUBLEWORD_API_KEY` and `ANTHROPIC_API_KEY`.

**Measured** (`bt-2026-08-28-104222`): 17 interceptions — 11 `complex`, 4
`background`, 2 `standard`; exhaustion fell from dominant to 2 residual
breaker/deadline cases; spend `$0.00`.

## 2. Ordering — a regression I introduced, and the fix

Local-primary first sat **above** `_maybe_swarm_short_circuit`. On a host with
no paid credential it answered every op first, so the swarm interceptor was
never reached: soak `bt-2026-08-28-111858` logged **zero** occurrences of
`"swarm"` with `JARVIS_SWARM_ROUTING_ENABLED=true`.

Enabling the chunker and then short-circuiting past it is *worse* than leaving
it off, because the telemetry claims it is on.

| stage | question it answers |
|---|---|
| swarm short-circuit | **what** to generate — slice a 75-line symbol from a 10,923-line file |
| local-primary | **who** generates it — engine selection |

Scope reduction is what makes a 32,768-token ceiling sufficient; choosing the
engine first discards it. Both still precede every route handler, preserving §1.

## 3. Syntax feedback, and the truncation reshape it exposed

`ast.parse` rejected candidates and the `SyntaxError` was **logged and dropped**,
so `all_candidates_syntax_error` was terminal on a lane with nowhere to escalate
(`syntax_escalation` cascades DW → J-Prime, and here the local 32B *is*
J-Prime). A model cannot correct an error it is never shown.

Both rejection sites now capture file, line, message and the offending source
line, carried on `OperationContext.syntax_retry_feedback` — the same seam as
`force_diff_on_retry`, hash-chain-advanced so the retry is auditable as a
distinct attempt.

The first live firing then **disproved the naive reading**: line 231
`unterminated string literal` → retry → line **196**, same class. Not a typo —
the output was *cut off*, and the retry was cut off earlier.
`_truncation_shaped()` classifies the CPython wordings meaning "stopped early"
and routes those to `force_diff_on_retry` instead of another whole-file attempt.
Deliberately asymmetric: reshaping unnecessarily costs a smaller output; failing
to reshape costs the op.

## 4. Episodic summary clamp — measured first, then bounded

Before building anything I measured: the window is count-bounded (8), recall is
count-bounded, and `Episode.render()` emits **one line per episode** — injection
is ~150–300 tokens against 32,768, **under 1%**. A dynamic token-budget
allocator would have hardened a 1% path while a **390% overrun** went untouched.

`summary` was the one unbounded input. `_clamp_summary` bounds it at **record**
time, not render, because an oversized summary also enters the durable
hash-chained receipt — trimming only at display would leave the ledger carrying
what the prompt refuses to show. Marked `…[+N chars]` so a reader can tell short
from truncated. A guard against a future caller, not a present bug.

## Tests

**206 passed / 1 skipped** across six suites.

A test caught a modelling error in its own double: `_RetryableCtx` rebuilt
context from scratch where the real `dataclasses.replace` preserves siblings,
silently dropping the reshape flag it was meant to prove.

## Known-not-done

- **The corrected ordering has unit coverage but no soak yet.** The run that
  would prove `ASTChunker` slices the symbol is queued behind an in-flight
  session. §2 is proven by *absence* (zero `"swarm"` lines) and by tests, not by
  a positive production observation.
- Config stays outside the repo — `.env`, `.jarvis/roadmap.yaml` and
  `.superpowers/sdd/progress.md` are gitignored — so this changes **no default
  behaviour on a host with a paid credential**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the local engine serve any route when no paid provider is configured, so sanctioned ops no longer die exhausted with an idle local model; with a paid key present, dispatch stays byte-identical. Also feeds parse errors back to the model, retries truncation-shaped failures with a reduced output shape, and clamps episodic summaries.

**Details**
- Local-primary now runs after the swarm short-circuit, fixing a regression where the swarm interceptor was never reached.
- Truncation-shaped parse failures (`unterminated string literal`, `unexpected EOF`, …) retry via `force_diff_on_retry`; other syntax errors get feedback-only retries.
- Episodic summaries are clamped to 240 chars at record time and marked `…[+N chars]` when truncated, configurable via `JARVIS_EPISODIC_SUMMARY_MAX_CHARS`.

**Rollout**
- All new behavior is gated by env masters (`JARVIS_LOCAL_PRIME_PRIMARY_ENABLED`, `JARVIS_TRUNCATION_RESHAPE_ENABLED`) that default on but are inert without a reachable local endpoint, so hosts with paid credentials are unaffected.
- The corrected dispatch ordering is unit-tested but has not yet run a soak with the swarm chunker enabled.

<sup>Written for commit bbbe435a44e137382df99bd4c986d1b77dab001c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

