### PR TITLE
[Ouroboros Review] Tier-1 multi-file atomic proof #3 (two docstring-free suites)

Make ONE

### DIFF
--- a/tests/governance/comms/karen_synth/test_speech_provider.py
+++ b/tests/governance/comms/karen_synth/test_speech_provider.py
@@ -25,5 +25,7 @@ async def test_dw_provider_yields_completion_text():
 async def test_dw_provider_failure_yields_nothing():
     sp = DWSpeechProvider(_FakeDW(boom=True))
     assert [c async for c in sp.source(system_prompt="s", user_prompt="u")] == []
+
+
 def test_tier1_multi_proof_speech():
     assert sum(range(6)) == 15


### PR DESCRIPTION
## Ouroboros Review Request

**Op ID:** `op-01a07b78-17dd-7fae-abbb-0b2ea33aa73a-cau`
**Risk tier:** `APPROVAL_REQUIRED` (Orange - human approval required)
**Description:** Tier-1 multi-file atomic proof #3 (two docstring-free suites)

Make ONE coordinated multi-file change across two EXISTING files, returned as a single multi-file candidate (a files:[...] array with BOTH files). Preserve every existing line in both files verbatim. FILE 1 = tests/governance/comms/karen_synth/test_persona.py: append at the very END a function def test_tier1_multi_proof_persona(): whose SINGLE body statement is exactly assert sum(range(5)) == 10. FILE 2 = tests/governance/comms/karen_synth/test_speech_provider.py: append at the very END a function def test_tier1_multi_proof_speech(): whose SINGLE body statement is exactly assert sum(range(6)) == 15. Add no imports to either file. These are real executable assertions (non-cosmetic) on short existing files; both must land atomically.

### Files changed

- `tests/governance/comms/karen_synth/test_persona.py`
- `tests/governance/comms/karen_synth/test_speech_provider.py`

### Risk evidence

```json
{
  "risk_tier": "APPROVAL_REQUIRED",
  "target_files": [
    "tests/governance/comms/karen_synth/test_persona.py",
    "tests/governance/comms/karen_synth/test_speech_provider.py"
  ],
  "file_count": 2
}
```

### Review checklist

- [ ] The diff does what the description claims
- [ ] Tests cover the new behavior (or are added in this PR)
- [ ] No new hardcoded model names, credentials, or URLs
- [ ] Nothing bypasses Manifesto §6 (Iron Gate) boundaries

---
*Filed automatically by the Ouroboros organism on behalf of an APPROVAL_REQUIRED change. The autonomous loop did NOT apply this change - it handed it off to you for review.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two new executable test functions across two existing test files as an atomic multi-file proof, without modifying existing lines or adding imports. The tests assert `sum(range(5)) == 10` and `sum(range(6)) == 15` respectively.

<sup>Written for commit bb5dd716614a2e3b19b667ce17a48ee9baf2729a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

