### PR TITLE
fix(a1): raise roadmap ignition router-ready budget from 60s to 600s

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -2475,14 +2475,35 @@ class GovernedLoopService:
                             _a1_router_is_ready = None
                             _a1_get_bus = None
                         if _a1_await_ready is not None:
+                            # 600s, not 60s. This budget is not the router's
+                            # own work — it is everything the router waits
+                            # BEHIND during a cold boot: 24 sensors
+                            # registering, the embedding service loading its
+                            # ONNX weights, the Aegis daemon binding a port.
+                            # Measured on the reference workstation (soak
+                            # bt-2026-08-30-070418): the breaker fired at
+                            # +2m12s while the wall-clock watchdog did not
+                            # arm until +4m38s, and full boot ran 6-7 min. A
+                            # 60s budget could therefore NEVER be met on that
+                            # host, so the very first sanctioned roadmap goal
+                            # aborted before the daemon emitted anything.
+                            #
+                            # The breaker itself is correct and stays: on a
+                            # clean not-ready it raises rather than looping a
+                            # goal into a void (the A1 run #15 silent-DLQ).
+                            # Only its calibration was wrong — it was sized
+                            # for a warm process, not a cold organism. A
+                            # too-SHORT deadline on a boot path is not a
+                            # safety property; it is an outage that reports
+                            # itself as one.
                             try:
                                 _a1_timeout = float(
                                     (os.environ.get(
                                         "JARVIS_A1_ROUTER_READY_TIMEOUT_S", ""
-                                    ) or "60").strip()
+                                    ) or "600").strip()
                                 )
                             except (TypeError, ValueError):
-                                _a1_timeout = 60.0
+                                _a1_timeout = 600.0
                             # Task 2 — CIRCUIT BREAKER: capture the readiness
                             # result. Fail-OPEN only on an UNEXPECTED valve error
                             # (infra hiccup) so a transient bus glitch doesn't


### PR DESCRIPTION
The roadmap ignition daemon waits for the intake router's dispatch loop before emitting an operator's signed goal, and raises on a clean not-ready rather than looping a goal into a void. That behaviour is correct and unchanged.

Its **budget** was wrong. `JARVIS_A1_ROUTER_READY_TIMEOUT_S` defaulted to 60s — which is not the router's own work, but everything it queues behind during a cold boot: 24 sensors registering, the embedding service loading ONNX weights, the Aegis daemon binding a port.

**Measured** (soak `bt-2026-08-30-070418`, reference workstation):

```
00:04:19  process start
00:06:31  CRITICAL [A1] roadmap daemon CIRCUIT BREAKER — intake router
          not ready within 60s; aborting roadmap ignition
00:08:57  wall-clock watchdog arms (+4m38s)
~6-7 min  full boot
```

The breaker fired **two and a half minutes before the watchdog on the same boot even armed**. 60s could never be met on this host, so the first sanctioned roadmap goal aborted before the daemon emitted anything — and the abort raises, so there is no retry.

**Proven by the next run** (`bt-2026-08-30-072704`, same host, 600s): `CIRCUIT BREAKER` 0 occurrences, `STRATEGIC IGNITION MESH live` present, and the reader ledger records the goal emitting:

```json
{"kind":"emit","goal_id":"docs-skip-tools-gate-drift","emitted":true}
```

**Why the old value looked fine:** a dormant daemon and an aborted daemon are indistinguishable from outside — both yield a session with no roadmap goal. With the master gate (`JARVIS_ROADMAP_ORCHESTRATOR_ENABLED`, §33.1 default-FALSE) off, this path had almost certainly never run on this hardware. The timeout was sized for a warm process and met a cold organism only once the gate was armed.

Only the fallback moved; the env override is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rakB8XYr6EMrfCD8UHrUy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the roadmap ignition router-ready timeout from 60s to 600s so cold boots no longer abort before the intake router becomes ready.

The old 60s default could never be met on cold boot, causing the first sanctioned goal to abort. Proven by the next run with 600s where the goal emitted successfully. The env override is unchanged; only the fallback moved.

<sup>Written for commit 579db7076bc0b7b653a0d4861fd6609129fe8b7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

