### PR TITLE
feat(resolver): a signed target symbol is an instruction, not a hint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ dist/
 .env.production.local
 .env.*.bak
 .env.bak
+# Dated backups (.env.bak.20260828) match neither pattern above: one is an
+# exact name, the other demands a .bak SUFFIX. An untracked file here makes the
+# tree dirty, and a dirty tree blocks battle-test accumulation branch creation.
+.env.bak*
 
 # IDE files
 # `.vscode/*`, NOT `.vscode/` — git does not descend into an ignored

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3159,7 +3159,7 @@ def _declared_symbols_for(context: Any, file_path: str) -> Tuple[str, ...]:
             return ()
 
         from backend.core.ouroboros.governance.delegated_provenance import (
-            _verified_roadmap,  # noqa: PLC0415 — verifies signature internally
+            _verified_roadmap,  # noqa: PLC0415 — REPORTS a verdict; see below
         )
         # (verdict, document) — NOT the other way round. Getting this
         # backwards yields a verdict object with no `.goals`, and the broad
@@ -3167,7 +3167,19 @@ def _declared_symbols_for(context: Any, file_path: str) -> Tuple[str, ...]:
         # empty result: declared symbols would simply never work, with nothing
         # in the log to say why.
         _verdict, doc = _verified_roadmap()
-        if doc is None:
+        # It RETURNS THE DOCUMENT REGARDLESS OF VERDICT — it reports
+        # verification, it does not enforce it. Gating on `doc is None` alone
+        # would honour a roadmap whose signature is invalid, tampered or absent
+        # and hand back its symbols at confidence 1.0 — precisely the forgery
+        # this function's pointer-only contract exists to prevent, and it would
+        # silently defeat an operator's JARVIS_ROADMAP_READER_REQUIRE_SIGNATURE.
+        # Demand BOTH properties, the same pair `delegated_provenance` demands
+        # of this same call: the cryptographic fact AND the verdict, because the
+        # reader permits an unsigned dev-mode (REQUIRE_SIGNATURE=false) that
+        # must never confer a target.
+        if doc is None or not bool(getattr(doc, "signature_valid", False)):
+            return ()
+        if str(getattr(_verdict, "value", _verdict)) != "valid":
             return ()
         for goal in getattr(doc, "goals", ()) or ():
             if getattr(goal, "goal_id", "") != goal_id:

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -59,7 +59,10 @@ import time
 from datetime import datetime, timedelta, timezone
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, Dict, List, NoReturn, Optional, Protocol, Tuple, runtime_checkable
+from typing import (
+    Any, Dict, List, Mapping, NoReturn, Optional, Protocol, Tuple,
+    runtime_checkable,
+)
 
 from backend.core.ouroboros.governance.op_context import (
     GenerationResult,
@@ -3126,6 +3129,63 @@ def _truncation_reshape_enabled() -> bool:
     return _envb("JARVIS_TRUNCATION_RESHAPE_ENABLED", True)
 
 
+def _declared_symbols_for(context: Any, file_path: str) -> Tuple[str, ...]:
+    """Operator-declared repair targets for *file_path*, from the SIGNED goal.
+
+    Re-derived from ground truth on every call — the op's evidence contributes
+    only a POINTER (``goal_id``), exactly as `verify_provenance_claim` treats
+    it. Reading the symbol list off the context instead would let a fabricated
+    or hallucinated field name a target the operator never authorised, which
+    is the forgery class Slice 20 exists to prevent.
+
+    Scope is enforced twice over: the goal must be signature-valid, and the
+    file must be inside that goal's own ``target_files``. A declaration cannot
+    reach a file the mandate does not cover.
+
+    Returns () for every op without a verified roadmap claim — which is almost
+    all of them — so the resolver's inference cascade is unchanged for
+    everything else. NEVER raises: a declaration that cannot be proven is
+    simply absent, and absence degrades to inference.
+    """
+    try:
+        claim = None
+        evidence = getattr(context, "evidence", None)
+        if isinstance(evidence, Mapping):
+            claim = evidence.get("provenance")
+        if not isinstance(claim, Mapping):
+            return ()
+        goal_id = str(claim.get("goal_id", "")).strip()
+        if not goal_id:
+            return ()
+
+        from backend.core.ouroboros.governance.delegated_provenance import (
+            _verified_roadmap,  # noqa: PLC0415 — verifies signature internally
+        )
+        # (verdict, document) — NOT the other way round. Getting this
+        # backwards yields a verdict object with no `.goals`, and the broad
+        # except below would have swallowed the AttributeError into a silent
+        # empty result: declared symbols would simply never work, with nothing
+        # in the log to say why.
+        _verdict, doc = _verified_roadmap()
+        if doc is None:
+            return ()
+        for goal in getattr(doc, "goals", ()) or ():
+            if getattr(goal, "goal_id", "") != goal_id:
+                continue
+            targets = tuple(getattr(goal, "target_files", ()) or ())
+            if targets and not any(
+                str(file_path).replace("\\", "/").endswith(
+                    str(t).replace("\\", "/").lstrip("./")
+                )
+                for t in targets
+            ):
+                return ()  # declaration does not cover this file
+            return tuple(getattr(goal, "target_symbols", ()) or ())
+    except Exception:  # noqa: BLE001 — unprovable ⇒ infer, never fabricate
+        return ()
+    return ()
+
+
 def _local_primary_enabled() -> bool:
     """Master for serving ANY route on the local lane when no paid lane exists.
 
@@ -4337,6 +4397,11 @@ class CandidateGenerator:
             traceback_frames=self._swarm_frames_from_ctx(context),
             source_loci=target_files,
             goal=getattr(context, "description", "") or "",
+            # Operator-declared targets from the SIGNED roadmap goal this op
+            # traces to. Re-derived from ground truth at read time rather than
+            # taken off the op, so a fabricated context field cannot inject a
+            # target the operator never authorised.
+            declared_symbols=_declared_symbols_for(context, path),
         )
         if not res.resolved:
             logger.info(

--- a/backend/core/ouroboros/governance/roadmap_reader.py
+++ b/backend/core/ouroboros/governance/roadmap_reader.py
@@ -310,6 +310,22 @@ class RoadmapGoal:
     success_criteria: str
     depends_on: Tuple[str, ...]
     max_duration_s: int
+    #: Optional operator-DECLARED repair target inside ``target_files`` — a
+    #: function/class name, or several. Distinct from ``target_files`` in kind,
+    #: not just granularity: a file says WHERE, a symbol says WHAT, and the
+    #: difference decides whether a 10,923-line file or a 75-line function is
+    #: handed to a 32,768-token model.
+    #:
+    #: It was already covered by the signature (``_build_signing_payload``
+    #: signs the whole ``goals`` list) but silently dropped here, so a goal
+    #: could DECLARE its target and still be resolved by keyword guessing —
+    #: observed in soak bt-2026-08-28-115654, which chose
+    #: ``_read_with_truncation`` at confidence 0.50 over the declared
+    #: ``_should_use_lean_prompt``. Signed intent outranks inference.
+    #:
+    #: Empty tuple = not declared; every consumer must keep inferring, so a
+    #: roadmap written before this field parses and behaves exactly as before.
+    target_symbols: Tuple[str, ...] = ()
     schema_version: str = ROADMAP_READER_SCHEMA_VERSION
 
     def to_dict(self) -> Dict[str, Any]:
@@ -495,6 +511,19 @@ def _parse_goal_entry(entry: Any) -> Optional[RoadmapGoal]:
             if isinstance(f, (str, bytes, int, float))
             and str(f).strip()
         )
+        # Accept both spellings: ``target_symbol`` (one) and
+        # ``target_symbols`` (several). An operator writing one symbol should
+        # not have to know the field is plural, and a schema that punishes the
+        # singular is a schema people get wrong silently.
+        _sym_raw = entry.get("target_symbols")
+        if _sym_raw is None:
+            _sym_raw = entry.get("target_symbol")
+        if isinstance(_sym_raw, (str, bytes)):
+            _sym_raw = [_sym_raw]
+        target_symbols = tuple(
+            str(s).strip() for s in (_sym_raw or ())
+            if isinstance(s, (str, bytes)) and str(s).strip()
+        )
         success = str(entry.get("success_criteria", "") or "")
         depends_raw = entry.get("depends_on") or ()
         depends_on = tuple(
@@ -515,6 +544,7 @@ def _parse_goal_entry(entry: Any) -> Optional[RoadmapGoal]:
             success_criteria=success,
             depends_on=depends_on,
             max_duration_s=max(0, max_dur),
+            target_symbols=target_symbols,
         )
     except Exception:  # noqa: BLE001
         return None

--- a/backend/core/ouroboros/governance/target_symbol_resolver.py
+++ b/backend/core/ouroboros/governance/target_symbol_resolver.py
@@ -61,6 +61,7 @@ _DEFAULT_MAX_CLUSTER = 6
 _MAX_PRIMARY_ENV = "JARVIS_SYMBOL_RESOLVER_MAX_PRIMARY"
 _DEFAULT_MAX_PRIMARY = 4
 
+METHOD_DECLARED = "declared_symbol"
 METHOD_STACK_TRACE = "stack_trace"
 METHOD_GOAL_KEYWORD = "goal_keyword"
 METHOD_UNRESOLVED = "unresolved"
@@ -312,6 +313,7 @@ def resolve_target_symbols(
     traceback_frames: Sequence[str] = (),
     source_loci: Sequence[str] = (),
     goal: str = "",
+    declared_symbols: Sequence[str] = (),
     min_confidence: Optional[float] = None,
     expand_cluster: Optional[bool] = None,
 ) -> ResolutionResult:
@@ -336,25 +338,76 @@ def resolve_target_symbols(
             "PlanGenerator._extract_symbols", file_path, len(top_level_universe),
         )
 
-    # ── Pass 1: deterministic stack-trace mapping ──
     primaries: List[_SymDef] = []
     method = METHOD_UNRESOLVED
     confidence = 0.0
     loci = {os.path.basename(p) for p in source_loci or ()}
-    for frame_file, line, func in _parse_frames(traceback_frames):
-        in_this_file = _file_matches(frame_file, file_path) or (
-            os.path.basename(frame_file) in loci and os.path.basename(frame_file) == os.path.basename(file_path)
-        )
-        if not in_this_file:
-            continue
-        hit = _enclosing(index, line)
-        if hit is None and func in by_base:      # line drifted → func-name tie-break
-            hit = by_base[func]
-        if hit is not None and hit.name not in {p.name for p in primaries}:
-            primaries.append(hit)
-    if primaries:
-        method = METHOD_STACK_TRACE
-        confidence = 1.0
+
+    # ── Pass 0: operator-DECLARED symbols ──────────────────────────────────
+    # Ordered ahead of every inference pass because it is not an inference.
+    # A stack trace is evidence, a goal keyword is a guess, and a declared
+    # symbol is an INSTRUCTION — carried on a goal whose HMAC the risk engine
+    # has already verified before the op was allowed to exist at all.
+    #
+    # Measured cost of not having this (soak bt-2026-08-28-115654): a goal
+    # declaring `_should_use_lean_prompt` resolved instead to
+    # `_read_with_truncation` at confidence 0.50, because the only signal that
+    # reached here was prose and the prose said "truncation" more often than it
+    # said the symbol's name. The declaration existed; nothing read it.
+    #
+    # Confidence 1.0, matching METHOD_STACK_TRACE: both are facts rather than
+    # scores, so neither should be filterable by a confidence floor an operator
+    # raised to suppress weak keyword guesses.
+    #
+    # Names are matched against the file's OWN symbol index, so a declaration
+    # naming something absent from this file resolves nothing here and the
+    # inference passes still run — a typo degrades to the old behaviour instead
+    # of fabricating a target.
+    declared = tuple(
+        str(s).strip() for s in (declared_symbols or ()) if str(s).strip()
+    )
+    if declared:
+        _wanted = {d for d in declared}
+        for sym in index:
+            if sym.name in _wanted or sym.basename in _wanted:
+                if sym.name not in {p.name for p in primaries}:
+                    primaries.append(sym)
+        if primaries:
+            method = METHOD_DECLARED
+            confidence = 1.0
+            logger.info(
+                "[TargetSymbolResolver] %s: DECLARED target(s) honoured %s "
+                "(operator-signed; inference passes skipped)",
+                file_path, [p.name for p in primaries],
+            )
+        else:
+            logger.info(
+                "[TargetSymbolResolver] %s: declared symbol(s) %s not present "
+                "in this file — falling back to inference",
+                file_path, list(declared),
+            )
+
+    # ── Pass 1: deterministic stack-trace mapping ──
+    # Guarded on `not primaries` for the same reason Pass 2 already is: a
+    # declared target must not be widened by frames it did not ask for, and
+    # `if primaries:` below would otherwise relabel a DECLARED result as
+    # STACK_TRACE even with zero frames parsed — a resolution reporting a
+    # provenance it does not have.
+    if not primaries:
+        for frame_file, line, func in _parse_frames(traceback_frames):
+            in_this_file = _file_matches(frame_file, file_path) or (
+                os.path.basename(frame_file) in loci and os.path.basename(frame_file) == os.path.basename(file_path)
+            )
+            if not in_this_file:
+                continue
+            hit = _enclosing(index, line)
+            if hit is None and func in by_base:      # line drifted → func-name tie-break
+                hit = by_base[func]
+            if hit is not None and hit.name not in {p.name for p in primaries}:
+                primaries.append(hit)
+        if primaries:
+            method = METHOD_STACK_TRACE
+            confidence = 1.0
 
     # ── Pass 2: deterministic goal keyword match (NO LLM) ──
     if not primaries and goal.strip():
@@ -428,6 +481,7 @@ def _to_public(sym: _SymDef, *, is_cluster: bool) -> ResolvedSymbol:
 
 __all__ = [
     "METHOD_GOAL_KEYWORD",
+    "METHOD_DECLARED",
     "METHOD_STACK_TRACE",
     "METHOD_UNRESOLVED",
     "ResolutionResult",

--- a/tests/governance/test_declared_target_symbols.py
+++ b/tests/governance/test_declared_target_symbols.py
@@ -1,0 +1,177 @@
+"""Operator-declared repair targets: signed intent outranks inference.
+
+`resolve_target_symbols` had two ways to find a repair target — a stack trace
+(evidence) and goal-text keyword scoring (a guess) — and no way to be TOLD one.
+So a roadmap goal could DECLARE its target and still be resolved by keyword
+matching, which is what happened in soak bt-2026-08-28-115654: a goal naming
+`_should_use_lean_prompt` resolved to `_read_with_truncation` at confidence
+0.50, because the only signal reaching the resolver was prose and the prose
+said "truncation" more often than it said the symbol's name.
+
+The declaration was not missing. `_build_signing_payload` signs the whole
+`goals` list, so `target_symbol` was covered by the HMAC — and then dropped by
+`RoadmapGoal`, which had no such field. Signed intent was being discarded one
+layer below the signature that protected it.
+
+Consequence, on the goal that motivated this: the op was scoped to
+providers.py entire (10,923 lines, ~126,600 tokens) against a 32,768-token
+local model — a 3.9x overrun that makes truncation arithmetic, not luck. The
+declared symbol is 75 lines, ~750 tokens: a 169x reduction.
+"""
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from backend.core.ouroboros.governance.target_symbol_resolver import (
+    METHOD_DECLARED,
+    METHOD_GOAL_KEYWORD,
+    METHOD_STACK_TRACE,
+    resolve_target_symbols,
+)
+
+# Deliberately keyword-hostile: the prose is dense with words matching the
+# WRONG symbol, so a passing result cannot be keyword scoring getting lucky.
+_SOURCE = textwrap.dedent('''
+    def _read_with_truncation(path):
+        """Truncation truncation truncation."""
+        return path
+
+    def _should_use_lean_prompt(ctx):
+        """The symbol the operator actually declared."""
+        return bool(ctx)
+
+    class Helper:
+        def truncate_helper(self):
+            return 1
+''')
+
+_HOSTILE_GOAL = "fix the truncation truncation truncation behaviour"
+
+
+def test_declared_symbol_beats_keyword_inference():
+    """The regression: a declaration must not lose to prose."""
+    inferred = resolve_target_symbols(
+        source=_SOURCE, file_path="providers.py", goal=_HOSTILE_GOAL,
+    )
+    declared = resolve_target_symbols(
+        source=_SOURCE, file_path="providers.py", goal=_HOSTILE_GOAL,
+        declared_symbols=("_should_use_lean_prompt",),
+    )
+
+    assert declared.method == METHOD_DECLARED
+    assert "_should_use_lean_prompt" in declared.primary
+    # And it genuinely changed the outcome — otherwise this test proves nothing.
+    assert inferred.primary != declared.primary
+
+
+def test_declared_symbol_is_confidence_one():
+    """A declaration is a fact, like a stack trace — not a score.
+
+    It must not be filterable by a confidence floor an operator raised to
+    suppress weak keyword guesses.
+    """
+    res = resolve_target_symbols(
+        source=_SOURCE, file_path="providers.py", goal=_HOSTILE_GOAL,
+        declared_symbols=("_should_use_lean_prompt",),
+        min_confidence=0.99,
+    )
+
+    assert res.confidence == 1.0
+    assert res.method == METHOD_DECLARED
+
+
+def test_a_declaration_naming_nothing_here_degrades_to_inference():
+    """A typo must not fabricate a target.
+
+    Matching is against the file's OWN symbol index, so a name absent from
+    this file resolves nothing and the inference passes still run — the
+    failure mode of a wrong declaration is "no worse than before", never
+    "confidently wrong".
+    """
+    res = resolve_target_symbols(
+        source=_SOURCE, file_path="providers.py", goal=_HOSTILE_GOAL,
+        declared_symbols=("_no_such_symbol_anywhere",),
+    )
+
+    assert res.method != METHOD_DECLARED
+    assert "_no_such_symbol_anywhere" not in res.primary
+
+
+def test_declaration_does_not_absorb_unrelated_stack_frames():
+    """A declared target must not be widened by frames it did not ask for.
+
+    `if primaries:` after the stack-trace pass would otherwise relabel a
+    DECLARED result as STACK_TRACE with zero frames parsed — a resolution
+    reporting a provenance it does not have.
+    """
+    frames = ['File "providers.py", line 2, in _read_with_truncation']
+    res = resolve_target_symbols(
+        source=_SOURCE, file_path="providers.py", goal=_HOSTILE_GOAL,
+        traceback_frames=frames,
+        declared_symbols=("_should_use_lean_prompt",),
+    )
+
+    assert res.method == METHOD_DECLARED
+    assert "_read_with_truncation" not in res.primary
+
+
+def test_no_declaration_leaves_the_cascade_untouched():
+    """Every op without a roadmap claim — nearly all of them — is unchanged."""
+    res = resolve_target_symbols(
+        source=_SOURCE, file_path="providers.py",
+        traceback_frames=['File "providers.py", line 2, in _read_with_truncation'],
+    )
+
+    assert res.method == METHOD_STACK_TRACE
+    assert res.confidence == 1.0
+
+
+@pytest.mark.parametrize("declared", [(), None, ("",), ("   ",)])
+def test_empty_declarations_are_inert(declared):
+    """Blank/absent declarations must not short-circuit inference."""
+    res = resolve_target_symbols(
+        source=_SOURCE, file_path="providers.py", goal="lean prompt",
+        declared_symbols=declared,
+    )
+
+    assert res.method in (METHOD_GOAL_KEYWORD, "unresolved")
+
+
+# ---------------------------------------------------------------------------
+# Reader: the field must survive parsing, in either spelling
+# ---------------------------------------------------------------------------
+
+
+def _goal_from(entry: dict):
+    from backend.core.ouroboros.governance.roadmap_reader import (
+        _parse_goal_entry,
+    )
+    return _parse_goal_entry(entry)
+
+
+@pytest.mark.parametrize("key", ["target_symbol", "target_symbols"])
+def test_reader_accepts_both_spellings(key):
+    """An operator writing ONE symbol should not have to know the field is
+    plural. A schema that punishes the singular is one people get wrong
+    silently — and silence is what this whole defect was made of."""
+    goal = _goal_from({
+        "id": "g1", "title": "t", "description": "d",
+        "target_files": ["backend/x.py"],
+        key: "_should_use_lean_prompt",
+    })
+
+    assert goal is not None
+    assert goal.target_symbols == ("_should_use_lean_prompt",)
+
+
+def test_reader_defaults_to_empty_for_older_roadmaps():
+    """A roadmap written before this field parses and behaves as before."""
+    goal = _goal_from({
+        "id": "g1", "title": "t", "description": "d",
+        "target_files": ["backend/x.py"],
+    })
+
+    assert goal is not None
+    assert goal.target_symbols == ()

--- a/tests/governance/test_declared_target_symbols.py
+++ b/tests/governance/test_declared_target_symbols.py
@@ -175,3 +175,130 @@ def test_reader_defaults_to_empty_for_older_roadmaps():
 
     assert goal is not None
     assert goal.target_symbols == ()
+
+
+# ---------------------------------------------------------------------------
+# The TRUST BOUNDARY itself.
+#
+# `_declared_symbols_for` is what turns a signed roadmap into a confidence-1.0
+# instruction, and it shipped with NO test of its own: the suite above proves
+# the resolver honours a declaration, and the reader parses one, but nothing
+# proved WHERE a declaration is allowed to come from. That gap is how the
+# function came to gate on `doc is None` alone.
+#
+# `_verified_roadmap()` RETURNS THE DOCUMENT REGARDLESS OF VERDICT — it reports
+# verification, it does not enforce it. So `doc is not None` says only "a file
+# was parsed", never "an operator signed it". These tests pin BOTH properties,
+# the same pair `delegated_provenance` demands of the same call.
+# ---------------------------------------------------------------------------
+
+
+class _Verdict:
+    def __init__(self, value):
+        self.value = value
+
+
+class _Goal:
+    goal_id = "g1"
+    target_files = ("backend/core/ouroboros/governance/providers.py",)
+    target_symbols = ("_should_use_lean_prompt",)
+
+
+class _Doc:
+    goals = (_Goal(),)
+
+    def __init__(self, signature_valid):
+        self.signature_valid = signature_valid
+
+
+class _Ctx:
+    evidence = {"provenance": {"goal_id": "g1"}}
+
+
+_PATH = "backend/core/ouroboros/governance/providers.py"
+
+
+def _declared_with(monkeypatch, verdict_value, signature_valid):
+    from backend.core.ouroboros.governance import delegated_provenance
+    from backend.core.ouroboros.governance.candidate_generator import (
+        _declared_symbols_for,
+    )
+    monkeypatch.setattr(
+        delegated_provenance, "_verified_roadmap",
+        lambda: (_Verdict(verdict_value), _Doc(signature_valid)),
+    )
+    return _declared_symbols_for(_Ctx(), _PATH)
+
+
+def test_a_validly_signed_roadmap_confers_the_declared_target(monkeypatch):
+    """The positive control. Without this the refusals below could pass for
+    the trivial reason that the function never returns anything at all."""
+    assert _declared_with(monkeypatch, "valid", True) == (
+        "_should_use_lean_prompt",
+    )
+
+
+@pytest.mark.parametrize(
+    "verdict_value",
+    ["invalid_signature", "tampered", "missing", "invalid_format", "expired"],
+)
+def test_an_unverified_roadmap_confers_nothing(monkeypatch, verdict_value):
+    """Every non-valid verdict must refuse. A tampered or unsigned roadmap
+    that still named a target would hand an attacker who can write
+    `.jarvis/roadmap.yaml` a confidence-1.0 instruction — the exact forgery
+    this function's pointer-only contract exists to prevent, and a silent
+    defeat of the operator's JARVIS_ROADMAP_READER_REQUIRE_SIGNATURE."""
+    assert _declared_with(monkeypatch, verdict_value, True) == ()
+
+
+def test_the_cryptographic_fact_is_demanded_not_just_the_verdict(monkeypatch):
+    """The reader permits an unsigned dev-mode (REQUIRE_SIGNATURE=false) that
+    can report `valid` for a document carrying no signature at all. The
+    verdict alone is therefore not sufficient — `delegated_provenance` demands
+    both of this same call, and so must this."""
+    assert _declared_with(monkeypatch, "valid", False) == ()
+
+
+def test_a_declaration_cannot_reach_a_file_its_goal_does_not_cover(monkeypatch):
+    """Scope is enforced twice over. Even validly signed, a goal may only
+    direct the files inside its own `target_files`."""
+    from backend.core.ouroboros.governance import delegated_provenance
+    from backend.core.ouroboros.governance.candidate_generator import (
+        _declared_symbols_for,
+    )
+    monkeypatch.setattr(
+        delegated_provenance, "_verified_roadmap",
+        lambda: (_Verdict("valid"), _Doc(True)),
+    )
+    assert _declared_symbols_for(_Ctx(), "backend/core/unrelated.py") == ()
+
+
+def test_an_unavailable_roadmap_degrades_to_inference(monkeypatch):
+    """No roadmap is not an error — it is the ordinary case for almost every
+    op. It must return empty, never raise."""
+    from backend.core.ouroboros.governance import delegated_provenance
+    from backend.core.ouroboros.governance.candidate_generator import (
+        _declared_symbols_for,
+    )
+    monkeypatch.setattr(
+        delegated_provenance, "_verified_roadmap", lambda: (None, None),
+    )
+    assert _declared_symbols_for(_Ctx(), _PATH) == ()
+
+
+def test_an_op_with_no_provenance_pointer_declares_nothing(monkeypatch):
+    """The op contributes only a POINTER. An op without one gets inference,
+    and a context cannot smuggle a symbol list in by another route."""
+    from backend.core.ouroboros.governance.candidate_generator import (
+        _declared_symbols_for,
+    )
+
+    class _Bare:
+        evidence = {}
+
+    class _Forged:
+        # A fabricated field naming a target directly, with no goal_id.
+        evidence = {"target_symbols": ["_should_use_lean_prompt"]}
+
+    assert _declared_symbols_for(_Bare(), _PATH) == ()
+    assert _declared_symbols_for(_Forged(), _PATH) == ()


### PR DESCRIPTION
`resolve_target_symbols` could find a repair target two ways — a **stack trace**
(evidence) and **goal-text keyword scoring** (a guess) — and had no way to be
*told* one. So a roadmap goal could **declare** its target and still be resolved
by keyword matching.

Measured, soak `bt-2026-08-28-115654`: a goal naming `_should_use_lean_prompt`
resolved instead to `_read_with_truncation` at **confidence 0.50**, because the
only signal reaching the resolver was prose — and the prose said "truncation"
more often than it said the symbol's name.

## The declaration was never missing

`_build_signing_payload` signs the whole `goals` list, so `target_symbol` was
**covered by the HMAC** — and then dropped by `RoadmapGoal`, which had no such
field. Signed operator intent was being discarded one layer below the signature
protecting it.

The cost on the goal that motivated this:

| | |
|---|---|
| scoped payload | `providers.py` entire — 10,923 lines, **~126,600 tokens** |
| model ceiling | **32,768 tokens** |
| overrun | **3.9×** — truncation is arithmetic, not luck |
| declared symbol | `_should_use_lean_prompt`, lines 3284–3358 — 75 lines, **~750 tokens** |

A **169× reduction**, and the difference between *impossible* and *0.02% of the
window*.

## Four layers now carry what one signature already covered

1. **`RoadmapGoal.target_symbols`** — parsed, accepting **both** `target_symbol`
   (one) and `target_symbols` (several). An operator writing one symbol
   shouldn't have to know the field is plural; a schema that punishes the
   singular is one people get wrong *silently*, and silence is what this whole
   defect was made of. Defaults to `()`, so an older roadmap is unchanged.
2. **`_declared_symbols_for()`** — re-derives from the **verified** roadmap on
   every call. The op's evidence contributes only a `goal_id` *pointer*, exactly
   as `verify_provenance_claim` treats it: reading the symbol list off the
   context would let a fabricated field name a target the operator never
   authorised — the forgery class Slice 20 exists to prevent. Scope enforced
   twice: signature-valid goal **and** file inside that goal's `target_files`.
3. **`METHOD_DECLARED`**, ordered ahead of both inference passes. A stack trace
   is evidence, a keyword is a guess, a declaration is an **instruction** on a
   goal whose HMAC was verified before the op was allowed to exist. Confidence
   **1.0**, matching `METHOD_STACK_TRACE` — both are facts, not scores, so
   neither should be filterable by a floor raised to suppress weak guesses.
4. **Pass 1 guarded on `not primaries`.** `if primaries:` after the stack-trace
   loop would otherwise relabel a DECLARED result as STACK_TRACE with zero
   frames parsed — a resolution reporting a provenance it does not have.

## Resilience

Names match against the file's **own** symbol index, so a declaration naming
something absent resolves nothing here and the inference passes still run. A
typo degrades to the previous behaviour rather than fabricating a target: wrong
declarations are *no worse than before*, never *confidently wrong*.

## Two bugs this found in my own code

Both invisible to a syntax check, and both of a kind the broad `except` would
have swallowed into a silent empty result — the feature would simply never work,
with nothing in the log to say why:

- `Mapping` used but never imported (`NameError` at runtime).
- `_verified_roadmap()` returns `(verdict, document)` — I had the tuple
  backwards, yielding a verdict object with no `.goals`.

Both surfaced only because the change was proven against the **live signed
roadmap** rather than trusted on AST-OK.

## Verification

Against that roadmap, end to end:

| check | result |
|---|---|
| reader parses signed field | `('_should_use_lean_prompt',)` |
| without declaration | `unresolved 0.0` |
| **with declaration** | **`declared_symbol 1.0`** |
| bogus declaration | degrades to inference, does not fabricate |
| resulting slice | lines 3284–3358 |

**12 new tests; 274 passed / 1 skipped** across six suites.

Not yet soak-proven — the run that exercises this in production is next. Config
stays outside the repo (`.env`, `.jarvis/roadmap.yaml`,
`.superpowers/sdd/progress.md` are gitignored), and ops without a verified
roadmap claim — nearly all of them — take the unchanged inference cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes roadmap goals able to declare their repair target symbol, and gives those declarations precedence over stack-trace and keyword inference, so a signed goal's explicit choice is no longer overridden by keyword scoring. Declarations are only honored when the roadmap's HMAC signature holds, so an unsigned or tampered roadmap cannot aim the resolver at a target.

**What changed**
- `RoadmapGoal` now accepts `target_symbol` (singular) or `target_symbols` (plural); older roadmaps parse to an empty tuple and behave exactly as before.
- A new `METHOD_DECLARED` pass runs before inference, matches declared names against the file's own symbol index, and reports confidence 1.0.
- Declarations are re-derived from the verified roadmap via a `goal_id` pointer, never from unverified context. The guard requires both `signature_valid` and verdict `valid`, the same pair `delegated_provenance` demands; previously `doc is None` was the only check, so an invalid signature still conferred a target.
- A declaration naming an absent symbol degrades to inference — it never fabricates a target.
- A declared result is no longer relabeled as stack-trace by pass 1.
- Fixes two runtime errors: missing `Mapping` import and wrong tuple order from `_verified_roadmap()`.
- `.gitignore` now covers dated `.env.bak*` backups, which left the tree dirty and blocked battle-test branch creation.
- Adds tests pinning the trust boundary; 6 of the new cases fail without the signature fix.

<sup>Written for commit cb49f4f110931e90778d51b44922876e21d361a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

