### PR TITLE
fix(intake): signed operator intent must not park behind unsigned sensor noise

### DIFF
--- a/backend/core/ouroboros/governance/background_agent_pool.py
+++ b/backend/core/ouroboros/governance/background_agent_pool.py
@@ -753,6 +753,40 @@ class BackgroundAgentPool:
 
     # -- Submit / Query ------------------------------------------------------
 
+    def _authority_headroom_slots(self) -> int:
+        """Slots reserved for authority-backed work. Dynamic, never a constant.
+
+        A RATIO of the configured queue size (``JARVIS_BG_AUTHORITY_HEADROOM_
+        RATIO``, default 0.125 -> 2 of 16) so it tracks the pool as the
+        operator sizes it. Floored at 1 so any queue of two or more keeps a
+        lane open, and capped at ``_queue_size - 1`` so the reservation can
+        never starve ordinary work to a standstill. NEVER raises.
+        """
+        try:
+            size = int(self._queue_size)
+        except (TypeError, ValueError):
+            return 0
+        if size < 2:
+            return 0                      # nothing to partition
+        try:
+            raw = os.environ.get(
+                "JARVIS_BG_AUTHORITY_HEADROOM_RATIO", ""
+            ).strip()
+            ratio = float(raw) if raw else 0.125
+        except (TypeError, ValueError):
+            ratio = 0.125
+        if ratio <= 0.0:
+            return 0                      # explicitly disabled
+        slots = int(round(size * ratio))
+        return max(1, min(slots, size - 1))
+
+    def _ordinary_soft_capacity(self) -> int:
+        """Queue depth beyond which ordinary (unsigned) work is deferred."""
+        try:
+            return max(1, int(self._queue_size) - self._authority_headroom_slots())
+        except (TypeError, ValueError):
+            return max(1, int(getattr(self, "_queue_size", 1) or 1))
+
     async def submit(self, op_context: OperationContext) -> str:
         """Submit an operation for background processing.
 
@@ -804,6 +838,38 @@ class BackgroundAgentPool:
         else:
             _priority = _ROUTE_PRIORITY.get(_route, 3)
         self._submit_counter += 1
+
+        # ── AUTHORITY HEADROOM ────────────────────────────────────────────
+        # `put_nowait` on a bounded queue rejects by CAPACITY, and capacity is
+        # priority-blind: a sovereign-priority op is refused exactly like
+        # trivia once the queue is full. The `_priority` computed above
+        # governs DEQUEUE ORDER only, so it cannot help an op that was never
+        # admitted. Measured, soak bt-2026-08-30-093912: an operator's signed
+        # goal reached the HEAD of the WAL re-drain (`wal_replay_reordered
+        # head_moved=True`) and still never dispatched -- 215
+        # `pool_capacity_full` parks -- because being first in line does not
+        # help when the line never moves.
+        #
+        # So ordinary work is capped BELOW the hard queue bound, leaving a
+        # reserve that only authority-backed work may enter. This is the same
+        # admission-partition idea the router applies at intake, one layer
+        # down, and it is what makes the priority tiers above actually
+        # reachable under saturation.
+        #
+        # The reserve is derived from the CONFIGURED capacity, never a fixed
+        # count: a ratio of `_queue_size`, floored at one slot so any pool of
+        # two or more always keeps a lane open, and clamped to leave at least
+        # one slot for ordinary work so background traffic can never be
+        # starved to a standstill by the reservation itself.
+        if not bool(getattr(op_context, "operator_authority", False)):
+            _soft_cap = self._ordinary_soft_capacity()
+            if self._queue.qsize() >= _soft_cap:
+                raise QueueFullError(
+                    f"Background queue at ordinary-work capacity "
+                    f"({self._queue.qsize()}/{_soft_cap} of "
+                    f"{self._queue_size}; authority headroom reserved). "
+                    f"Operation {op_id} deferred."
+                )
 
         try:
             self._queue.put_nowait((_priority, self._submit_counter, op))

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3129,6 +3129,50 @@ def _truncation_reshape_enabled() -> bool:
     return _envb("JARVIS_TRUNCATION_RESHAPE_ENABLED", True)
 
 
+def _provenance_claim_from_ctx(context: Any) -> Optional[Mapping]:
+    """The op's roadmap provenance CLAIM, read from where it actually rides.
+
+    THE CARRIER IS NOT `ctx.evidence`. `roadmap_reader` attaches the claim to
+    the ENVELOPE (`evidence["provenance"] = claim_for_goal(goal.goal_id)`), and
+    the dispatch path snapshots that dict onto `ctx.intake_evidence_json` — a
+    JSON STRING. An `OperationContext` has no `.evidence` mapping at all, so a
+    reader written against one always saw nothing and silently degraded to
+    inference.
+
+    Measured, soak bt-2026-08-30-145744: the operator's signed goal reached
+    the resolver and came back `goal_keyword (conf=1.00)` — the right symbol,
+    found by scoring prose, while the DECLARATION that names it exactly sat
+    unread one attribute away. The declared pass has therefore never fired in
+    production; it was reachable only from tests that hand-built a context
+    with a `.evidence` dict no dispatch path produces. That is the same shape
+    as the `Mapping`-import defect: a feature that cannot work, with nothing
+    in the log to say so.
+
+    Reads the JSON carrier FIRST (the production shape, exactly as
+    `_swarm_frames_from_ctx` does with the same attribute — one parsing idiom
+    for one field), then falls back to a live `.evidence` mapping for callers
+    that hold an envelope-shaped object. NEVER raises; any miss returns None
+    and the resolver's inference cascade runs unchanged.
+    """
+    raw = getattr(context, "intake_evidence_json", "") or ""
+    if raw:
+        try:
+            import json as _json  # noqa: PLC0415
+            data = _json.loads(raw)
+            if isinstance(data, Mapping):
+                claim = data.get("provenance")
+                if isinstance(claim, Mapping):
+                    return claim
+        except (ValueError, TypeError):
+            pass
+    evidence = getattr(context, "evidence", None)
+    if isinstance(evidence, Mapping):
+        claim = evidence.get("provenance")
+        if isinstance(claim, Mapping):
+            return claim
+    return None
+
+
 def _declared_symbols_for(context: Any, file_path: str) -> Tuple[str, ...]:
     """Operator-declared repair targets for *file_path*, from the SIGNED goal.
 
@@ -3148,10 +3192,7 @@ def _declared_symbols_for(context: Any, file_path: str) -> Tuple[str, ...]:
     simply absent, and absence degrades to inference.
     """
     try:
-        claim = None
-        evidence = getattr(context, "evidence", None)
-        if isinstance(evidence, Mapping):
-            claim = evidence.get("provenance")
+        claim = _provenance_claim_from_ctx(context)
         if not isinstance(claim, Mapping):
             return ()
         goal_id = str(claim.get("goal_id", "")).strip()
@@ -3678,6 +3719,71 @@ class CandidateGenerator:
         # ``self._counters`` above.
         from ._governance_state import get_jprime_state
         self._jprime_state = get_jprime_state()
+
+    # ------------------------------------------------------------------
+    # Swarm generation client — resolved, never assigned
+    # ------------------------------------------------------------------
+    @property
+    def _client(self) -> Any:
+        """The provider the symbol-sliced swarm path generates through.
+
+        THIS ATTRIBUTE NEVER EXISTED. `ce141a7af8` wired the Agentic Swarm
+        seam with three reads of `self._client` and no writer anywhere in the
+        class, which sets `_primary` / `_fallback` / `_tier0` / `_jprime`. The
+        path could not crash while nothing reached it: five upstream gates
+        (the §33.1 master, the A1 breaker, intake backpressure, WAL re-drain
+        order, pool capacity) each stopped the first operator-signed goal
+        before generation. Soak bt-2026-08-30-145744 cleared the last of them
+        and the seam raised `AttributeError` on its first execution ever.
+
+        LOCAL FIRST, AND NOT AS A PREFERENCE. Binding this to `_primary`
+        would have been the obvious repair and the wrong one: on a host whose
+        cloud tiers answer 402, `_primary` is a funded-endpoint handle with no
+        funding. That trades an AttributeError for a payment failure — the
+        same dead end, wearing a costlier and more confusing error. The
+        resident model is not a fallback here; it is the lane that can
+        actually serve.
+
+        Resolution order — local, then whatever else is configured:
+
+          1. `_jprime`  — the resident zero-marginal-cost lane. Chosen when it
+             can generate, which on a free-lane host is the only true answer.
+             `_free_lane_active()` is consulted for TELEMETRY-grade certainty
+             (it means "local is the ONLY lane"), never as a gate: a host that
+             has both should still spend nothing on a pure-completion node
+             repair.
+          2. `_primary`, `_tier0`, `_fallback` — in the class's own declared
+             order, for a deployment where local inference is unconfigured.
+
+        Every candidate must expose `generate`; a handle that does not is
+        skipped rather than returned, because returning it only defers the
+        AttributeError to a deeper frame. `None` when nothing qualifies —
+        the caller declines the swarm and the standard route runs unchanged,
+        which is the same outcome as before this property existed.
+
+        A PROPERTY, NOT AN ASSIGNMENT, because the answer is not fixed for
+        the life of the generator: a lane can be reconfigured, and a
+        credential can appear mid-session (`_free_lane_active` re-reads `.env`
+        on a TTL for exactly that reason). Resolving per access keeps this
+        honest; caching it would pin a stale topology.
+        """
+        for name in ("_jprime", "_primary", "_tier0", "_fallback"):
+            handle = getattr(self, name, None)
+            if handle is None:
+                continue
+            if not callable(getattr(handle, "generate", None)):
+                continue
+            if name == "_jprime":
+                try:
+                    logger.debug(
+                        "[CandidateGenerator] swarm client=local jprime "
+                        "free_lane=%s", _free_lane_active(),
+                    )
+                except Exception:  # noqa: BLE001 — telemetry only
+                    pass
+            return handle
+        return None
+
         self._jprime_sem = self._jprime_state.jprime_sem
         self._jprime_counters = self._jprime_state.counters
 

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -5746,6 +5746,21 @@ class CandidateGenerator:
                 "[CandidateGenerator] Context-Hardware Negotiator: VRAM-safe "
                 "num_ctx=%d for the 32B at %s op=%s", _num_ctx, endpoint, _op,
             )
+            # PUBLISH the negotiated window. It was previously a local override
+            # that died with this dispatch, so every client built outside this
+            # path -- L2 Repair's most consequentially -- saw `num_ctx=None`,
+            # lost the streaming inter-token watchdog, and fell to the legacy
+            # total-duration branch with a cold seed sized for a small model.
+            # One negotiation, every consumer: no duplicated VRAM probe, no
+            # second policy, and nothing static (absent a negotiation the
+            # registry stays empty and behaviour is unchanged).
+            try:
+                from backend.core.ouroboros.governance.local_inference_director import (  # noqa: PLC0415, E501
+                    publish_negotiated_num_ctx as _pub_ctx,
+                )
+                _pub_ctx(endpoint, int(_num_ctx))
+            except Exception:  # noqa: BLE001 — publication is additive
+                pass
 
         # Stateful, session-scoped Latency Profiler kept PER ENDPOINT on this
         # generator (EWMA survives across ops + L7 retries -- cures profiler

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -21,7 +21,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from backend.core.ouroboros.governance.operation_id import generate_operation_id
 
@@ -297,6 +297,84 @@ _URGENCY_BOOST: Dict[str, int] = {
 
 # Sources that bypass backpressure
 _BACKPRESSURE_EXEMPT = frozenset({"voice_human", "test_failure"})
+
+
+def _operator_authority_exemption_enabled() -> bool:
+    """Master for the signed-intent backpressure exemption. Default ON.
+
+    Falsey restores the pre-existing behaviour exactly: the static
+    ``_BACKPRESSURE_EXEMPT`` set alone decides, and an operator's signed goal
+    parks behind sensor noise as before.
+    """
+    raw = (
+        os.environ.get("JARVIS_SIGNED_INTENT_BACKPRESSURE_EXEMPT", "")
+        .strip()
+        .lower()
+    )
+    return raw in {"", "1", "true", "yes", "on"}
+
+
+def _carries_verified_operator_authority(envelope: Any) -> bool:
+    """True iff *envelope* traces to a goal in a CRYPTOGRAPHICALLY VERIFIED
+    operator roadmap.
+
+    WHY THIS IS NOT ``source == "roadmap"``. The static exemption set encodes
+    one idea — a signal carrying HUMAN authority must not be parked behind
+    machine-generated work. ``voice_human`` is a person speaking now;
+    ``test_failure`` is a runtime fire. An operator-signed goal is delegated
+    human intent, and belongs in that category. But the SOURCE NAME is not the
+    authority: the SIGNATURE is. A roadmap read under dev-mode
+    (``REQUIRE_SIGNATURE=false``), or one an attacker dropped into ``.jarvis/``,
+    presents the identical ``source="roadmap"`` string. Exempting on the name
+    would let unsigned work preempt the queue — the same forgery class the
+    declared-symbol path had to close.
+
+    So authority is RE-DERIVED from ground truth on every call. The envelope
+    contributes only a ``goal_id`` POINTER; the verdict, the signature bytes,
+    and the goal's presence are all read back from the verified document. A
+    fabricated evidence block names a goal that must still exist in a roadmap
+    whose HMAC validates, or it earns nothing.
+
+    Cost is not a concern despite re-deriving: the caller short-circuits, so
+    this runs ONLY when the queue is already past its backpressure threshold
+    AND the source was not already statically exempt — the rare path, never
+    the hot one.
+
+    NEVER raises. Anything unprovable returns False, which means the envelope
+    stays subject to backpressure exactly as before — fail-closed, so a broken
+    reader degrades to the old behaviour rather than opening the gate.
+    """
+    if not _operator_authority_exemption_enabled():
+        return False
+    try:
+        evidence = getattr(envelope, "evidence", None)
+        if not isinstance(evidence, Mapping):
+            return False
+        claim = evidence.get("provenance")
+        if not isinstance(claim, Mapping):
+            return False
+        goal_id = str(claim.get("goal_id", "")).strip()
+        if not goal_id:
+            return False
+
+        from backend.core.ouroboros.governance.delegated_provenance import (  # noqa: PLC0415, E501
+            _verified_roadmap,
+        )
+        verdict, doc = _verified_roadmap()
+        # Both properties, the pair `delegated_provenance` demands of this same
+        # call: the verdict AND the cryptographic fact. The reader permits an
+        # unsigned dev-mode that can report `valid` for a document carrying no
+        # signature at all.
+        if doc is None or not bool(getattr(doc, "signature_valid", False)):
+            return False
+        if str(getattr(verdict, "value", verdict)) != "valid":
+            return False
+        for goal in getattr(doc, "goals", ()) or ():
+            if str(getattr(goal, "goal_id", "")) == goal_id:
+                return True
+        return False
+    except Exception:  # noqa: BLE001 — unprovable => no exemption
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -1522,9 +1600,23 @@ class UnifiedIntakeRouter:
                 return "queued_behind"
 
         # 4. Backpressure check
+        # Order matters and is load-bearing. The depth probe is cheap and the
+        # authority check re-reads + verifies the roadmap, so the expensive
+        # term is LAST: it evaluates only for a non-exempt source that is
+        # actually about to be rejected. On every healthy tick this short-
+        # circuits before it, costing nothing.
+        #
+        # Step 4 sits UPSTREAM of every adaptive mechanism below it — the
+        # SensorGovernor consult and the QoS aging/starvation escalation at 4b
+        # both live after this return. A signal bounced here never reaches the
+        # machinery designed to rescue a starved one, which is how an
+        # operator's signed goal parked 146 times behind background sensor
+        # noise in soak bt-2026-08-30-072704 while the reader ledger recorded
+        # it as emitted (`idempotency_key: "backpressure"` — this literal).
         if (
             envelope.source not in _BACKPRESSURE_EXEMPT
             and self.intake_queue_depth() >= self._config.backpressure_threshold
+            and not _carries_verified_operator_authority(envelope)
         ):
             return "backpressure"
 

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -2924,6 +2924,90 @@ class UnifiedIntakeRouter:
     # WAL crash recovery
     # ------------------------------------------------------------------
 
+
+    def _replay_ordering_enabled(self) -> bool:
+        """Master for authority-ordered WAL re-drain. Default ON.
+
+        Falsey restores raw insertion order byte-for-byte.
+        """
+        raw = (
+            os.environ.get("JARVIS_WAL_REPLAY_AUTHORITY_ORDER", "")
+            .strip()
+            .lower()
+        )
+        return raw in {"", "1", "true", "yes", "on"}
+
+    def _order_replay_by_authority(
+        self, pending: "List[WALEntry]", IE: Any
+    ) -> "List[WALEntry]":
+        """Order parked WAL rows by the SAME priority the live queue uses.
+
+        THE DEFECT THIS CLOSES. `_replay_wal` iterated `pending` in raw
+        insertion order. A row's position was therefore decided by WHEN the
+        pool happened to be full when it arrived — not by what it is. Under
+        sustained backpressure the parked set is dominated by background
+        sensor churn, so an operator's signed goal re-dispatches somewhere in
+        the middle of a queue of trivia, every drain, forever. Admission was
+        fixed at intake step 4; this is the second half of the same problem,
+        one layer down: winning the door does not help if the re-drain then
+        deals you back into the pack.
+
+        NO NEW PRIORITY VOCABULARY. Ordinary rows are scored by the module's
+        own `_compute_priority` — the identical function the live queue uses,
+        so replay order and queue order cannot drift into disagreement.
+        Authority-backed rows take `_sovereign_human_priority()`, the existing
+        dynamic anchor whose docstring already states the invariant this needs
+        ("a live human intent can never be starved"): it is derived from
+        `_PRIORITY_MAP`'s own floor with an env-tunable margin, so nothing here
+        is a hardcoded tier.
+
+        STABILITY IS LOAD-BEARING. Python's sort is stable, so rows of equal
+        priority keep their insertion order — the ordering ADDS a tier
+        discipline over FIFO rather than replacing it with churn, and a drain
+        that repeats cannot reshuffle equals into a different order each time.
+
+        NEVER RAISES. A row whose envelope will not rebuild, or whose scoring
+        throws, keeps a neutral key and stays in place; any failure of the sort
+        as a whole returns `pending` untouched. The replay path must survive a
+        malformed row, because the alternative is losing durably parked work.
+        """
+        if not self._replay_ordering_enabled() or len(pending) < 2:
+            return pending
+        try:
+            neutral = 0
+            try:
+                neutral = max(_PRIORITY_MAP.values()) + 1
+            except (ValueError, TypeError):
+                neutral = 100
+
+            def _key(entry: Any) -> int:
+                try:
+                    envelope = IE.from_dict(entry.envelope_dict)
+                except Exception:  # noqa: BLE001 — unrebuildable: leave in place
+                    return neutral
+                try:
+                    if _carries_verified_operator_authority(envelope):
+                        return _sovereign_human_priority()
+                except Exception:  # noqa: BLE001
+                    pass
+                try:
+                    score, _ = _compute_priority(envelope)
+                    return int(score)
+                except Exception:  # noqa: BLE001
+                    return neutral
+
+            ordered = sorted(pending, key=_key)
+            if ordered and ordered[0] is not pending[0]:
+                logger.info(
+                    "[Router] wal_replay_reordered n=%d head_moved=True "
+                    "(authority/priority ahead of insertion order)",
+                    len(ordered),
+                )
+            return ordered
+        except Exception:  # noqa: BLE001 — ordering is an optimisation, never a risk
+            logger.debug("[Router] replay ordering skipped", exc_info=True)
+            return pending
+
     async def _replay_wal(
         self, pending: Optional[List[WALEntry]] = None
     ) -> None:
@@ -2942,6 +3026,7 @@ class UnifiedIntakeRouter:
         logger.info("Router: replaying %d pending WAL entries", len(pending))
         from .intent_envelope import IntentEnvelope as IE
 
+        pending = self._order_replay_by_authority(pending, IE)
         for entry in pending:
             try:
                 envelope = IE.from_dict(entry.envelope_dict)

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -2757,6 +2757,21 @@ class UnifiedIntakeRouter:
             _a1trace("submit", ctx.op_id, target="GLS")
         except Exception:  # noqa: BLE001
             pass
+        # AUTHORITY STAMP. The pool cannot re-verify an HMAC on its submit
+        # path -- it has no roadmap reader and no business growing one. So the
+        # layer that ALREADY established authority at intake step 4 records
+        # the finding on the context, and the pool reads the finding. Same
+        # trust boundary as `provider_route`: an internal field set by the
+        # component that computed it, never parsed from an outside claim.
+        # Absent or False => the op is ordinary, which is the old behaviour.
+        try:
+            setattr(
+                ctx,
+                "operator_authority",
+                bool(_carries_verified_operator_authority(envelope)),
+            )
+        except Exception:  # noqa: BLE001 — a stamp must never fail a submit
+            pass
         try:
             _submit_fn = getattr(self._gls, "submit_background", None)
             if _submit_fn is not None:

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -16,7 +16,7 @@ import os
 import threading
 import time
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, replace as _dc_replace
 from typing import Any, Deque, Dict, List, Optional, Tuple
 
 from .memory_pressure_gate import PressureLevel, get_default_gate, is_enabled as memory_gate_enabled
@@ -727,6 +727,58 @@ class LatencyProfiler:
         return elapsed_ms > (m + 3.0 * sd_eff)
 
 
+# ---------------------------------------------------------------------------
+# Negotiated-context registry — one negotiation, every consumer
+# ---------------------------------------------------------------------------
+# The Context-Hardware Negotiator derives a VRAM-safe ``num_ctx`` from MEASURED
+# hardware, but it ran inside ONE dispatch path and its result died there as a
+# local override. `LocalConfig.from_env()` reads `JARVIS_LOCAL_NUM_CTX`, which
+# is deliberately unset on a machine that autodetects — so every client built
+# outside that path got ``num_ctx=None`` and fell to the legacy survival branch:
+# no streaming inter-token watchdog, and a flat cold seed sized for a small
+# model.
+#
+# Measured, soak bt-2026-08-30-155721: the main path negotiated
+# ``num_ctx=32768`` 69 times while L2 Repair -- calling the SAME provider object
+# by a different route -- timed out at ``budget=30000ms warm=False`` against a
+# cold 32B, cascading 7 ops into ``l2_cancelled``.
+#
+# Publishing the negotiated value per endpoint keeps ONE negotiation (no
+# duplicated VRAM probing, no second policy) and lets any client inherit it.
+# The value is never a constant: absent a negotiation, the registry is empty
+# and behaviour is byte-identical to before.
+_NEGOTIATED_NUM_CTX: Dict[str, int] = {}
+_NEGOTIATED_LOCK = threading.Lock()
+
+
+def publish_negotiated_num_ctx(endpoint: str, num_ctx: int) -> None:
+    """Record the Negotiator's VRAM-safe window for *endpoint*. NEVER raises."""
+    try:
+        key = str(endpoint or "").strip()
+        value = int(num_ctx or 0)
+        if not key or value <= 0:
+            return
+        with _NEGOTIATED_LOCK:
+            _NEGOTIATED_NUM_CTX[key] = value
+    except Exception:  # noqa: BLE001 — telemetry-grade, never fatal
+        return
+
+
+def negotiated_num_ctx(endpoint: str) -> Optional[int]:
+    """The negotiated window for *endpoint*, or None if never negotiated."""
+    try:
+        with _NEGOTIATED_LOCK:
+            return _NEGOTIATED_NUM_CTX.get(str(endpoint or "").strip())
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def reset_negotiated_num_ctx_for_tests() -> None:
+    """Test hook — the registry is process-wide by design."""
+    with _NEGOTIATED_LOCK:
+        _NEGOTIATED_NUM_CTX.clear()
+
+
 class LocalLatencyLockup(RuntimeError):
     """Raised when local inference breaches the adaptive/ceiling timeout.
 
@@ -1261,6 +1313,35 @@ class LocalPrimeClient:
                              total_ms=total_ms, output_tokens=out_toks)
         return LocalCompletion(text=text, output_tokens=out_toks, ttft_ms=ttft_ms, total_ms=total_ms)
 
+    def _inherit_negotiated_num_ctx(self) -> None:
+        """Adopt this endpoint's negotiated window when this client has none.
+
+        A client built straight from env has ``num_ctx=None`` on a host that
+        autodetects, because the value is DERIVED from measured VRAM rather
+        than configured. Inheriting the published figure puts every consumer
+        -- L2 Repair included -- on the same streaming inter-token watchdog and
+        the same context-aware cold seed as the main dispatch path, instead of
+        the legacy total-duration branch.
+
+        Only ever FILLS A GAP: an explicitly configured or already-negotiated
+        window is left exactly as it is, so a caller that chose a smaller
+        window keeps it. No negotiation published => unchanged. NEVER raises.
+        """
+        try:
+            if self._cfg.num_ctx:
+                return
+            inherited = negotiated_num_ctx(getattr(self._cfg, "base_url", ""))
+            if not inherited:
+                return
+            self._cfg = _dc_replace(self._cfg, num_ctx=int(inherited))
+            logger.info(
+                "[LocalPrimeClient] inherited negotiated num_ctx=%d for %s "
+                "(streaming watchdog armed; legacy survival branch bypassed)",
+                int(inherited), getattr(self._cfg, "base_url", "?"),
+            )
+        except Exception:  # noqa: BLE001 — inheritance is additive, never fatal
+            return
+
     async def complete_guarded(self, *, system: str, user: str, prompt_tokens: int,
                                temperature: float = 0.2,
                                max_tokens: "Optional[int]" = None) -> LocalCompletion:
@@ -1268,6 +1349,7 @@ class LocalPrimeClient:
         # Inter-Token Watchdog inside _complete_streaming is the sole guard -- a
         # model that keeps emitting tokens runs indefinitely; only a STALL trips it.
         # This is the mathematically-robust replacement for guessing total latency.
+        self._inherit_negotiated_num_ctx()
         if self._cfg.num_ctx and _streaming_enabled():
             logger.info(
                 "[LocalPrimeClient] streaming generation (inter-token watchdog=%.0fs, "

--- a/tests/governance/test_authority_headroom.py
+++ b/tests/governance/test_authority_headroom.py
@@ -1,0 +1,112 @@
+"""A bounded queue rejects by capacity, and capacity is priority-blind.
+
+`BackgroundAgentPool.submit` computes a rich priority -- sovereign human,
+resurrection, route tier -- and then calls `put_nowait`. On a full bounded
+queue that raises regardless of priority, so the tiers govern DEQUEUE ORDER
+and cannot help an op that was never admitted.
+
+Measured, soak bt-2026-08-30-093912: an operator's signed goal reached the
+HEAD of the WAL re-drain (`wal_replay_reordered head_moved=True`, batches of
+178/71/144) and still never dispatched -- 215 `pool_capacity_full` parks.
+Being first in line does not help when the line never moves.
+
+Ordinary work is now capped BELOW the hard bound, leaving a reserve only
+authority-backed work may enter.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.background_agent_pool import (
+    BackgroundAgentPool,
+)
+
+
+class _Pool(BackgroundAgentPool):
+    """Only the sizing surface is needed; no event loop, no workers."""
+    def __init__(self, queue_size):
+        self._queue_size = queue_size
+
+
+@pytest.mark.parametrize(
+    "size,reserved,soft",
+    [(16, 2, 14), (8, 1, 7), (4, 1, 3), (2, 1, 1)],
+)
+def test_headroom_scales_with_configured_capacity(size, reserved, soft):
+    """The reserve is a RATIO of the configured queue, never a fixed count --
+    it tracks the pool as the operator sizes it."""
+    p = _Pool(size)
+    assert p._authority_headroom_slots() == reserved
+    assert p._ordinary_soft_capacity() == soft
+
+
+def test_a_reserve_always_leaves_room_for_ordinary_work():
+    """The reservation must never starve background traffic to a standstill:
+    soft capacity stays >= 1 at every size."""
+    for size in range(1, 65):
+        p = _Pool(size)
+        assert p._ordinary_soft_capacity() >= 1
+        assert p._authority_headroom_slots() <= max(0, size - 1)
+
+
+def test_a_queue_too_small_to_partition_degrades_to_old_behaviour():
+    """size < 2 cannot be split; reserve 0 so nothing changes."""
+    p = _Pool(1)
+    assert p._authority_headroom_slots() == 0
+
+
+def test_ratio_is_env_tunable(monkeypatch):
+    """No hardcoded policy: the operator sets the split."""
+    monkeypatch.setenv("JARVIS_BG_AUTHORITY_HEADROOM_RATIO", "0.5")
+    p = _Pool(16)
+    assert p._authority_headroom_slots() == 8
+    assert p._ordinary_soft_capacity() == 8
+
+
+def test_ratio_zero_disables_the_reservation(monkeypatch):
+    """An explicit opt-out restores the pre-existing admission exactly."""
+    monkeypatch.setenv("JARVIS_BG_AUTHORITY_HEADROOM_RATIO", "0")
+    p = _Pool(16)
+    assert p._authority_headroom_slots() == 0
+    assert p._ordinary_soft_capacity() == 16
+
+
+@pytest.mark.parametrize("bad", ["", "abc", "-1"])
+def test_a_malformed_ratio_never_raises(monkeypatch, bad):
+    """Admission must survive a typo in an env var."""
+    monkeypatch.setenv("JARVIS_BG_AUTHORITY_HEADROOM_RATIO", bad)
+    p = _Pool(16)
+    slots = p._authority_headroom_slots()
+    assert 0 <= slots <= 15
+
+
+def test_the_submit_path_consults_the_soft_cap():
+    """WIRING PIN. The helpers are useless unless `submit` gates on them, and
+    every test above calls them directly -- blind to an unwired gate."""
+    import ast
+    import io as _io
+
+    import backend.core.ouroboros.governance.background_agent_pool as M
+
+    src = _io.open(M.__file__, encoding="utf-8").read()
+    called = {
+        n.func.attr
+        for n in ast.walk(ast.parse(src))
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+    }
+    assert "_ordinary_soft_capacity" in called, "soft cap is unwired"
+    assert "operator_authority" in src, "authority stamp never read"
+
+
+def test_the_router_stamps_authority_before_submitting():
+    """The other half of the contract: the pool reads a stamp the router must
+    actually write, from the finding it already computed at intake."""
+    import io as _io
+
+    import backend.core.ouroboros.governance.intake.unified_intake_router as R
+
+    src = _io.open(R.__file__, encoding="utf-8").read()
+    assert "operator_authority" in src, "router never stamps authority"
+    assert src.index("operator_authority") < src.index(
+        "_submit_fn = getattr(self._gls"
+    ), "stamp must be written before the submit call"

--- a/tests/governance/test_declared_target_symbols.py
+++ b/tests/governance/test_declared_target_symbols.py
@@ -302,3 +302,122 @@ def test_an_op_with_no_provenance_pointer_declares_nothing(monkeypatch):
 
     assert _declared_symbols_for(_Bare(), _PATH) == ()
     assert _declared_symbols_for(_Forged(), _PATH) == ()
+
+# ---------------------------------------------------------------------------
+# The CARRIER.
+#
+# Every test above hands `_declared_symbols_for` an object with a `.evidence`
+# dict. No dispatch path produces one. `roadmap_reader` attaches the claim to
+# the ENVELOPE and the dispatch path snapshots it onto
+# `ctx.intake_evidence_json` -- a JSON STRING -- so the reader always saw
+# nothing in production and silently degraded to inference.
+#
+# Measured, soak bt-2026-08-30-145744: the signed goal reached the resolver
+# and came back `goal_keyword (conf=1.00)`. The right symbol, found by scoring
+# prose, while the declaration naming it exactly sat unread one attribute
+# away. These tests fix the suite's own blind spot: they drive the shape
+# production actually builds.
+# ---------------------------------------------------------------------------
+import json as _json
+
+from backend.core.ouroboros.governance.candidate_generator import (
+    _provenance_claim_from_ctx,
+)
+
+_CLAIM = {
+    "schema_version": "delegated_provenance.v1",
+    "kind": "roadmap_reader",
+    "goal_id": "g1",
+}
+
+
+class _ProdCtx:
+    """What the dispatch path actually hands the generator."""
+    def __init__(self, claim=_CLAIM):
+        self.intake_evidence_json = _json.dumps({"provenance": claim})
+
+
+class _EnvelopeCtx:
+    """Envelope-shaped: a live evidence mapping, no JSON snapshot."""
+    def __init__(self, claim=_CLAIM):
+        self.evidence = {"provenance": claim}
+
+
+def test_the_production_json_carrier_is_read():
+    """The shape that ships. This is the one that was broken."""
+    assert _provenance_claim_from_ctx(_ProdCtx()) == _CLAIM
+
+
+def test_the_envelope_mapping_still_works():
+    """The fallback must keep serving callers holding an envelope."""
+    assert _provenance_claim_from_ctx(_EnvelopeCtx()) == _CLAIM
+
+
+def test_declared_symbols_resolve_from_the_production_shape(monkeypatch):
+    """End to end on the real carrier: a context with ONLY
+    `intake_evidence_json` must yield the operator's declared symbol."""
+    from backend.core.ouroboros.governance import delegated_provenance
+    from backend.core.ouroboros.governance.candidate_generator import (
+        _declared_symbols_for,
+    )
+
+    class _V:
+        value = "valid"
+
+    class _G:
+        goal_id = "g1"
+        target_files = ("backend/x.py",)
+        target_symbols = ("_should_use_lean_prompt",)
+
+    class _D:
+        signature_valid = True
+        goals = (_G(),)
+
+    monkeypatch.setattr(
+        delegated_provenance, "_verified_roadmap", lambda: (_V(), _D())
+    )
+    assert _declared_symbols_for(_ProdCtx(), "backend/x.py") == (
+        "_should_use_lean_prompt",
+    )
+
+
+@pytest.mark.parametrize("raw", ["", "not json", "[]", '{"provenance": 7}'])
+def test_a_malformed_carrier_never_raises(raw):
+    """A truncated or wrong-typed snapshot degrades to inference, never a
+    crash -- the broad except in the caller would have hidden a raise here."""
+    class _Bad:
+        intake_evidence_json = raw
+
+    assert _provenance_claim_from_ctx(_Bad()) is None
+
+
+def test_a_context_with_neither_carrier_yields_nothing():
+    """The ordinary case for almost every op."""
+    class _Bare:
+        pass
+
+    assert _provenance_claim_from_ctx(_Bare()) is None
+
+
+def test_the_json_carrier_takes_precedence():
+    """When both exist the production snapshot wins -- it is the one the
+    dispatch path authored for THIS op."""
+    class _Both:
+        intake_evidence_json = _json.dumps(
+            {"provenance": {"kind": "roadmap_reader", "goal_id": "from-json"}}
+        )
+        evidence = {"provenance": {"kind": "roadmap_reader",
+                                   "goal_id": "from-mapping"}}
+
+    assert _provenance_claim_from_ctx(_Both())["goal_id"] == "from-json"
+
+
+def test_the_reader_uses_the_same_attribute_the_swarm_path_does():
+    """DRY pin: one parsing idiom for one field. If a future edit invents a
+    second way to reach intake evidence, this fails."""
+    import io as _io
+
+    import backend.core.ouroboros.governance.candidate_generator as M
+
+    src = _io.open(M.__file__, encoding="utf-8").read()
+    assert src.count('getattr(context, "intake_evidence_json", "")') >= 2

--- a/tests/governance/test_negotiated_num_ctx_inheritance.py
+++ b/tests/governance/test_negotiated_num_ctx_inheritance.py
@@ -1,0 +1,118 @@
+"""One negotiation, every consumer.
+
+The Context-Hardware Negotiator derives a VRAM-safe `num_ctx` from MEASURED
+hardware, but the result lived as a local override inside ONE dispatch path.
+`LocalConfig.from_env()` reads `JARVIS_LOCAL_NUM_CTX`, deliberately unset on a
+host that autodetects -- so every client built outside that path got
+`num_ctx=None`, lost the streaming inter-token watchdog, and fell to the legacy
+total-duration branch with a cold seed sized for a small model.
+
+Measured, soak bt-2026-08-30-155721: the main path negotiated `num_ctx=32768`
+69 times while L2 Repair -- calling the SAME provider object by a different
+route -- died at `budget=30000ms warm=False` against a cold 32B, cascading
+seven ops into `l2_cancelled`.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from backend.core.ouroboros.governance import local_inference_director as L
+
+_E = "http://127.0.0.1:11434"
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    L.reset_negotiated_num_ctx_for_tests()
+    yield
+    L.reset_negotiated_num_ctx_for_tests()
+
+
+def _client(num_ctx=None, base_url=_E):
+    cfg = dataclasses.replace(
+        L.LocalConfig.from_env(), base_url=base_url, num_ctx=num_ctx
+    )
+    c = L.LocalPrimeClient.__new__(L.LocalPrimeClient)
+    c._cfg = cfg
+    return c
+
+
+def test_a_client_with_no_window_inherits_the_negotiated_one():
+    """The defect. A client built from env alone must not be left on the
+    legacy branch when the hardware window is already known."""
+    L.publish_negotiated_num_ctx(_E, 32768)
+    c = _client(num_ctx=None)
+    c._inherit_negotiated_num_ctx()
+    assert c._cfg.num_ctx == 32768
+
+
+def test_an_explicit_window_is_never_overwritten():
+    """Inheritance FILLS A GAP. A caller that chose a smaller window keeps it."""
+    L.publish_negotiated_num_ctx(_E, 32768)
+    c = _client(num_ctx=4096)
+    c._inherit_negotiated_num_ctx()
+    assert c._cfg.num_ctx == 4096
+
+
+def test_no_negotiation_leaves_the_client_untouched():
+    """Byte-identical to the previous behaviour when nothing was published."""
+    c = _client(num_ctx=None)
+    c._inherit_negotiated_num_ctx()
+    assert c._cfg.num_ctx is None
+
+
+def test_the_registry_is_per_endpoint():
+    """A second node must not inherit the first node's hardware window."""
+    L.publish_negotiated_num_ctx(_E, 32768)
+    c = _client(num_ctx=None, base_url="http://other:11434")
+    c._inherit_negotiated_num_ctx()
+    assert c._cfg.num_ctx is None
+
+
+@pytest.mark.parametrize("bad", [0, -1, None])
+def test_a_nonsense_window_is_never_published(bad):
+    """A zero or negative window would re-create the survival branch while
+    looking configured."""
+    L.publish_negotiated_num_ctx(_E, bad)
+    assert L.negotiated_num_ctx(_E) is None
+
+
+def test_publication_never_raises_on_a_bad_endpoint():
+    """Publication is additive telemetry; it must never break a dispatch."""
+    L.publish_negotiated_num_ctx("", 32768)
+    L.publish_negotiated_num_ctx(None, 32768)
+    assert L.negotiated_num_ctx("") is None
+
+
+def test_inheritance_arms_the_streaming_path():
+    """The POINT of inheriting: `complete_guarded` chooses streaming (an
+    inter-token watchdog, no total-duration cap) only when num_ctx is set.
+    Without inheritance a cold 32B is judged by a budget it cannot meet."""
+    L.publish_negotiated_num_ctx(_E, 32768)
+    c = _client(num_ctx=None)
+    c._inherit_negotiated_num_ctx()
+    assert bool(c._cfg.num_ctx) and L._streaming_enabled()
+
+
+def test_the_guarded_path_inherits_before_deciding():
+    """WIRING PIN -- inheritance must run BEFORE the streaming branch, or the
+    decision is made on a stale window and the fix is inert."""
+    import inspect
+
+    src = inspect.getsource(L.LocalPrimeClient.complete_guarded)
+    assert "_inherit_negotiated_num_ctx" in src, "inheritance is unwired"
+    assert src.index("_inherit_negotiated_num_ctx") < src.index(
+        "_streaming_enabled()"
+    ), "inheritance must precede the streaming decision"
+
+
+def test_the_negotiator_publishes_its_result():
+    """The other half of the contract: the producer must actually publish."""
+    import io as _io
+
+    import backend.core.ouroboros.governance.candidate_generator as CG
+
+    src = _io.open(CG.__file__, encoding="utf-8").read()
+    assert "publish_negotiated_num_ctx" in src, "negotiator never publishes"

--- a/tests/governance/test_signed_intent_backpressure_exemption.py
+++ b/tests/governance/test_signed_intent_backpressure_exemption.py
@@ -1,0 +1,171 @@
+"""Signed operator intent must not park behind unsigned sensor noise.
+
+Intake step 4 rejects an envelope when the queue is past its backpressure
+threshold and the source is not in a static exemption set. That set sits
+UPSTREAM of every adaptive mechanism in the router: the SensorGovernor consult
+and the QoS aging/starvation escalation both live at step 4b, after this
+return. A signal bounced at 4 never reaches the machinery built to rescue a
+starved one.
+
+Measured, soak bt-2026-08-30-072704: the operator's signed goal
+`docs-skip-tools-gate-drift` emitted with a valid HMAC and was rejected here
+146 times, the reader ledger recording the literal return value of this gate
+as its idempotency key -- `"backpressure"`.
+
+The exemption is derived from the SIGNATURE, never from `source == "roadmap"`.
+A dev-mode read (REQUIRE_SIGNATURE=false) and an attacker-dropped `.jarvis/`
+file both present that same string.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.intake import unified_intake_router as R
+
+
+class _Verdict:
+    def __init__(self, value):
+        self.value = value
+
+
+class _Goal:
+    goal_id = "g-signed"
+
+
+class _Doc:
+    goals = (_Goal(),)
+
+    def __init__(self, signature_valid=True):
+        self.signature_valid = signature_valid
+
+
+class _Env:
+    """Envelope carrying only a POINTER, exactly as production does."""
+    def __init__(self, goal_id="g-signed"):
+        self.evidence = {"provenance": {"goal_id": goal_id}}
+        self.source = "roadmap"
+
+
+def _patch_reader(monkeypatch, verdict, doc):
+    from backend.core.ouroboros.governance import delegated_provenance
+    monkeypatch.setattr(
+        delegated_provenance, "_verified_roadmap", lambda: (verdict, doc)
+    )
+
+
+def test_a_validly_signed_goal_is_exempt(monkeypatch):
+    """The positive control. Without it every refusal below could pass for
+    the trivial reason that the helper never returns True at all."""
+    _patch_reader(monkeypatch, _Verdict("valid"), _Doc(True))
+    assert R._carries_verified_operator_authority(_Env()) is True
+
+
+@pytest.mark.parametrize(
+    "verdict_value",
+    ["invalid_signature", "tampered", "missing", "invalid_format", "expired"],
+)
+def test_an_unverified_roadmap_earns_no_exemption(monkeypatch, verdict_value):
+    """Any non-valid verdict must NOT preempt the queue. Otherwise anyone able
+    to write `.jarvis/roadmap.yaml` could push work past backpressure without
+    holding the HMAC key."""
+    _patch_reader(monkeypatch, _Verdict(verdict_value), _Doc(True))
+    assert R._carries_verified_operator_authority(_Env()) is False
+
+
+def test_the_cryptographic_fact_is_demanded_too(monkeypatch):
+    """The reader permits an unsigned dev-mode that reports `valid` for a
+    document carrying no signature. The verdict alone is insufficient."""
+    _patch_reader(monkeypatch, _Verdict("valid"), _Doc(False))
+    assert R._carries_verified_operator_authority(_Env()) is False
+
+
+def test_a_goal_id_absent_from_the_document_earns_nothing(monkeypatch):
+    """The envelope supplies a pointer, not a claim. A fabricated evidence
+    block must name a goal that actually exists in the verified roadmap."""
+    _patch_reader(monkeypatch, _Verdict("valid"), _Doc(True))
+    assert R._carries_verified_operator_authority(_Env("g-forged")) is False
+
+
+def test_source_name_alone_confers_nothing(monkeypatch):
+    """source == "roadmap" with no provenance pointer is not authority."""
+    _patch_reader(monkeypatch, _Verdict("valid"), _Doc(True))
+
+    class _Bare:
+        source = "roadmap"
+        evidence = {}
+
+    assert R._carries_verified_operator_authority(_Bare()) is False
+
+
+def test_a_broken_reader_fails_closed(monkeypatch):
+    """A reader that raises must degrade to the PREVIOUS behaviour (subject to
+    backpressure), never open the gate."""
+    from backend.core.ouroboros.governance import delegated_provenance
+
+    def _boom():
+        raise RuntimeError("reader down")
+
+    monkeypatch.setattr(delegated_provenance, "_verified_roadmap", _boom)
+    assert R._carries_verified_operator_authority(_Env()) is False
+
+
+def test_master_flag_off_restores_legacy_behaviour(monkeypatch):
+    """Falsey master => byte-identical to the static-set-only gate."""
+    _patch_reader(monkeypatch, _Verdict("valid"), _Doc(True))
+    monkeypatch.setenv("JARVIS_SIGNED_INTENT_BACKPRESSURE_EXEMPT", "false")
+    assert R._carries_verified_operator_authority(_Env()) is False
+
+
+def test_default_is_on(monkeypatch):
+    """Unset means enabled -- the fix is live without operator action."""
+    monkeypatch.delenv(
+        "JARVIS_SIGNED_INTENT_BACKPRESSURE_EXEMPT", raising=False
+    )
+    assert R._operator_authority_exemption_enabled() is True
+
+
+def test_the_static_set_still_stands():
+    """The pre-existing exemptions are untouched -- this ADDS a category, it
+    does not replace one."""
+    assert "voice_human" in R._BACKPRESSURE_EXEMPT
+    assert "test_failure" in R._BACKPRESSURE_EXEMPT
+    # And `roadmap` is deliberately NOT here: the name is not the authority.
+    assert "roadmap" not in R._BACKPRESSURE_EXEMPT
+
+
+def test_the_gate_actually_calls_the_helper():
+    """WIRING PIN. A correct helper that nothing invokes is the failure mode
+    this whole change exists to avoid -- and it is invisible to every test
+    above, which call the helper directly. Pin the call site by AST so the
+    helper cannot be silently orphaned by a later edit.
+
+    Also pins the ORDER: the authority check must come AFTER the depth probe,
+    so the roadmap re-read happens only for an envelope actually about to be
+    rejected. Reversing them turns a rare-path verification into a hot-path
+    one on every single ingest.
+    """
+    import ast
+    import io as _io
+
+    src = _io.open(R.__file__, encoding="utf-8").read()
+    tree = ast.parse(src)
+    called = {
+        n.func.id
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+    }
+    assert "_carries_verified_operator_authority" in called, (
+        "helper is defined but never called -- the gate is unwired"
+    )
+
+    # Bounded window starting at the gate comment; both terms must appear
+    # inside it, with the cheap probe first.
+    start = src.index("# 4. Backpressure check")
+    gate = src[start:start + 2000]
+    assert "intake_queue_depth" in gate, "depth probe missing from the gate"
+    assert "_carries_verified_operator_authority" in gate, (
+        "authority check missing from the gate"
+    )
+    assert gate.index("intake_queue_depth") < gate.index(
+        "_carries_verified_operator_authority"
+    ), "authority check must be last so it short-circuits"

--- a/tests/governance/test_wal_replay_authority_order.py
+++ b/tests/governance/test_wal_replay_authority_order.py
@@ -1,0 +1,157 @@
+"""Parked work must re-drain by what it IS, not by when it was parked.
+
+`_replay_wal` iterated pending WAL rows in raw insertion order, so a row's
+position was decided by WHEN the pool happened to be full when it arrived.
+Under sustained backpressure the parked set is dominated by background sensor
+churn (177 `pool_capacity_full` parks in soak bt-2026-08-30-085852), so an
+operator's signed goal re-dispatches somewhere in the middle of a queue of
+trivia on every drain.
+
+Admission was fixed at intake step 4 -- the ledger went from
+`idempotency_key: "backpressure"` to `"enqueued"`. This is the second half of
+the same problem one layer down: winning the door does not help if the
+re-drain deals you back into the pack.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.intake import unified_intake_router as R
+
+
+class _Entry:
+    """Minimal WAL row: the replay path only reads `.envelope_dict`."""
+    def __init__(self, tag, source="doc_staleness", goal_id=None):
+        self.tag = tag
+        self.envelope_dict = {"tag": tag, "source": source, "goal_id": goal_id}
+
+    def __repr__(self):
+        return "<Entry %s>" % self.tag
+
+
+class _Env:
+    def __init__(self, d):
+        self.tag = d.get("tag")
+        self.source = d.get("source")
+        gid = d.get("goal_id")
+        self.evidence = {"provenance": {"goal_id": gid}} if gid else {}
+
+
+class _IE:
+    @staticmethod
+    def from_dict(d):
+        if d.get("tag") == "BROKEN":
+            raise ValueError("unrebuildable row")
+        return _Env(d)
+
+
+@pytest.fixture
+def router():
+    return R.UnifiedIntakeRouter.__new__(R.UnifiedIntakeRouter)
+
+
+def _authority(monkeypatch, holder):
+    """Only the envelope whose goal_id is in *holder* carries authority."""
+    monkeypatch.setattr(
+        R, "_carries_verified_operator_authority",
+        lambda env: getattr(env, "evidence", {})
+        .get("provenance", {})
+        .get("goal_id") in holder,
+    )
+
+
+def test_signed_intent_moves_to_the_head(router, monkeypatch):
+    """The whole point. A signed goal parked LAST must re-drain FIRST."""
+    _authority(monkeypatch, {"g-signed"})
+    monkeypatch.setattr(R, "_compute_priority", lambda e, *a, **k: (50, None))
+    rows = [
+        _Entry("noise-1"),
+        _Entry("noise-2"),
+        _Entry("signed", source="roadmap", goal_id="g-signed"),
+    ]
+    out = router._order_replay_by_authority(rows, _IE)
+    assert out[0].tag == "signed"
+
+
+def test_equal_priority_rows_keep_insertion_order(router, monkeypatch):
+    """Stability is load-bearing: this ADDS a tier discipline over FIFO, it
+    does not replace it with churn. A repeated drain must not reshuffle."""
+    _authority(monkeypatch, set())
+    monkeypatch.setattr(R, "_compute_priority", lambda e, *a, **k: (50, None))
+    rows = [_Entry("a"), _Entry("b"), _Entry("c")]
+    out = router._order_replay_by_authority(rows, _IE)
+    assert [e.tag for e in out] == ["a", "b", "c"]
+
+
+def test_priority_score_orders_ordinary_rows(router, monkeypatch):
+    """Ordinary rows use the module's OWN _compute_priority, so replay order
+    and live-queue order cannot drift into disagreement."""
+    _authority(monkeypatch, set())
+    scores = {"low": 90, "high": 2, "mid": 40}
+    monkeypatch.setattr(
+        R, "_compute_priority", lambda e, *a, **k: (scores[e.tag], None)
+    )
+    rows = [_Entry("low"), _Entry("high"), _Entry("mid")]
+    out = router._order_replay_by_authority(rows, _IE)
+    assert [e.tag for e in out] == ["high", "mid", "low"]
+
+
+def test_an_unrebuildable_row_does_not_raise(router, monkeypatch):
+    """Replay must survive a malformed row -- the alternative is losing
+    durably parked work."""
+    _authority(monkeypatch, set())
+    monkeypatch.setattr(R, "_compute_priority", lambda e, *a, **k: (10, None))
+    rows = [_Entry("ok-1"), _Entry("BROKEN"), _Entry("ok-2")]
+    out = router._order_replay_by_authority(rows, _IE)
+    assert len(out) == 3
+    assert {e.tag for e in out} == {"ok-1", "BROKEN", "ok-2"}
+
+
+def test_a_throwing_scorer_leaves_the_batch_intact(router, monkeypatch):
+    """Ordering is an optimisation and must never be a risk."""
+    _authority(monkeypatch, set())
+
+    def _boom(*a, **k):
+        raise RuntimeError("scorer down")
+
+    monkeypatch.setattr(R, "_compute_priority", _boom)
+    rows = [_Entry("a"), _Entry("b")]
+    out = router._order_replay_by_authority(rows, _IE)
+    assert len(out) == 2
+
+
+def test_master_flag_off_preserves_insertion_order(router, monkeypatch):
+    """Falsey master restores raw FIFO byte-for-byte."""
+    _authority(monkeypatch, {"g-signed"})
+    monkeypatch.setattr(R, "_compute_priority", lambda e, *a, **k: (50, None))
+    monkeypatch.setenv("JARVIS_WAL_REPLAY_AUTHORITY_ORDER", "false")
+    rows = [_Entry("noise"), _Entry("signed", "roadmap", "g-signed")]
+    out = router._order_replay_by_authority(rows, _IE)
+    assert [e.tag for e in out] == ["noise", "signed"]
+
+
+def test_single_row_is_returned_untouched(router):
+    """No sort, no rebuild, no scoring for a batch that cannot be reordered."""
+    rows = [_Entry("solo")]
+    assert router._order_replay_by_authority(rows, _IE) is rows
+
+
+def test_sovereign_priority_outranks_every_mapped_source():
+    """The authority key is not a hardcoded tier -- it is derived from the
+    map's own floor, and must sit strictly below it."""
+    assert R._sovereign_human_priority() < min(R._PRIORITY_MAP.values())
+
+
+def test_replay_actually_calls_the_ordering():
+    """WIRING PIN -- a correct sorter nothing invokes is invisible to every
+    test above."""
+    import ast
+    import io as _io
+
+    src = _io.open(R.__file__, encoding="utf-8").read()
+    called = {
+        n.func.attr
+        for n in ast.walk(ast.parse(src))
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+    }
+    assert "_order_replay_by_authority" in called, "sorter is unwired"


### PR DESCRIPTION
## The defect

Intake step 4 rejects an envelope when the queue is past its backpressure threshold and its source is not statically exempt:

```python
_BACKPRESSURE_EXEMPT = frozenset({"voice_human", "test_failure"})
```

That set encodes one idea — **a signal carrying human authority must not park behind machine-generated work.** `voice_human` is a person speaking now; `test_failure` is a runtime fire. An operator-signed roadmap goal is delegated human intent and belongs in that category. It wasn't in it.

**Measured** (soak `bt-2026-08-30-072704`): the signed goal `docs-skip-tools-gate-drift` emitted with a valid HMAC and was rejected here **146 times**. The reader ledger recorded this gate's literal return value as the goal's idempotency key:

```json
{"goal_id":"docs-skip-tools-gate-drift","emitted":true,"idempotency_key":"backpressure"}
```

## Why step 4 is the right layer

It sits **upstream of every adaptive mechanism in the router.** The SensorGovernor consult and the QoS aging/starvation escalation — the machinery built precisely to rescue a starved envelope — both live at step **4b**, after this return. No amount of aging can save what was refused before aging was consulted.

## Why not just add `"roadmap"` to the set

Because the source name is not the authority — the **signature** is. A dev-mode read (`REQUIRE_SIGNATURE=false`) and a roadmap an attacker dropped into `.jarvis/` both present the identical `source="roadmap"` string. Exempting on the name would let unsigned work preempt a contended queue: the same forgery class the declared-symbol path closed this week, one layer up.

So the exemption is derived from the signature, re-read from ground truth. The envelope contributes only a `goal_id` **pointer**; verdict, signature bytes, and the goal's presence are all read back from the verified document. It demands both `verdict == "valid"` **and** `doc.signature_valid`, matching what `delegated_provenance` demands of the same call.

## Cost is structurally bounded

Two short-circuits: the caller evaluates the authority term **last**, so it runs only for a non-exempt source already past threshold; and the helper returns before importing the reader unless the envelope carries a provenance pointer. A sensor envelope carries none and never triggers a roadmap read on any path.

Fail-closed throughout. Master `JARVIS_SIGNED_INTENT_BACKPRESSURE_EXEMPT` (default ON) restores the old gate byte-for-byte when falsey.

## Tests

14, including a positive control (so refusals can't pass vacuously), 5 non-valid verdicts, dev-mode signature absence, a forged `goal_id`, a raising reader, and an **AST wiring pin** asserting the gate actually calls the helper and evaluates it after the depth probe — a correct helper nothing invokes being the failure mode every direct-call test is blind to.

`Mapping` was missing from the typing import, caught by asserting `hasattr(module, "Mapping")` rather than trusting an AST parse. It would have raised `NameError` inside the helper's own broad `except`, silently disabling the exemption forever.

Pre-existing failures in `tests/governance/intake` (3) verified identical with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rakB8XYr6EMrfCD8UHrUy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Signed operator intent now clears backpressure at every admission point, so a validated goal dispatches under saturation instead of parking behind unsigned sensor noise and resolves correctly when it reaches generation.

**Admission and dispatch**
- Intake step 4 exempts envelopes traced to a cryptographically verified roadmap goal, derived from the signature rather than the source name and fail-closed; `JARVIS_SIGNED_INTENT_BACKPRESSURE_EXEMPT=false` restores the previous gate.
- WAL re-drain orders parked rows by authority and priority instead of insertion order; `JARVIS_WAL_REPLAY_AUTHORITY_ORDER=false` restores raw FIFO.
- The background pool caps ordinary work below the hard queue bound, leaving a reserve only authority-stamped ops may enter; `JARVIS_BG_AUTHORITY_HEADROOM_RATIO=0` restores the previous admission.

**Generation and local lane**
- The swarm path resolves a client that never existed, local-first, and declared target symbols read the production JSON carrier instead of a mapping no dispatch path produces.
- The negotiated VRAM-safe context window is published per endpoint, so clients built outside the negotiating path inherit it instead of falling to the legacy timeout branch.

<sup>Written for commit 67aeb14dae711ec0bf88bfedae7803887da6512a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

