### PR TITLE
test(roadmap): stop test fixtures writing into the production audit ledger

### DIFF
--- a/tests/governance/test_roadmap_orchestrator_integration.py
+++ b/tests/governance/test_roadmap_orchestrator_integration.py
@@ -64,6 +64,7 @@ _DECOMP_LEDGER_FLAG = "JARVIS_GOAL_DECOMPOSITION_LEDGER_PATH"
 #   orchestrator ledger = "...ORCHESTRATION_LEDGER_PATH"
 #   orchestrator completion ledger reader =
 #                    "...ORCHESTRATION_COMPLETION_LEDGER_PATH"
+_READER_LEDGER_FLAG = "JARVIS_ROADMAP_READER_LEDGER_PATH"
 _ORCH_LEDGER_FLAG = "JARVIS_MULTI_STEP_ORCHESTRATION_LEDGER_PATH"
 _ORCH_COMPLETION_LEDGER_FLAG = (
     "JARVIS_MULTI_STEP_ORCHESTRATION_COMPLETION_LEDGER_PATH"
@@ -85,7 +86,8 @@ def _isolate(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> Iterator[None]:
-    """Enable all 4 master flags + redirect every ledger to tmp."""
+    """Enable all 4 master flags + redirect every ledger AND the roadmap
+    source to tmp. "Every" is load-bearing: it was previously only three."""
     monkeypatch.setenv(_MASTER_FLAG, "true")
     monkeypatch.setenv(_READER_MASTER, "true")
     monkeypatch.setenv(_DECOMP_MASTER, "true")
@@ -106,6 +108,24 @@ def _isolate(
     monkeypatch.setenv(
         _ORCH_COMPLETION_LEDGER_FLAG,
         str(tmp_path / "goal_decomp_ledger.jsonl"),
+    )
+    # The RoadmapReader's own audit ledger. Omitting it did not fail a test —
+    # it appended fixture rows (goal_id "g-idem", operator_id
+    # "test@operator.local") to the PRODUCTION
+    # `.jarvis/roadmap_reader_ledger.jsonl` on every run, so a §8 append-only
+    # audit of operator intent silently accumulated events no operator caused.
+    # Nothing reads this ledger back, which is exactly why it went unnoticed:
+    # the damage is to the audit trail's truthfulness, not to control flow.
+    monkeypatch.setenv(
+        _READER_LEDGER_FLAG,
+        str(tmp_path / "roadmap_reader_ledger.jsonl"),
+    )
+    # Pin the roadmap SOURCE too. `_READER_PATH_FLAG` was declared and never
+    # used, leaving reads to fall through to the production `.jarvis/`
+    # roadmap — so these tests' results depended on an operator's live file.
+    monkeypatch.setenv(
+        _READER_PATH_FLAG,
+        str(tmp_path / "roadmap.yaml"),
     )
     yield
 


### PR DESCRIPTION
The `_isolate` autouse fixture promised *"redirect every ledger to tmp"* and redirected three of four. The fourth was the RoadmapReader's own audit ledger, so every run of these 26 tests appended fixture rows to the production `.jarvis/roadmap_reader_ledger.jsonl`.

Observed rows: `goal_id "g-idem"`, `operator_id "test@operator.local"`, title "Trivial goal" — written at 23:36 by a test invocation, not by any operator.

Nothing reads that ledger back, which is exactly why it survived: no test could fail from it. The damage is to the audit trail's truthfulness. It is a §8 append-only record of operator intent that accumulated events no operator caused. The fix stops the writes; it does not prune the file.

`_READER_PATH_FLAG` was the same gap twice — declared and never used, leaving the reader's *source* to fall through to the production `.jarvis/roadmap.yaml`, so results depended on whatever an operator had signed locally. Both now pinned to `tmp_path`.

**Verified by measurement:** production ledger 33 lines before the suite, 33 after. 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rakB8XYr6EMrfCD8UHrUy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes test isolation in the roadmap orchestrator integration suite so tests no longer write fixture rows to the production audit ledger or read from the live roadmap file.

- The `_isolate` fixture now pins the RoadmapReader's audit ledger and source path to `tmp_path`.
- Existing rows already in the production ledger are not pruned.

<sup>Written for commit 868abab233d3d5e09526aa39e5a3220f2db64649. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

